### PR TITLE
feat(builder): produce multiple image formats from a single build

### DIFF
--- a/exordos/builder/base.py
+++ b/exordos/builder/base.py
@@ -34,10 +34,50 @@ class Image:
 
     script: str
     profile: c.ImageProfileType = "ubuntu_24"
-    format: c.ImageFormatType = DEF_IMG_FORMAT
+    formats: list[str] = dataclasses.field(default_factory=lambda: ["raw"])
     name: str | None = None
     envs: list[str] | None = None
     override: dict[str, tp.Any] | None = None
+
+    @property
+    def format(self) -> str:
+        """Return the primary (first) image format."""
+        return self.formats[0]
+
+    @classmethod
+    def _resolve_formats(cls, raw_format_str: str) -> list[str]:
+        """Resolve image formats from a comma-separated string."""
+        raw_format_str = raw_format_str.strip()
+        if raw_format_str.startswith(cls.ENV_IMG_PREFIX):
+            # Extract key and default image format if they present
+            if "=" in raw_format_str:
+                env_key, img_formats = raw_format_str.split("=", 1)
+            else:
+                env_key, img_formats = raw_format_str, None
+
+            try:
+                img_formats = os.environ[env_key]
+            except KeyError:
+                if not img_formats:
+                    raise ValueError(
+                        f"Image format {raw_format_str} is not found in the environment "
+                        f"and no default value is provided"
+                    )
+
+            # Save extracted formats back to the string
+            raw_format_str = img_formats
+
+        formats = list(dict.fromkeys(f.strip() for f in raw_format_str.split(",")))
+
+        # Validate formats
+        for f in formats:
+            if f not in c.ImageFormatType.__args__:
+                raise ValueError(
+                    f"Invalid image format: {f}, "
+                    f"expected one of {c.ImageFormatType.__args__}"
+                )
+
+        return formats
 
     @classmethod
     def from_config(cls, image_config: dict[str, tp.Any], work_dir: str) -> "Image":
@@ -47,33 +87,12 @@ class Image:
         if not os.path.isabs(script):
             script = os.path.join(work_dir, script)
 
-        # Determine the image format
-        img_format = image_config.pop("format")
-        if img_format.startswith(cls.ENV_IMG_PREFIX):
-            format_def = None
+        # Determine the image format(s). The value may be a comma-separated
+        # string of formats, e.g. "raw, qcow2" or "gz, qcow2".
+        raw_format_value = str(image_config.pop("format", cls.DEF_IMG_FORMAT))
+        formats = cls._resolve_formats(raw_format_value)
 
-            # Handle case if there is a default value
-            if "=" in img_format:
-                img_format, format_def = [i.strip() for i in img_format.split("=", 1)]
-
-            try:
-                img_format = os.environ[img_format]
-            except KeyError:
-                if not format_def:
-                    raise ValueError(
-                        f"Image format {img_format} is not found in the environment "
-                        f"and no default value is provided"
-                    )
-                img_format = format_def
-
-        # Validate the image format
-        if img_format not in c.ImageFormatType.__args__:
-            raise ValueError(
-                f"Invalid image format: {img_format}, "
-                f"expected one of {c.ImageFormatType.__args__}"
-            )
-
-        return cls(script=script, format=img_format, **image_config)
+        return cls(script=script, formats=formats, **image_config)
 
 
 @dataclasses.dataclass

--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -19,6 +19,7 @@ import gzip
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import typing as tp
 
@@ -81,6 +82,50 @@ class SimpleBuilder:
 
         return dst_path
 
