### PR TITLE
Bugfix: Building several images for one element

### DIFF
--- a/genesis_devtools/builder/base.py
+++ b/genesis_devtools/builder/base.py
@@ -131,6 +131,7 @@ class AbstractImageBuilder(abc.ABC):
         image: Image,
         deps: tp.List[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
+        output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
         """Actions to prepare the environment for building the image."""
 
@@ -157,9 +158,10 @@ class AbstractImageBuilder(abc.ABC):
         image: Image,
         deps: tp.List[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
+        output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
         """Run the image builder."""
-        self.pre_build(image_dir, image, deps, developer_keys)
+        self.pre_build(image_dir, image, deps, developer_keys, output_dir)
         self.build(image_dir, image, developer_keys)
         self.post_build(image_dir, image)
 
@@ -176,6 +178,7 @@ class DummyImageBuilder(AbstractImageBuilder):
         image: Image,
         deps: tp.List[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
+        output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
         """Actions to prepare the environment for building the image."""
         return None

--- a/genesis_devtools/builder/packer.py
+++ b/genesis_devtools/builder/packer.py
@@ -90,7 +90,7 @@ class PackerVariable(tp.NamedTuple):
         return self.var_tmpl.format(**data)
 
     @classmethod
-    def variable_file_content(cls, overrides: tp.Dict[str, tp.Any]) -> str:
+    def variable_file_content(cls, overrides: dict[str, tp.Any]) -> str:
         if not overrides:
             return ""
 
@@ -116,12 +116,9 @@ class PackerBuilder(base.DummyImageBuilder):
     Packer image builder that uses Packer tools to build images.
     """
 
-    def __init__(
-        self, output_dir: str, logger: AbstractLogger | None = None
-    ) -> None:
+    def __init__(self, logger: AbstractLogger | None = None) -> None:
         super().__init__()
         self._logger = logger or DummyLogger()
-        self._output_dir = output_dir
 
     def _resolve_envs(self, envs: list[str]) -> str:
         if len(envs) == 0:
@@ -144,8 +141,9 @@ class PackerBuilder(base.DummyImageBuilder):
         self,
         image_dir: str,
         image: base.Image,
-        deps: tp.List[base.AbstractDependency],
+        deps: list[base.AbstractDependency],
         developer_keys: str | None = None,
+        output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
         """Actions to prepare the environment for building the image."""
 
@@ -195,7 +193,7 @@ class PackerBuilder(base.DummyImageBuilder):
             file_provisioners="\n".join(provisioners),
             script=image.script,
             developer_keys=developer_keys_prov,
-            output_directory=self._output_dir,
+            output_directory=output_dir,
             envs=envs,
         )
 

--- a/genesis_devtools/cmd/cli.py
+++ b/genesis_devtools/cmd/cli.py
@@ -133,7 +133,7 @@ def build_cmd(
         return
 
     logger = ClickLogger()
-    packer_image_builder = PackerBuilder(output_dir, logger)
+    packer_image_builder = PackerBuilder(logger)
 
     # Path where genesis.yaml configuration file is located
     work_dir = os.path.abspath(
@@ -147,7 +147,7 @@ def build_cmd(
 
     for _, build in builds.items():
         builder = SimpleBuilder.from_config(
-            work_dir, build, packer_image_builder, logger
+            work_dir, build, packer_image_builder, logger, output_dir
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             builder.fetch_dependency(deps_dir or temp_dir)
@@ -210,8 +210,6 @@ def build_cmd(
 @click.option(
     "-f",
     "--force",
-    default=False,
-    type=bool,
     show_default=True,
     is_flag=True,
     help="Rebuild if the output already exists",


### PR DESCRIPTION
This patch fixes the problem building several images for an element:

Spec example:
```yaml
    - images:
      - name: genesis-base
        format: raw
        profile: ubuntu_24
        script: images/genesis_base/install_genesis_base.sh
        override:
          disk_size: "4G"

      - name: genesis-base1
        format: raw
        profile: ubuntu_24
        script: images/genesis_base/install_genesis_base.sh
        override:
          disk_size: "4G"
```

Before:
```
directory 'output' already exists
```

It works correctly now.
