### PR TITLE
The tool to manager life cycle of genesis projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,44 @@
-# Genesis images
+# Genesis Dev Tools
 
-Repo with configuraitons and build tools for Genesis images.
+The tools to manager life cycle of genesis projects
+
+# Requirements
+
+Before you can install and use genesis tools you need to install several requirements:
+- [packer](https://www.packer.io/)
+- [libvirt](https://libvirt.org/)
+- [qemu](https://www.qemu.org/)
+
+## Ubuntu
+
+Install packages
+```sh
+sudo apt update
+sudo apt install qemu-kvm libvirt-daemon-system mkisofs
+```
+
+Add user to group
+```sh
+sudo adduser $USER libvirt
+```
+
+Install packer like described in [this article](https://yandex.cloud/ru/docs/tutorials/infrastructure-management/packer-quickstart#from-y-mirror)
+```sh
+
+```
 
 # Install
 
-To install the `gcl_images` package, follow these steps:
+To install the `genesis-dev-tools` package, follow these steps:
 
 1. Clone the repository:
     ```sh
-    git clone https://github.com/infraguys/gcl_images.git
+    git clone https://github.com/infraguys/genesis_dev_tools.git
     ```
 
 2. Navigate to the project directory:
     ```sh
-    cd gcl_images
+    cd genesis_dev_tools
     ```
 
 3. Install the required dependencies:
@@ -28,13 +53,114 @@ To install the `gcl_images` package, follow these steps:
 
 # Usage
 
-A new command `genesis-images` is available now. To build an image use a command like this:
+The package provides a command line interface for building genesis projects, managing genesis installations and cover many other useful aspects. To use the command line interface, run the `genesis` command from the command line. For full documentation about CLI commands, run `genesis --help`.
+
+For every genesis project the directory `genesis` should exist in the project root. The project configuration file should be named `genesis.yaml` in this directory. For example my project structure looks like this:
 
 ```sh
-genesis-images build /path/to/image/configs
+.
+├── my_project
+│   └── main.py
+├── project_settings.json
+├── requirements.txt
+├── setup.cfg
+├── setup.py
+└── README.md
 ```
 
-For more detailed documentation:
+The project should be extended as follows:
+
 ```sh
-genesis-images build --help
+.
+├── my_project
+│   └── main.py
+├── genesis
+│   └── genesis.yaml
+├── README.md
+├── project_settings.json
+├── requirements.txt
+├── setup.cfg
+├── setup.py
+└── README.md
+```
+
+## Genesis configuration file
+
+The `genesis.yaml` file contains the configuration for the genesis project. It should be placed in the `genesis` directory. It consists of several sections such as build, deploy, etc.
+
+Example of the `genesis.yaml` file:
+
+```yaml
+# Build section. It describes the build process of the project.
+build:
+  # Dependencies of the project
+  # This section is used to specify build dependencies
+  # for the project
+  deps:
+      # Target path in the image
+    - dst: /opt/genesis_core
+      # Local path of the build machine
+      path:
+        src: ../../genesis_core
+  
+  # This section describes elements of the project.
+  # Images, artifacts and manifests for every element. 
+  elements:
+      # List of images in the element
+    - images:
+      - name: genesis-core
+        format: raw
+        
+        # OS profile for the image
+        profile: ubuntu_24
+
+        # Provisioning script
+        script: images/install.sh
+      manifest: manifests/genesis-core.yaml
+      
+      # List of artifacts in the element
+      artifacts:
+        - configs/my-cofig.yaml
+        - templates/my-template.yaml
+```
+
+## Build project
+
+The `genesis build` command builds the project. The build process is described in the `build` section of the `genesis.yaml` file. The mandatory argument is path to the project root directory.
+
+Build a Genesis project.
+```sh
+genesis build my_project
+```
+
+This will build the Genesis project in the `my_project` directory using the default configuration file will be located in `my_project/genesis/genesis.yaml`.
+
+After build the project output artifacts will be stored in the `output` directory.
+For detailed information about the `genesis build` command run `genesis build --help`.
+
+## Manager Genesis installation locally
+
+To bootstrap genesis installation locally, run the `genesis bootstrap` command. The mandatory argument is path to the genesis image. For instance,
+
+```sh
+genesis bootstrap output/genesis-core.raw
+```
+
+This command will create and boot a virtual machine with the specified genesis image `output/genesis-core.raw`. The default name of the installation is `genesis-core`. For detailed information about the `genesis bootstrap` command run `genesis bootstrap --help`.
+
+To connect to the genesis installation, run the `genesis ssh` command. For instance,
+```sh
+genesis ssh
+```
+
+To list genesis installations, run the `genesis ps` command. For instance,
+
+```sh
+genesis ps
+```
+
+To delete genesis installation, run the `genesis delete` command. For instance,
+
+```sh
+genesis delete genesis-core
 ```

--- a/gcl_images/builder/__init__.py
+++ b/gcl_images/builder/__init__.py
@@ -1,0 +1,17 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from gcl_images.builder import dependency

--- a/gcl_images/builder/builder.py
+++ b/gcl_images/builder/builder.py
@@ -1,0 +1,108 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import typing as tp
+import tempfile
+
+from gcl_images.builder import base
+from gcl_images.logger import AbstractLogger, DummyLogger
+
+
+class SimpleBuilder:
+    """Abstract element builder.
+
+    This class defines the interface for building elements.
+    """
+
+    DEP_KEY = "deps"
+    ELEMENT_KEY = "elements"
+
+    def __init__(
+        self,
+        work_dir: str,
+        deps: tp.List[base.AbstractDependency],
+        elements: tp.List[base.Element],
+        image_builder: base.AbstractImageBuilder,
+        logger: tp.Optional[AbstractLogger] = None,
+    ) -> None:
+        super().__init__()
+        self._deps = deps
+        self._elements = elements
+        self._image_builder = image_builder
+        self._work_dir = work_dir
+        self._logger = logger or DummyLogger()
+
+    def fetch_dependency(self, deps_dir: str) -> None:
+        """Fetch common dependencies for elements."""
+        self._logger.important("Fetching dependencies")
+        for dep in self._deps:
+            self._logger.info(f"Fetching dependency: {dep}")
+            dep.fetch(deps_dir)
+
+    def build(
+        self,
+        build_dir: tp.Optional[str] = None,
+        developer_keys: tp.Optional[str] = None,
+    ) -> None:
+        """Build all elements."""
+        self._logger.important("Building elements")
+        for e in self._elements:
+            self._logger.info(f"Building element: {e}")
+            for img in e.images:
+                # The build_dir is used only for debugging purposes to observe
+                # the content of the image. In production, the image is built
+                # in a temporary directory.
+                if build_dir is not None:
+                    self._image_builder.run(
+                        build_dir, img, self._deps, developer_keys
+                    )
+                else:
+                    with tempfile.TemporaryDirectory() as temp_dir:
+                        self._image_builder.run(
+                            temp_dir, img, self._deps, developer_keys
+                        )
+
+    @classmethod
+    def from_config(
+        cls,
+        work_dir: str,
+        build_config: tp.Dict[str, tp.Any],
+        image_builder: base.AbstractImageBuilder,
+        logger: tp.Optional[AbstractLogger] = None,
+    ) -> "SimpleBuilder":
+        """Create a builder from configuration."""
+        # Prepare dependencies entries but do not fetch them
+        deps = []
+        dep_configs = build_config.get(cls.DEP_KEY, [])
+        for dep in dep_configs:
+            dep_item = base.AbstractDependency.find_dependency(dep, work_dir)
+            if dep_item is None:
+                raise ValueError(
+                    f"Unable to handle dependency: {dep}. Unknown type."
+                )
+            deps.append(dep_item)
+
+        # Prepare elements
+        element_configs = build_config.get(cls.ELEMENT_KEY, [])
+        elements = [
+            base.Element.from_config(elem, work_dir)
+            for elem in element_configs
+        ]
+
+        if not elements:
+            raise ValueError("No elements found in configuration")
+
+        return cls(work_dir, deps, elements, image_builder, logger)

--- a/gcl_images/builder/dependency.py
+++ b/gcl_images/builder/dependency.py
@@ -1,0 +1,71 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import shutil
+import typing as tp
+
+from gcl_images.builder import base
+
+
+class LocalPathDependency(base.AbstractDependency):
+    """Local path dependency item."""
+
+    def __init__(self, path: str, img_dest: str) -> None:
+        super().__init__()
+        self._path = path
+        self._img_dest = img_dest
+        self._local_path = None
+
+    @property
+    def img_dest(self) -> tp.Optional[str]:
+        """Destination for the image."""
+        return self._img_dest
+
+    @property
+    def local_path(self) -> tp.Optional[str]:
+        """Local path to the dependency."""
+        return self._local_path
+
+    def fetch(self, output_dir: str) -> None:
+        """Fetch the dependency."""
+        path = self._path
+        if os.path.isdir(path):
+            name = os.path.basename(path)
+            shutil.copytree(path, os.path.join(output_dir, name))
+            self._local_path = os.path.join(output_dir, name)
+        else:
+            shutil.copy(path, output_dir)
+            self._local_path = os.path.join(output_dir, os.path.basename(path))
+
+    def __str__(self):
+        return f"Local path -> {self._path}"
+
+    @classmethod
+    def from_config(
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+    ) -> "LocalPathDependency":
+        """Create a dependency item from configuration."""
+        if "path" not in dep_config or "src" not in dep_config["path"]:
+            raise ValueError("Path not found in dependency configuration")
+
+        path = dep_config["path"]["src"]
+        img_dest = dep_config["dst"]
+
+        if not os.path.isabs(path):
+            path = os.path.join(work_dir, path)
+
+        return cls(path, img_dest)

--- a/gcl_images/builder/packer.py
+++ b/gcl_images/builder/packer.py
@@ -14,42 +14,154 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
 import subprocess
 import typing as tp
 import shutil
 from importlib.resources import files
 
-from gcl_images.builder.base import DummyBuilder
+from gcl_images.builder import base
+from gcl_images.logger import AbstractLogger, DummyLogger
 from gcl_images import constants as c
 
 
-def _get_base_files(base: str) -> str:
+file_provisioner_tmpl = """
+  provisioner "file" {{
+      source      = "{source}"
+      destination = "{tmp_destination}"
+  }}
+  provisioner "shell" {{
+    inline = [
+      "sudo mv {tmp_destination} {destination}",
+    ]
+  }}
+"""
+
+
+dev_keys_provisioner_tmpl = """
+  provisioner "file" {{
+      source      = "{source}"
+      destination = "/tmp/__dev_keys"
+  }}
+"""
+
+
+packer_build_tmpl = """
+variable "output_directory" {{
+  type    = string
+  default = "{output_directory}"
+}}
+
+build {{
+  source "qemu.{profile}" {{
+    name = "{name}"
+  }}
+
+  {file_provisioners}
+
+  provisioner "shell" {{
+    execute_command = "sudo -S env {{{{ .Vars }}}} {{{{ .Path }}}}"
+    script          = "{script}"
+    env             = {{
+      EXAMPLE_VARIABLE = "example_value"
+    }}
+  }}
+
+  {developer_keys}
+}}
+"""
+
+
+def _get_profile_files(base: str) -> str:
     """Get base files for the image."""
-    base_files = []
+    profile_files = []
     for bfile in files(f"{c.PKG_NAME}.packer.{base}").iterdir():
-        base_files.append(bfile)
+        profile_files.append(bfile)
 
-    return base_files
+    return profile_files
 
 
-class PackerBuilder(DummyBuilder):
+class PackerBuilder(base.DummyImageBuilder):
     """Packer image builder.
 
     Packer image builder that uses Packer tools to build images.
     """
 
-    def pre_build(self, image_dir: str, base: tp.Optional[str]) -> None:
+    def __init__(
+        self, output_dir: str, logger: tp.Optional[AbstractLogger] = None
+    ) -> None:
+        super().__init__()
+        self._logger = logger or DummyLogger()
+        self._output_dir = output_dir
+
+    def pre_build(
+        self,
+        image_dir: str,
+        image: base.Image,
+        deps: tp.List[base.AbstractDependency],
+        developer_keys: tp.Optional[str] = None,
+    ) -> None:
         """Actions to prepare the environment for building the image."""
-        # Copy base files to image_dir if base is not None
-        if base is not None:
-            base_files = _get_base_files(base)
-            for bfile in base_files:
-                shutil.copy(bfile, image_dir)
+        if image.override:
+            self._logger.error("Override not supported at the moment")
+            raise ValueError("Override not supported")
+
+        # Prepare the packer build file
+        # Data provisioners
+        provisioners = []
+        for i, dep in enumerate(deps):
+            tmp_dest = os.path.join(
+                "/tmp/", os.path.basename(dep.img_dest) + f"_{i}"
+            )
+            provisioners.append(
+                file_provisioner_tmpl.format(
+                    source=dep.local_path,
+                    destination=dep.img_dest,
+                    tmp_destination=tmp_dest,
+                )
+            )
+
+        # Prepare developer
+        if developer_keys:
+            dev_key_path = os.path.join(image_dir, "__dev_keys")
+            with open(dev_key_path, "w") as f:
+                f.write(developer_keys)
+            developer_keys_prov = dev_keys_provisioner_tmpl.format(
+                source=dev_key_path
+            )
+        else:
+            developer_keys_prov = ""
+
+        profile = image.profile.replace("_", "-")
+        packer_build = packer_build_tmpl.format(
+            profile=profile,
+            name=image.name or profile,
+            file_provisioners="\n".join(provisioners),
+            script=image.script,
+            developer_keys=developer_keys_prov,
+            output_directory=self._output_dir,
+        )
+
+        # Write the packer build file
+        main_path = os.path.join(image_dir, "main.pkr.hcl")
+        with open(main_path, "w") as f:
+            f.write(packer_build)
+
+        # Copy profile files to the image directory
+        profile_files = _get_profile_files(image.profile)
+        for bfile in profile_files:
+            shutil.copy(bfile, image_dir)
 
         subprocess.run(["packer", "init", image_dir], check=True)
 
-    def build(self, image_dir: str, base: tp.Optional[str]) -> None:
+    def build(
+        self,
+        image_dir: str,
+        image: base.Image,
+        developer_keys: tp.Optional[str] = None,
+    ) -> None:
         """Actions to build the image."""
+        self._logger.important(f"Build image: {image.name}")
         subprocess.run(
             ["packer", "build", "-parallel-builds=1", image_dir], check=True
         )

--- a/gcl_images/cmd/cli.py
+++ b/gcl_images/cmd/cli.py
@@ -14,63 +14,292 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import click
+import os
+import shutil
 import typing as tp
 import tempfile
-import shutil
-import os
+
+import click
+import prettytable
 
 import gcl_images.constants as c
 from gcl_images import utils
-from gcl_images.builder.base import AbstractBuilder
+from gcl_images.logger import ClickLogger
+from gcl_images.builder.builder import SimpleBuilder
+from gcl_images.builder.packer import PackerBuilder
+from gcl_images import libvirt
+
+
+BOOTSTRAP_TAG = "bootstrap"
 
 
 @click.group(invoke_without_command=True)
-def main():
+def main() -> None:
     pass
 
 
-@main.command("build", help="Build Genesis images")
-@click.option("-b", "--base", default="ubuntu_24", help="Base image to use")
+@main.command("build", help="Build Genesis project")
 @click.option(
-    "-d",
-    "--driver",
-    default="PackerBuilder",
-    help="Image builder driver",
+    "-c",
+    "--genesis-cfg-file",
+    default=c.DEF_GEN_CFG_FILE_NAME,
+    help="Name of the project configuration file",
+)
+@click.option(
+    "--deps-dir",
+    default=None,
+    help="Directory where dependencies will be fetched",
+)
+@click.option(
+    "--build-dir",
+    default=None,
+    help="Directory where temporary build artifacts will be stored",
+)
+@click.option(
+    "--output-dir",
+    default=None,
+    help="Directory where output artifacts will be stored",
+)
+@click.option(
+    "-i",
+    "--developer-key-path",
+    default=None,
+    help="Path to developer public key",
+)
+@click.option(
+    "-f",
+    "--force",
+    default=False,
+    type=bool,
     show_default=True,
+    is_flag=True,
+    help="Rebuild if the output already exists",
+)
+@click.argument("project_dir", type=click.Path())
+def build_cmd(
+    genesis_cfg_file: str,
+    deps_dir: tp.Optional[str],
+    build_dir: tp.Optional[str],
+    output_dir: tp.Optional[str],
+    developer_key_path: tp.Optional[str],
+    force: bool,
+    project_dir: str,
+) -> None:
+    if not project_dir:
+        raise click.UsageError("No project directories specified")
+
+    output_dir = output_dir or c.DEF_GEN_OUTPUT_DIR_NAME
+    if os.path.exists(output_dir) and not force:
+        click.secho(
+            f"The '{output_dir}' directory already exists. Use '--force' "
+            "flag to remove current artifacts and new build.",
+            fg="yellow",
+        )
+        return
+    elif os.path.exists(output_dir) and force:
+        shutil.rmtree(output_dir)
+
+    # Developer keys
+    developer_keys = utils.get_keys_by_path_or_env(developer_key_path)
+
+    # Find path to genesis configuration
+    try:
+        gen_config = utils.get_genesis_config(project_dir, genesis_cfg_file)
+    except FileNotFoundError:
+        raise click.ClickException(
+            f"Genesis configuration file not found in {project_dir}"
+        )
+
+    # Take all build sections from the configuration
+    builds = {k: v for k, v in gen_config.items() if k.startswith("build")}
+    if not builds:
+        click.secho("No builds found in the configuration", fg="yellow")
+        return
+
+    logger = ClickLogger()
+    packer_image_builder = PackerBuilder(output_dir, logger)
+
+    # Path where genesis.yaml configuration file is located
+    work_dir = os.path.abspath(
+        os.path.join(project_dir, c.DEF_GEN_WORK_DIR_NAME)
+    )
+
+    for _, build in builds.items():
+        builder = SimpleBuilder.from_config(
+            work_dir, build, packer_image_builder, logger
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            builder.fetch_dependency(deps_dir or temp_dir)
+            builder.build(build_dir, developer_keys)
+
+
+@main.command("bootstrap", help="Bootstrap genesis locally")
+@click.option(
+    "-i",
+    "--image-path",
+    default=None,
+    help="Path to the genesis image",
 )
 @click.option(
-    "-o", "--output", default=None, help="Output directory", type=click.Path()
+    "-p",
+    "--profile",
+    default=None,
+    help="Name of the image profile",
 )
-@click.argument("image_dirs", nargs=-1, type=click.Path())
-def build_cmd(base: str, driver: str, output: str, image_dirs: tp.List[str]):
-    if not image_dirs:
-        raise click.UsageError("No image directories specified")
+@click.option(
+    "--cores",
+    default=2,
+    show_default=True,
+    help="Number of cores for the bootstrap VM",
+)
+@click.option(
+    "--memory",
+    default=4096,
+    show_default=True,
+    help="Memory in Mb for the bootstrap VM",
+)
+@click.option(
+    "--name",
+    default="genesis-core",
+    help="Name of the installation",
+)
+@click.option(
+    "-f",
+    "--force",
+    default=False,
+    type=bool,
+    show_default=True,
+    is_flag=True,
+    help="Rebuild if the output already exists",
+)
+def bootstrap_cmd(
+    image_path: tp.Optional[str],
+    profile: tp.Optional[str],
+    cores: int,
+    memory: int,
+    name: str,
+    force: bool,
+) -> None:
+    if profile is None and image_path is None:
+        raise click.UsageError("No image path or profile specified")
 
-    # Load the image builder driver
-    try:
-        builder_class = utils.load_from_entry_point(
-            c.EP_GCL_IMAGE_BUILDER_GROUP, driver
-        )
-        builder: AbstractBuilder = builder_class()
-    except RuntimeError:
-        raise click.ClickException(
-            f"Invalid driver: {driver}, not found in entry points "
-            f"{c.EP_GCL_IMAGE_BUILDER_GROUP}"
-        )
+    if image_path and not os.path.isabs(image_path):
+        image_path = os.path.abspath(image_path)
 
-    click.echo(click.style(f"Image builder driver: {driver}", fg="green"))
+    logger = ClickLogger()
 
-    # Build each image into a temporary directory
-    for image_dir in image_dirs:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Copy all contents from image_dir to temp_dir
-            for item in os.listdir(image_dir):
-                s = os.path.join(image_dir, item)
-                d = os.path.join(temp_dir, item)
-                if os.path.isdir(s):
-                    shutil.copytree(s, d, False, None)
-                else:
-                    shutil.copy2(s, d)
+    # KiB for libvirt
+    memory = memory << 10
+    net_name = utils.installation_net_name(name)
+    bootstrap_domain_name = utils.installation_bootstrap_name(name)
 
-            builder.run(temp_dir, base)
+    # Check if the any genesis installation is running
+    has_domain = libvirt.has_domain(bootstrap_domain_name)
+    has_net = libvirt.has_net(net_name)
+    if has_domain or has_net:
+        if not force:
+            logger.warn(
+                "Genesis installation is already running. Use '--force' flag to "
+                "rerun genesis installation.",
+            )
+            return
+
+        if has_domain:
+            libvirt.destroy_domain(bootstrap_domain_name)
+
+        if has_net:
+            libvirt.destroy_net(net_name)
+
+        logger.info("Destroyed old genesis installation")
+
+    libvirt.create_nat_network(net_name)
+    libvirt.create_domain(
+        name=bootstrap_domain_name,
+        cores=cores,
+        memory=memory,
+        image=image_path,
+        network=net_name,
+    )
+    logger.important("Launched genesis installation. Started VM: " + name)
+
+
+@main.command("ssh", help="Connect to genesis installation")
+@click.option(
+    "-i",
+    "--ip-address",
+    default=None,
+    help="IP address of installation",
+)
+@click.option(
+    "-u",
+    "--username",
+    default="ubuntu",
+    help="Default username",
+)
+def conn_cmd(ip_address: tp.Optional[str], username: str) -> None:
+    installations = _list_installations()
+
+    if ip_address is None:
+        if len(installations) == 1:
+            ip_address = installations[0][1]
+        elif len(installations) > 1:
+            raise click.UsageError(
+                "There are multiple genesis installations. "
+                "You must specify IP address of the installation"
+            )
+        else:
+            click.secho("No genesis installation found", fg="yellow")
+            return
+
+    os.system(f"ssh {username}@{ip_address}")
+
+
+@main.command("ps", help="List of running genesis installation")
+def ps_cmd() -> None:
+    table = prettytable.PrettyTable()
+    table.field_names = [
+        "name",
+        "IP",
+    ]
+
+    for name, ip in _list_installations():
+        table.add_row([name, ip])
+
+    click.echo("Genesis installations:")
+    click.echo(table)
+
+
+@main.command("delete", help="Delete the genesis installation")
+@click.argument("name", type=str)
+def delete_cmd(name: str) -> None:
+    logger = ClickLogger()
+    destroyed = False
+
+    net_name = utils.installation_net_name(name)
+    bootstrap_domain_name = utils.installation_bootstrap_name(name)
+
+    if libvirt.has_domain(bootstrap_domain_name):
+        libvirt.destroy_domain(bootstrap_domain_name)
+        destroyed = True
+
+    if libvirt.has_net(net_name):
+        libvirt.destroy_net(net_name)
+        destroyed = True
+
+    if not destroyed:
+        logger.warn("Genesis installation not found")
+        return
+
+    logger.important(f"Destroyed genesis installation: {name}")
+
+
+def _list_installations() -> tp.List[tp.Tuple[str, str]]:
+    installations = []
+
+    # Each bootstrap is a separate installation
+    for domain in libvirt.list_domains():
+        if BOOTSTRAP_TAG in domain:
+            installation = utils.installation_name_from_bootstrap(domain)
+            ip = libvirt.get_domain_ip(domain)
+            installations.append((installation, str(ip)))
+    return installations

--- a/gcl_images/constants.py
+++ b/gcl_images/constants.py
@@ -14,5 +14,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import typing as tp
+
 PKG_NAME = "gcl_images"
 EP_GCL_IMAGE_BUILDER_GROUP = "gcl_image_builder"
+LIBVIRT_DEF_POOL_PATH = "/var/lib/libvirt/images"
+DEF_GEN_CFG_FILE_NAME = "genesis.yaml"
+DEF_GEN_WORK_DIR_NAME = "genesis"
+DEF_GEN_OUTPUT_DIR_NAME = "output"
+
+# ENV vars
+ENV_GEN_DEV_KEYS = "GEN_DEV_KEYS"
+
+# Types
+ImageProfileType = tp.Literal["ubuntu_24"]
+ImageFormatType = tp.Literal["raw"]

--- a/gcl_images/libvirt.py
+++ b/gcl_images/libvirt.py
@@ -1,0 +1,245 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import re
+import typing as tp
+import tempfile
+import subprocess
+
+from gcl_images import constants as c
+
+domain_template = """
+<domain type="kvm">
+  <name>{name}</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://ubuntu.com/ubuntu/24.04"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory>{memory}</memory>
+  <currentMemory>{memory}</currentMemory>
+  <vcpu>{cores}</vcpu>
+  <os>
+    <type arch="x86_64" machine="q35">hvm</type>
+    <boot dev="hd"/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <vmport state="off"/>
+  </features>
+  <cpu mode="host-passthrough"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <pm>
+    <suspend-to-mem enabled="no"/>
+    <suspend-to-disk enabled="no"/>
+  </pm>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type="file" device="disk">
+      <driver name="qemu" type="raw"/>
+      <source file="{image}"/>
+      <target dev="vda" bus="virtio"/>
+    </disk>
+    <controller type="usb" model="qemu-xhci" ports="5"/>
+    <controller type="pci" model="pcie-root"/>
+    <controller type="pci" model="pcie-root-port"/>
+    <interface type="network">
+      <source network="{network}"/>
+      <model type="virtio"/>
+    </interface>
+    <console type="pty"/>
+    <channel type="unix">
+      <source mode="bind"/>
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+    </channel>
+    <channel type="spicevmc">
+      <target type="virtio" name="com.redhat.spice.0"/>
+    </channel>
+    <input type="tablet" bus="usb"/>
+    <graphics type="spice" port="-1" tlsPort="-1" autoport="yes">
+      <image compression="off"/>
+    </graphics>
+    <video>
+      <model type="qxl"/>
+    </video>
+    <redirdev bus="usb" type="spicevmc"/>
+    <memballoon model="virtio"/>
+    <rng model="virtio">
+      <backend model="random">/dev/urandom</backend>
+    </rng>
+  </devices>
+</domain>
+"""
+
+nat_network_template = """
+<network>
+  <name>{name}</name>
+  <forward mode="nat"/>
+  <domain name="{name}"/>
+  <ip address="192.168.{net_number}.1" netmask="255.255.255.0">
+    <dhcp>
+      <range start="192.168.{net_number}.128" end="192.168.{net_number}.254"/>
+    </dhcp>
+  </ip>
+</network>
+"""
+
+
+def list_domains():
+    """List all domains."""
+    out = subprocess.check_output("sudo virsh list --all --name", shell=True)
+    out = out.decode().strip()
+    return out.split("\n")
+
+
+def list_nets():
+    """List all networks."""
+    out = subprocess.check_output(
+        "sudo virsh net-list --all --name", shell=True
+    )
+    out = out.decode().strip()
+    return out.split("\n")
+
+
+def list_pool():
+    """List all pools."""
+    out = subprocess.check_output(
+        "sudo virsh pool-list --all --name", shell=True
+    )
+    out = out.decode().strip()
+    return out.split("\n")
+
+
+def create_nat_network(name: str, net_number: int = 130):
+    network = nat_network_template.format(name=name, net_number=net_number)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        network_path = os.path.join(temp_dir, f"{name}.xml")
+        with open(network_path, "w") as f:
+            f.write(network)
+
+        subprocess.run(
+            f"sudo virsh net-define {network_path} 1>/dev/null",
+            shell=True,
+            check=True,
+        )
+        subprocess.run(
+            f"sudo virsh net-start {name} 1>/dev/null", shell=True, check=True
+        )
+        subprocess.run(
+            f"sudo virsh net-autostart {name} 1>/dev/null",
+            shell=True,
+            check=True,
+        )
+
+
+def create_domain(
+    name: str,
+    cores: str,
+    memory: int,
+    image: str,
+    network: str,
+    pool: str = c.LIBVIRT_DEF_POOL_PATH,
+):
+    # Copy the image to a pool
+    image_name = os.path.basename(image)
+    pool_image_path = os.path.join(pool, image_name)
+
+    # TODO: Need default user pool
+    if not os.path.exists(pool_image_path):
+        subprocess.run(
+            f"sudo cp {image} {pool_image_path}",
+            shell=True,
+            check=True,
+        )
+
+    domain = domain_template.format(
+        name=name,
+        cores=cores,
+        memory=memory,
+        image=pool_image_path,
+        network=network,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        domain_path = os.path.join(temp_dir, f"{name}.xml")
+        with open(domain_path, "w") as f:
+            f.write(domain)
+
+        subprocess.run(
+            f"sudo virsh define {domain_path} 1>/dev/null",
+            shell=True,
+            check=True,
+        )
+        subprocess.run(
+            f"sudo virsh start {name} 1>/dev/null", shell=True, check=True
+        )
+
+
+def get_domain_ip(name: str) -> tp.Optional[str]:
+    out = subprocess.check_output(f"sudo virsh dumpxml {name}", shell=True)
+    out = out.decode().strip()
+
+    mac_addresses = re.findall(r"<mac address='(.*?)'", out)
+    networs = re.findall(r"<source network='(.*?)'", out)
+    # Instance without network interfaces ?
+    if not mac_addresses:
+        return
+
+    # Actually it's not right solution but for simplicity keep it.
+    for mac, net in zip(mac_addresses, networs):
+        out = subprocess.check_output(
+            f"sudo virsh net-dhcp-leases {net}",
+            shell=True,
+        )
+        out = out.decode().strip()
+        for line in out.split("\n"):
+            if mac in line:
+                return re.findall(r"\d+\.\d+\.\d+\.\d+", line)[0]
+
+
+def has_domain(name: str) -> bool:
+    return name in list_domains()
+
+
+def has_net(name: str) -> bool:
+    return name in list_nets()
+
+
+def destroy_domain(name: str) -> None:
+    """Delete domain."""
+    subprocess.run(
+        f"sudo virsh destroy {name} 1>/dev/null && "
+        f"sudo virsh undefine {name} 1>/dev/null",
+        shell=True,
+        check=True,
+    )
+
+
+def destroy_net(name: str) -> None:
+    """Delete network."""
+    subprocess.run(
+        f"sudo virsh net-destroy {name} 1>/dev/null && "
+        f"sudo virsh net-undefine {name} 1>/dev/null",
+        shell=True,
+        check=True,
+    )

--- a/gcl_images/logger.py
+++ b/gcl_images/logger.py
@@ -1,0 +1,78 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import click
+
+
+class AbstractLogger(abc.ABC):
+    """Abstract logger."""
+
+    @abc.abstractmethod
+    def error(self, msg: str) -> None:
+        """Log an error message."""
+
+    @abc.abstractmethod
+    def warn(self, msg: str) -> None:
+        """Log a warning message."""
+
+    @abc.abstractmethod
+    def info(self, msg: str) -> None:
+        """Log an information message."""
+
+    def important(self, msg: str) -> None:
+        """Log an important message."""
+        self.info(msg)
+
+
+class ClickLogger(AbstractLogger):
+    """Logger based on Click."""
+
+    def error(self, msg: str) -> None:
+        """Log an error message."""
+        click.secho(msg, fg="red")
+
+    def warn(self, msg: str) -> None:
+        """Log a warning message."""
+        click.secho(msg, fg="yellow")
+
+    def info(self, msg: str) -> None:
+        """Log an information message."""
+        click.echo(msg)
+
+    def important(self, msg: str) -> None:
+        """Log an important message."""
+        click.secho(msg, fg="green")
+
+
+class DummyLogger(AbstractLogger):
+    """Dummy logger."""
+
+    def error(self, msg: str) -> None:
+        """Log an error message."""
+        pass
+
+    def warn(self, msg: str) -> None:
+        """Log a warning message."""
+        pass
+
+    def info(self, msg: str) -> None:
+        """Log an information message."""
+        pass
+
+    def important(self, msg: str) -> None:
+        """Log an important message."""
+        pass

--- a/gcl_images/tests/unit/conftest.py
+++ b/gcl_images/tests/unit/conftest.py
@@ -1,0 +1,66 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import typing as tp
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from gcl_images.builder.builder import SimpleBuilder
+from gcl_images.builder.base import (
+    AbstractDependency,
+    AbstractImageBuilder,
+    Element,
+)
+from gcl_images.logger import DummyLogger
+from gcl_images.builder.dependency import LocalPathDependency
+
+
+@pytest.fixture
+def simple_builder() -> SimpleBuilder:
+    work_dir = "/tmp/work_dir"
+    deps = [MagicMock(spec=AbstractDependency) for _ in range(2)]
+    elements = [MagicMock(spec=Element) for _ in range(2)]
+    image_builder = MagicMock(spec=AbstractImageBuilder)
+    logger = DummyLogger()
+    return SimpleBuilder(work_dir, deps, elements, image_builder, logger)
+
+
+@pytest.fixture
+def dep_local_path_factory():
+    def factory(path: str, img_path: str) -> LocalPathDependency:
+        return LocalPathDependency(path, img_path)
+
+    return factory
+
+
+@pytest.fixture
+def build_config() -> tp.Dict[str, tp.Any]:
+    fixture = """
+build:
+  deps:
+    - dst: /opt/genesis_core
+      path:
+        src: /tmp/genesis_core_test_dir
+  elements:
+    - images:
+      - name: genesis-core
+        format: raw
+        profile: ubuntu_24
+        script: images/install.sh
+"""
+    cfg = yaml.safe_load(fixture)
+    return cfg["build"]

--- a/gcl_images/tests/unit/test_builder.py
+++ b/gcl_images/tests/unit/test_builder.py
@@ -1,0 +1,45 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import typing as tp
+from unittest.mock import MagicMock
+
+from gcl_images.builder.builder import SimpleBuilder
+from gcl_images.logger import DummyLogger
+
+
+class TestBuilder:
+
+    def test_fetch_dependency(self, simple_builder: SimpleBuilder) -> None:
+        deps_dir = "/tmp/deps_dir"
+        simple_builder.fetch_dependency(deps_dir)
+        for dep in simple_builder._deps:
+            dep.fetch.assert_called_once_with(deps_dir)
+
+        assert len(simple_builder._deps) > 1
+
+    def test_from_config(self, build_config: tp.Dict[str, tp.Any]) -> None:
+        work_dir = "/tmp/work_dir"
+
+        builder = SimpleBuilder.from_config(
+            work_dir,
+            build_config,
+            MagicMock(),
+            DummyLogger(),
+        )
+
+        assert len(builder._deps) == 1
+        assert len(builder._elements) == 1
+        assert builder._work_dir == work_dir

--- a/gcl_images/tests/unit/test_dependency.py
+++ b/gcl_images/tests/unit/test_dependency.py
@@ -1,0 +1,56 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import os
+import shutil
+import typing as tp
+import tempfile
+
+from gcl_images.builder.dependency import LocalPathDependency
+
+
+class TestDependency:
+
+    def test_local_path_from_config(
+        self, build_config: tp.Dict[str, tp.Any]
+    ) -> None:
+        work_dir = "/tmp/work_dir"
+        dep = LocalPathDependency.from_config(
+            build_config["deps"][0],
+            work_dir,
+        )
+
+        assert dep.img_dest == "/opt/genesis_core"
+        assert dep._path == "/tmp/genesis_core_test_dir"
+        assert dep.local_path is None
+
+    def test_local_path_fetch(
+        self, build_config: tp.Dict[str, tp.Any]
+    ) -> None:
+        os.makedirs("/tmp/genesis_core_test_dir", exist_ok=True)
+
+        dep = LocalPathDependency.from_config(
+            build_config["deps"][0],
+            "/tmp",
+        )
+
+        os.makedirs("/tmp/___deps_dir", exist_ok=True)
+        dep.fetch("/tmp/___deps_dir")
+
+        try:
+            assert os.path.exists("/tmp/___deps_dir/genesis_core_test_dir")
+        finally:
+            shutil.rmtree("/tmp/genesis_core_test_dir")
+            shutil.rmtree("/tmp/___deps_dir")

--- a/gcl_images/utils.py
+++ b/gcl_images/utils.py
@@ -14,8 +14,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
 import typing as tp
 from importlib.metadata import entry_points
+import yaml
+
+import gcl_images.constants as c
 
 
 def load_from_entry_point(group: str, name: str) -> tp.Any:
@@ -25,3 +29,47 @@ def load_from_entry_point(group: str, name: str) -> tp.Any:
             return ep.load()
 
     raise RuntimeError(f"No class '{name}' found in entry points {group}")
+
+
+def get_genesis_config(
+    project_dir: str, genesiss_cfg_file: str = c.DEF_GEN_CFG_FILE_NAME
+) -> tp.Dict[str, tp.Any]:
+    """Find the project configuration file."""
+    alternatives = [
+        os.path.join(project_dir, genesiss_cfg_file),
+        os.path.join(project_dir, c.DEF_GEN_WORK_DIR_NAME, genesiss_cfg_file),
+    ]
+
+    for alt in alternatives:
+        if os.path.exists(alt):
+            with open(alt, "r") as f:
+                return yaml.safe_load(f)
+
+    raise FileNotFoundError("Genesis configuration file not found")
+
+
+def get_keys_by_path_or_env(path: tp.Optional[str]) -> tp.Optional[str]:
+    # Keys by path has the first priority
+    if path is not None:
+        if not os.path.exists(path) or not os.path.isfile(path):
+            raise ValueError(f"Invalid path to the developer keys: {path}")
+
+        with open(path) as f:
+            return f.read()
+    # The second priority is the developer key by env
+    elif developer_keys := os.environ.get(c.ENV_GEN_DEV_KEYS):
+        return developer_keys
+
+    return
+
+
+def installation_net_name(name: str) -> str:
+    return f"{name}-net"
+
+
+def installation_bootstrap_name(name: str) -> str:
+    return f"{name}-bootstrap"
+
+
+def installation_name_from_bootstrap(bootstrap_name: str) -> str:
+    return bootstrap_name.replace("-bootstrap", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pbr>=1.10.0,<5.8.1  # Apache-2.0
 click>=8.1.7,<9.0.0  # BSD-3
+pyyaml>=6.0.0,<7.0.0  # MIT
+prettytable>=3.7.0,<4.0.0  # MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,4 @@ ubuntu_24 =
 
 [entry_points]
 console_scripts =
-    genesis-images = gcl_images.cmd.cli:main
-gcl_image_builder =
-    PackerBuilder = gcl_images.builder.packer:PackerBuilder
+    genesis = gcl_images.cmd.cli:main

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ flake8>=6.1.0  # MIT License (MIT)
 mock>=3.0.5,<4.0.0  # BSD
 pytest==7.0.1,<8.0.0  # MIT License (MIT)
 pytest-timer==0.0.11  # MIT License (MIT)
+pyyaml>=6.0.0,<7.0.0  # MIT


### PR DESCRIPTION
The package provides a command line interface for building genesis projects, managing genesis installations and cover many other useful aspects. To use the command line interface, run the `genesis` command from the command line. For full documentation about CLI commands, run `genesis --help`.