+    def _convert_image(
+        self,
+        raw_src: str,
+        img_name: str,
+        fmt: str,
+        images_output_dir: str,
+    ) -> str:
+        """Convert a RAW image to the requested format and return the final path."""
+        if fmt == "raw":
+            tgt = os.path.join(images_output_dir, f"{img_name}.raw")
+            shutil.move(raw_src, tgt)
+            return os.path.abspath(tgt)
+        elif fmt == "qcow2":
+            self._logger.info(f"Converting {img_name} to qcow2")
+            tgt = os.path.join(images_output_dir, f"{img_name}.qcow2")
+            subprocess.run(
+                [
+                    "qemu-img",
+                    "convert",
+                    "-f",
+                    "raw",
+                    "-O",
+                    "qcow2",
+                    "-c",
+                    "-o",
+                    "preallocation=off,compression_type=zstd",
+                    raw_src,
+                    tgt,
+                ],
+                check=True,
+            )
+            return os.path.abspath(tgt)
+        elif fmt == "gz":
+            self._logger.info(f"Compressing {img_name} to {img_name}.raw.gz")
+            tgt = os.path.join(images_output_dir, f"{img_name}.raw.gz")
+            with (
+                open(raw_src, "rb") as f_in,
+                gzip.open(tgt, "wb", compresslevel=5) as f_out,
+            ):
+                shutil.copyfileobj(f_in, f_out)
+            return os.path.abspath(tgt)
+        else:
+            raise ValueError(f"Unsupported image format: {fmt}")
+
     def _build_image(
         self,
         img: base.Image,
@@ -88,7 +133,7 @@ class SimpleBuilder:
         output_dir: str,
         developer_keys: str,
         inventory_mode: bool = False,
-    ) -> str:
+    ) -> tp.List[str]:
 
         # Determine images output directory
         if inventory_mode:
@@ -121,26 +166,23 @@ class SimpleBuilder:
         if not os.path.exists(images_output_dir):
             os.makedirs(images_output_dir)
 
-        # Determine source path to move. If gzip was requested,
-        # compress RAW -> GZ first.
-        if img.format == "gz":
-            self._logger.info(f"Compressing {img.name} to {img.name}.raw.gz")
-            # Source RAW image produced by Packer
-            raw_src = os.path.join(output_dir, f"{img.name}.raw")
-            gz_tgt = os.path.join(images_output_dir, f"{img.name}.raw.gz")
-            # Compress using standard library (gzip uses zlib) with level 5
-            with (
-                open(raw_src, "rb") as f_in,
-                gzip.open(gz_tgt, "wb", compresslevel=5) as f_out,
-            ):
-                shutil.copyfileobj(f_in, f_out)
-            return os.path.abspath(gz_tgt)
+        # A builder always produces a RAW image. Convert to each requested format.
+        raw_src = os.path.join(output_dir, f"{img.name}.raw")
+
+        # Move "raw" in the end as it will be moved
+        if "raw" in img.formats:
+            img_formats = [f for f in img.formats if f != "raw"] + ["raw"]
         else:
-            src_path = os.path.join(output_dir, f"{img.name}.{img.format}")
-            shutil.move(src_path, images_output_dir)
-            return os.path.abspath(
-                os.path.join(images_output_dir, f"{img.name}.{img.format}")
-            )
+            img_formats = img.formats
+
+        result_paths = []
+        for fmt in img_formats:
+            path = self._convert_image(raw_src, img.name, fmt, images_output_dir)
+            result_paths.append(path)
+
+        # TODO(akremenetsky): Should we clear raw format?
+
+        return result_paths
 
     def fetch_dependency(self, deps_dir: str) -> None:
         """Fetch common dependencies for elements."""
@@ -185,14 +227,14 @@ class SimpleBuilder:
             tmp_img_output = f"_tmp_{img.name}-output"
 
             try:
