### PR TITLE
Bootstrap new installation with boot and main networks

### DIFF
--- a/genesis_devtools/infra/libvirt/constants.py
+++ b/genesis_devtools/infra/libvirt/constants.py
@@ -23,5 +23,6 @@ GENESIS_META_CPU_TAG = "genesis:vcpu"
 GENESIS_META_MEM_TAG = "genesis:mem"
 GENESIS_META_IMAGE_TAG = "genesis:image"
 GENESIS_META_NET_TAG = "genesis:network"
+GENESIS_META_BOOT_NET_TAG = "genesis:boot_network"
 
 BootMode = tp.Literal["hd", "network"]

--- a/genesis_devtools/utils.py
+++ b/genesis_devtools/utils.py
@@ -97,6 +97,10 @@ def installation_net_name(name: str) -> str:
     return f"{name}-net"
 
 
+def installation_boot_net_name(name: str) -> str:
+    return f"{name}-boot-net"
+
+
 def installation_bootstrap_name(name: str) -> str:
     return f"{name}-bootstrap"
 


### PR DESCRIPTION
Adaptation for the bootstrap command to run a new installation with two network.
- Boot network. It's required to perform provisioning process of new node. Also it's a private isolate network allows to transfer a private keys for agents.
- Main network. It's a base network for communication.