### PR TITLE
Fix init crash for empty template scenarios

### DIFF
--- a/genesis_devtools/builder/dependency.py
+++ b/genesis_devtools/builder/dependency.py
@@ -62,12 +62,9 @@ class LocalPathDependency(base.AbstractDependency):
 
     def fetch(self, output_dir: str) -> None:
         """Fetch the dependency."""
-        path = self._path
+        path = os.path.normpath(self._path)
 
         if os.path.isdir(path):
-            # Remove trailing slash
-            if path.endswith("/"):
-                path = path[:-1]
             name = os.path.basename(path)
             ignore_func = self._ignore_func if self._exclude else None
             shutil.copytree(path, os.path.join(output_dir, name), ignore=ignore_func)
@@ -138,11 +135,9 @@ class LocalEnvPathDependency(base.AbstractDependency):
         if not os.path.isabs(path):
             path = os.path.join(self._work_dir, path)
 
-        if os.path.isdir(path):
-            # Remove trailing slash
-            if path.endswith("/"):
-                path = path[:-1]
+        path = os.path.normpath(path)
 
+        if os.path.isdir(path):
             name = os.path.basename(path)
             shutil.copytree(path, os.path.join(output_dir, name))
             self._local_path = os.path.join(output_dir, name)

--- a/genesis_devtools/tests/unit/test_dependency.py
+++ b/genesis_devtools/tests/unit/test_dependency.py
@@ -16,6 +16,7 @@
 
 import os
 import shutil
+import tempfile
 import typing as tp
 
 from genesis_devtools.builder import dependency as deps
@@ -49,6 +50,29 @@ class TestDependency:
         finally:
             shutil.rmtree("/tmp/genesis_core_test_dir")
             shutil.rmtree("/tmp/___deps_dir")
+
+    def test_local_path_fetch_normalizes_parent_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            src_dir = os.path.join(temp_dir, "source")
+            nested_dir = os.path.join(src_dir, "nested")
+            output_dir = os.path.join(temp_dir, "deps")
+
+            os.makedirs(nested_dir, exist_ok=True)
+            os.makedirs(output_dir, exist_ok=True)
+
+            readme_path = os.path.join(src_dir, "README.md")
+            with open(readme_path, "w") as fp:
+                fp.write("content")
+
+            dep = deps.LocalPathDependency(
+                path=os.path.join(nested_dir, ".."),
+                img_dest="/opt/genesis_core",
+            )
+
+            dep.fetch(output_dir)
+
+            assert dep.local_path == os.path.join(output_dir, "source")
+            assert os.path.exists(os.path.join(dep.local_path, "README.md"))
 
     def test_http_from_config(self, build_config: tp.Dict[str, tp.Any]) -> None:
         work_dir = "/tmp/work_dir"

--- a/genesis_devtools/wizards/engines/templaters/templaters.py
+++ b/genesis_devtools/wizards/engines/templaters/templaters.py
@@ -20,6 +20,7 @@ import pathlib
 
 import jinja2
 
+from genesis_devtools.wizards import constants as c
 from genesis_devtools.wizards.engines import base
 from genesis_devtools.wizards.engines.templaters import settings
 from genesis_devtools.wizards.scenarios import base as scenarios
@@ -42,6 +43,15 @@ class JinjaTemplateEngine(base.AbstractEngine):
                 isinstance(action.result, scenarios.Scenario)
                 for _, action in scenario_actions
             ):
+                continue
+
+            if (
+                isinstance(scenario, scenarios.TemplateScenario)
+                and scenario.template == c.EMPTY_TEMPLATE
+            ):
+                # TODO: Temporary workaround for nested orchestration scenarios
+                # that still use the placeholder `empty` template. This should
+                # be fixed at template/scenario definition level.
                 continue
 
             self._settings.append(settings.TemplateSetting(scenario))


### PR DESCRIPTION
Skip TemplateScenario entries with the placeholder 'empty' template when building Jinja template settings. This prevents init from resolving a non-existent templates/empty path for nested orchestration scenarios.