-                _path = self._build_image(
+                _paths = self._build_image(
                     img,
                     build_dir,
                     tmp_img_output,
                     developer_keys,
                     inventory_mode,
                 )
-                image_paths.append(_path)
+                image_paths.extend(_paths)
             finally:
                 if os.path.exists(tmp_img_output):
                     shutil.rmtree(tmp_img_output)

--- a/exordos/builder/packer.py
+++ b/exordos/builder/packer.py
@@ -219,10 +219,15 @@ class PackerBuilder(base.DummyImageBuilder):
         # Override variables
         override = image.override or {}
 
-        # Enrich with the image format
-        # If compressed gzip is requested, we build a RAW image first
-        # and compress it afterwards in the SimpleBuilder.
-        override["img_format"] = "raw" if image.format == "gz" else image.format
+        # Packer always produces a raw image; all format conversions are
+        # handled by SimpleBuilder after the build.
+        if override.get("img_format") and override["img_format"] != "raw":
+            self._logger.warning(
+                "Packer uses only 'raw' format. The output will be converted "
+                "to the specified format."
+            )
+
+        override["img_format"] = "raw"
 
         # Write the packer variables
         variables = PackerVariable.variable_file_content(override)

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -103,6 +103,7 @@ def _download_inventory_files(
     base_url: str,
     raw: dict,
     cache_dir: pathlib.Path,
+    images_suffix_filter: tp.Optional[str] = None,
 ) -> None:
     """Download all artefact files referenced in *raw* inventory to *cache_dir*.
 
@@ -112,6 +113,11 @@ def _download_inventory_files(
     Already-cached files are skipped.  On completion, *raw* is mutated in-place
     so that every category list contains absolute local paths, and the final
     ``inventory.json`` is written to *cache_dir*.
+
+    Args:
+        images_suffix_filter: When set, only image files whose name ends with
+            this suffix (e.g. ``'.qcow2'``) are downloaded and kept in the
+            cached inventory.  All other categories are unaffected.
     """
     inventories = raw if isinstance(raw, list) else [raw]
 
@@ -121,7 +127,14 @@ def _download_inventory_files(
     all_files: list[tuple[str, pathlib.Path, str]] = []
     for inv in inventories:
         for category in base_builder.ElementInventory.categories():
-            for rel_path in inv.get(category, []):
+            rel_paths = inv.get(category, [])
+            if images_suffix_filter and category == "images":
+                rel_paths = [
+                    p
+                    for p in rel_paths
+                    if pathlib.Path(p).name.endswith(images_suffix_filter)
+                ]
+            for rel_path in rel_paths:
                 file_name = pathlib.Path(rel_path).name
                 remote_url = f"{base_url}/{category}/{file_name}"
                 local_file = cache_dir / category / file_name
@@ -162,9 +175,16 @@ def _download_inventory_files(
 
     for inv in inventories:
         for category in base_builder.ElementInventory.categories():
+            rel_paths = inv.get(category, [])
+            if images_suffix_filter and category == "images":
+                rel_paths = [
+                    p
+                    for p in rel_paths
+                    if pathlib.Path(p).name.endswith(images_suffix_filter)
+                ]
             inv[category] = [
                 str(cache_dir / category / pathlib.Path(rel_path).name)
-                for rel_path in inv.get(category, [])
+                for rel_path in rel_paths
             ]
 
     inventory_local = cache_dir / "inventory.json"
@@ -194,7 +214,9 @@ def _resolve_inventory_from_url(url: str) -> pathlib.Path:
     cache_dir.mkdir(parents=True, exist_ok=True)
     with requests.Session() as session:
         raw = _download_inventory_json(session, base_url)
-        _download_inventory_files(session, base_url, raw, cache_dir)
+        _download_inventory_files(
+            session, base_url, raw, cache_dir, images_suffix_filter=".qcow2"
+        )
 
     return cache_dir
 

--- a/exordos/tests/unit/test_builder.py
+++ b/exordos/tests/unit/test_builder.py
@@ -197,3 +197,103 @@ class TestBuilder:
 
         assert (out_dir / "manifests" / "app1.yaml").exists()
         assert (out_dir / "manifests" / "app2.yaml").exists()
+
+    def test_image_from_config_single_format(self) -> None:
+        """Image.from_config parses a single format string into a one-element list."""
+        img = base.Image.from_config(
+            {"script": "/tmp/install.sh", "format": "qcow2", "name": "my-img"},
+            work_dir="/tmp",
+        )
+        assert img.formats == ["qcow2"]
+        assert img.format == "qcow2"
+
+    def test_image_from_config_multi_format(self) -> None:
+        """Image.from_config parses a comma-separated format string correctly."""
+        img = base.Image.from_config(
+            {"script": "/tmp/install.sh", "format": "raw, qcow2", "name": "my-img"},
+            work_dir="/tmp",
+        )
+        assert img.formats == ["raw", "qcow2"]
+        assert img.format == "raw"
+
+    def test_image_from_config_gz_qcow2(self) -> None:
+        """Image.from_config parses gz,qcow2 multi-format correctly."""
+        img = base.Image.from_config(
+            {"script": "/tmp/install.sh", "format": "gz,qcow2", "name": "my-img"},
+            work_dir="/tmp",
+        )
+        assert img.formats == ["gz", "qcow2"]
+
+    def test_convert_image_raw(self, tmp_path) -> None:
+        """_convert_image copies a raw image to the output dir."""
+        images_dir = tmp_path / "images"
+        images_dir.mkdir()
+        raw_src = tmp_path / "my-img.raw"
+        raw_src.write_bytes(b"rawdata")
+
+        builder = SimpleBuilder(
+            work_dir=str(tmp_path),
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=str(tmp_path / "out"),
+        )
+        result = builder._convert_image(str(raw_src), "my-img", "raw", str(images_dir))
+        assert pathlib.Path(result).name == "my-img.raw"
+        assert pathlib.Path(result).exists()
+
+    def test_build_element_multi_format_inventory(self, tmp_path) -> None:
+        """build_element lists all requested format variants in inventory images."""
+        work_dir = tmp_path / "work"
+        out_dir = tmp_path / "out"
+        work_dir.mkdir()
+        out_dir.mkdir()
+
+        manifest_rel = "app.yaml"
+        (work_dir / manifest_rel).write_text("name: myapp\nversion: 0\n")
+
+        raw_file = tmp_path / "packer_out" / "myapp.raw"
+        raw_file.parent.mkdir(parents=True)
+        raw_file.write_bytes(b"fake-raw-image-data")
+
+        img = base.Image(
+            script=str(work_dir / "install.sh"),
+            formats=["raw", "gz"],
+            name="myapp",
+        )
+
+        mock_builder = MagicMock(spec=base.AbstractImageBuilder)
+
+        def fake_run(image_dir, image, deps, developer_keys, output_dir):
+            out = pathlib.Path(output_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            (out / f"{image.name}.raw").write_bytes(b"fake-raw-image-data")
+
+        mock_builder.run.side_effect = fake_run
+
+        builder = SimpleBuilder(
+            work_dir=str(work_dir),
+            deps=[],
+            elements=[base.Element(manifest=manifest_rel, images=[img])],
+            image_builder=mock_builder,
+            logger=DummyLogger(),
+            elements_output_dir=str(out_dir),
+        )
+
+        builder.build(
+            build_dir=None,
+            developer_keys=None,
+            build_suffix="1.0.0",
+            inventory_mode=True,
+            manifest_vars=None,
+        )
+
+        inventory_json = out_dir / "inventory.json"
+        assert inventory_json.exists()
+        data = json.loads(inventory_json.read_text())
+        assert isinstance(data, list)
+        images = data[0]["images"]
+        image_names = [pathlib.Path(p).name for p in images]
+        assert any(n.endswith(".raw") for n in image_names)
+        assert any(n.endswith(".raw.gz") for n in image_names)


### PR DESCRIPTION
Replace single-format `Image.format` with `Image.formats` list. SimpleBuilder converts the Packer-produced RAW image to each requested format (raw, qcow2, gz). Add suffix filtering when downloading inventory image files.