### PR TITLE
Fix zstd compression level from -10 to -9 for raw image compression

### DIFF
--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -131,7 +131,7 @@ class SimpleBuilder:
             subprocess.run(
                 [
                     "zstd",
-                    "-10",  # The trade-off between speed and size
+                    "-9",  # The trade-off between speed and size
                     "-T0",
                     "-f",
                     "-o",


### PR DESCRIPTION
In the level `-9` ~ 1.5 faster compression speed and output artifact gives additional 0.4% size.