### PR TITLE
Templated manifests

### DIFF
--- a/genesis_devtools/cmd/cli.py
+++ b/genesis_devtools/cmd/cli.py
@@ -51,7 +51,20 @@ def main() -> None:
     pass
 
 
-@main.command("build", help="Build Genesis project")
+@main.command(
+    "build",
+    help=(
+        "Build a Genesis element. The command build all images, manifests "
+        "and other artifacts required for the element. The manifest in the "
+        "project may be a raw YAML file or a template using Jinja2 "
+        "templates. For Jinja2 templates, the following variables are "
+        "available: \n\n"
+        "- {{ version }}: version of the element \n\n"
+        "- {{ name }}: name of the element \n\n"
+        "- {{ images }}: list of images \n\n"
+        "- {{ manifests }}: list of manifests \n\n"
+    ),
+)
 @click.option(
     "-c",
     "--genesis-cfg-file",
@@ -114,6 +127,15 @@ def build_cmd(
 ) -> None:
     if not project_dir:
         raise click.UsageError("No project directories specified")
+
+    # Leave 'none' for backward compatibility
+    if version_suffix == "none" and inventory:
+        version_suffix = "element"
+        click.secho(
+            "Inventory mode is not supported for 'none' version suffix, "
+            "using 'element' instead",
+            fg="yellow",
+        )
 
     if os.path.exists(output_dir) and not force:
         click.secho(

--- a/genesis_devtools/tests/unit/test_builder.py
+++ b/genesis_devtools/tests/unit/test_builder.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 from genesis_devtools.builder.builder import SimpleBuilder
 from genesis_devtools.logger import DummyLogger
+from genesis_devtools.builder import base
 
 
 class TestBuilder:
@@ -43,3 +44,96 @@ class TestBuilder:
         assert len(builder._deps) == 2
         assert len(builder._elements) == 1
         assert builder._work_dir == work_dir
+
+    def test_manifest_rendering_jinja2_variables(self, tmp_path) -> None:
+        """Ensure Jinja2 variables render correctly."""
+        # Arrange: temp work dir and output dir
+        work_dir = tmp_path / "work"
+        out_dir = tmp_path / "out"
+        work_dir.mkdir()
+        out_dir.mkdir()
+
+        # Create a Jinja2 manifest template that is also valid YAML before rendering
+        # so that the pre-parse with yaml.safe_load succeeds.
+        manifest_rel = "myapp.yaml.j2"
+        manifest_path = work_dir / manifest_rel
+        manifest_content = (
+            "name: my-element\n"
+            'version: "{{ version }}"\n'
+            "images: \"{{ images | join(',') }}\"\n"
+            "metadata:\n"
+            '  title: "{{ name }} v{{ version }}"\n'
+        )
+        manifest_path.write_text(manifest_content)
+
+        # Prepare builder with no images to focus on manifest rendering
+        builder = SimpleBuilder(
+            work_dir=str(work_dir),
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=str(out_dir),
+        )
+
+        element = base.Element(manifest=manifest_rel, images=[])
+
+        # Act
+        builder.build_element(
+            element=element,
+            build_dir=None,
+            developer_keys=None,
+            build_suffix="1.2.3",
+            inventory_mode=True,
+        )
+
+        # Assert: rendered manifest exists without the .j2 extension
+        manifests_dir = out_dir / "manifests"
+        rendered_manifest = manifests_dir / "myapp.yaml"
+        assert rendered_manifest.exists(), "Rendered manifest file not found"
+
+        content = rendered_manifest.read_text()
+        # Variables should be interpolated
+        assert 'version: "1.2.3"' in content
+        assert 'title: "my-element v1.2.3"' in content
+        # images list is empty -> joined string should be empty quotes
+        assert 'images: ""' in content
+
+        # Inventory file should be created and include the manifest reference
+        inventory_json = out_dir / "inventory.json"
+        assert inventory_json.exists(), "inventory.json was not created"
+
+    def test_manifest_rendering_preserves_filename_without_template_ext(
+        self, tmp_path
+    ) -> None:
+        """Ensure the rendered manifest file drops the template extension (.j2/.jinja2)."""
+        work_dir = tmp_path / "work"
+        out_dir = tmp_path / "out"
+        work_dir.mkdir()
+        out_dir.mkdir()
+
+        manifest_rel = "service.yaml.jinja2"
+        manifest_path = work_dir / manifest_rel
+        manifest_path.write_text('name: svc\nversion: "{{ version }}"\n')
+
+        builder = SimpleBuilder(
+            work_dir=str(work_dir),
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=str(out_dir),
+        )
+
+        element = base.Element(manifest=manifest_rel, images=[])
+
+        builder.build_element(
+            element=element,
+            build_dir=None,
+            developer_keys=None,
+            build_suffix="0.0.1",
+            inventory_mode=True,
+        )
+
+        # The output manifest should be saved without the .jinja2 extension
+        assert (out_dir / "manifests" / "service.yaml").exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ GitPython>=3.1.30,<4.0.0
 bazooka>=1.0.0,<2.0.0  # Apache-2.0
 cryptography>=45.0.5,<47.0.0 # BSD-3
 boto3>=1.40.34,<2.0.0  # Apache-2.0
+Jinja2>=3.1.5,<4.0.0  # BSD License (BSD-3-Clause)


### PR DESCRIPTION
Added support of templated manifests. Manifests can be written in Jinja2 format to have an ablity specify some build time variables such as:
- version
- name
- images
- manifests

For instance, the original templated manifest:
```yaml
name: "demo"
description: "Demo element"
schema_version: 1
version: "{{ version }}"
...
```

The manifest after build
```yaml
name: "demo"
description: "Demo element"
schema_version: 1
version: "0.0.1"
...
```

The manifest is considired as a template if its extension finishes at `.j2` or `.jinja2`.

Closes #81 