### PR TITLE
Add introduction command and enable inventory by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ mdlint:
 	markdownlint-cli2 --config .markdownlint.yaml "**/*.md" "#node_modules" --fix
 
 build_empty:
-	./dist/exordos build -i $(SSH_KEY) -f ../exordos_empty -o ../exordos_empty/output --inventory --manifest-var repository=$(REPOSITORY)
+	./dist/exordos build -i $(SSH_KEY) -f ../exordos_empty -o ../exordos_empty/output --manifest-var repository=$(REPOSITORY)
 
 push_empty:
 	./dist/exordos repo push -t my_push_name -f --latest ../exordos_empty -e ../exordos_empty/output

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -146,9 +146,7 @@ download_and_extract "https://repository.genesis-core.tech/exordos/latest" "$BIN
 $SUDO chmod +x "$BINDIR"/exordos
 
 install_success() {
-    exordos --silent hello
-    exordos --silent autocomplete_help
-    status 'Install complete. Run "exordos" from the command line.'
+    exordos introduction
 }
 trap install_success EXIT
 

--- a/exordos/cmd/builds/commands.py
+++ b/exordos/cmd/builds/commands.py
@@ -90,10 +90,10 @@ from exordos.logger import ClickLogger
     help="Rebuild if the output already exists",
 )
 @click.option(
-    "--inventory",
+    "--only-images",
     show_default=True,
     is_flag=True,
-    help="Build using the inventory format",
+    help="Build only images, skip manifests and other artifacts",
 )
 @click.option(
     "--manifest-var",
@@ -104,7 +104,7 @@ from exordos.logger import ClickLogger
         "key1=value1 --manifest-var key2=value2"
     ),
 )
-@click.argument("project_dir", type=click.Path())
+@click.argument("project_dir", type=click.Path(), default=".")
 @click.pass_context
 def build_cmd(
     ctx: click.Context,
@@ -115,14 +115,12 @@ def build_cmd(
     developer_key_path: str | None,
     version_suffix: c.VersionSuffixType,
     force: bool,
-    inventory: bool,
+    only_images: bool,
     manifest_var: tuple[str, ...],
     project_dir: str,
 ) -> None:
-    if not project_dir:
-        raise click.UsageError("No project directories specified")
-
     manifest_vars = utils.convert_input_multiply(manifest_var)
+    inventory = not only_images
 
     # Leave 'none' for backward compatibility
     if version_suffix == "none" and inventory:

--- a/exordos/cmd/cli.py
+++ b/exordos/cmd/cli.py
@@ -22,12 +22,12 @@ from requests.exceptions import RequestException
 import rich_click as click
 
 from exordos.cmd.aliases import ClickAliasedGroup
+from exordos.cmd.builds import commands as builds_commands
 from exordos.cmd.compute import compute_group
 from exordos.cmd.compute.hypervisors import commands as hypervisors_commands
 from exordos.cmd.compute.nodes import commands as nodes_commands
 from exordos.cmd.configs import commands as configs_commands
 from exordos.cmd.em import em_group
-from exordos.cmd.em.builder import commands as builder_commands
 from exordos.cmd.em.elements import commands as elements_commands
 from exordos.cmd.iam import iam_group
 from exordos.cmd.iam.auth import commands as auth_commands
@@ -47,7 +47,7 @@ import exordos.constants as c
 
 COMMANDS_WITHOUT_CONFIG = {
     auth_commands.auth_group.name,
-    builder_commands.build_cmd.name,
+    builds_commands.build_cmd.name,
     initialization_commands.init_cmd.name,
     version_commands.version_cmd.name,
     version_commands.latest_cmd.name,
@@ -58,6 +58,7 @@ COMMANDS_WITHOUT_CONFIG = {
     utils_commands.autocomplete.name,
     utils_commands.autocomplete_help.name,
     utils_commands.hello.name,
+    utils_commands.introduction.name,
     hypervisors_commands.init_cmd.name,
     settings_commands.settings_group.name,
 }
@@ -247,7 +248,7 @@ exordos.add_command(nodes_commands.cn_group)  # noqa
 
 exordos.add_command(em_group, aliases=["e"])  # noqa
 exordos.add_command(elements_commands.ee_group)  # noqa
-exordos.add_command(builder_commands.build_cmd)  # noqa
+exordos.add_command(builds_commands.build_cmd)  # noqa
 
 exordos.add_command(configs_commands.configs_group)  # noqa
 exordos.add_command(settings_commands.settings_group)  # noqa
@@ -269,6 +270,7 @@ exordos.add_command(utils_commands.hello)  # noqa
 exordos.add_command(utils_commands.autocomplete_help)  # noqa
 exordos.add_command(utils_commands.autocomplete)  # noqa
 exordos.add_command(utils_commands.sync)  # noqa
+exordos.add_command(utils_commands.introduction)  # noqa
 
 
 if __name__ == "__main__":

--- a/exordos/cmd/stand/utils_commands.py
+++ b/exordos/cmd/stand/utils_commands.py
@@ -20,6 +20,8 @@ import typing as tp
 
 import requests
 import rich_click as click
+from rich.console import Console
+from rich.markdown import Markdown
 
 from exordos import utils
 import exordos.constants as c
@@ -204,3 +206,57 @@ def sync(obj: "ContextObject", target_dir: str | None, project_dir: str | None) 
     ]
     subprocess.run(cmd, check=True)
     return None
+
+
+INTRODUCTION_TEXT = """
+# Welcome to Exordos CLI!
+
+Exordos CLI is now installed and ready to use. Next steps:
+
+## Development
+
+Initialize a new element in the current directory:
+
+```bash
+exordos init
+```
+
+Learn more: [https://exordos.github.io/exordos_core/app-developer-guide/init/](https://exordos.github.io/exordos_core/app-developer-guide/init/)
+
+Build your project as an Exordos element:
+
+```bash
+exordos build
+```
+
+Learn more: [https://exordos.github.io/exordos_core/app-developer-guide/build/](https://exordos.github.io/exordos_core/app-developer-guide/build/)
+
+## Local Deployment
+
+To set up a local Exordos platform instance:
+
+Install [dependencies](https://exordos.github.io/exordos_core/usage/local_deployment/#dependencies) and bootstrap the Exordos platform locally:
+
+```bash
+exordos bootstrap -i latest -m core --ssh-public-key /path/to/your/public/key
+```
+
+Learn more: [https://exordos.github.io/exordos_core/usage/local_deployment/](https://exordos.github.io/exordos_core/usage/local_deployment/)
+
+## References
+
+- **Documentation**: [https://exordos.github.io/exordos_core/](https://exordos.github.io/exordos_core/)
+- **Quick Start Guide**: [https://exordos.github.io/exordos_core/app-developer-guide/](https://exordos.github.io/exordos_core/app-developer-guide/)
+- **Local Deployment**: [https://exordos.github.io/exordos_core/usage/local_deployment/](https://exordos.github.io/exordos_core/usage/local_deployment/)
+
+Use `exordos autocomplete` to enable autocomplete for your shell.
+
+Use `exordos --help` to see all available commands.
+"""
+
+
+@click.command("introduction", help="Display introduction guide")
+def introduction() -> None:
+    console = Console()
+    md = Markdown(INTRODUCTION_TEXT)
+    console.print(md)


### PR DESCRIPTION
- Add `exordos introduction` command for post-install user guidance
- Display quick start, local deployment docs and references
- Run introduction automatically after installation
- Rename builder commands to builds and enable inventory mode by default