### PR TITLE
Configurable disk sizes, IAM default client settings

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -20,6 +20,7 @@ import ipaddress
 import json
 import os
 import pathlib
+import secrets
 import subprocess
 import time
 import typing as tp
@@ -390,6 +391,14 @@ def _register_core(
     return realm_uuid, realm_secret, tokens_dict
 
 
+def _iam_default_client_settings() -> dict:
+    return {
+        "default_client_uuid": "00000000-0000-0000-0000-000000000000",
+        "default_client_id": "Exordos",
+        "default_client_secret": secrets.token_urlsafe(32),
+    }
+
+
 def _bootstrap_core(
     image_path: str | None,
     image_uri: str | None,
@@ -398,6 +407,7 @@ def _bootstrap_core(
     stand_spec: tp.Dict[str, tp.Any] | None,
     stand_main_network: stand_models.Network,
     stand_boot_network: stand_models.Network,
+    disks: list[str] | None,
     force: bool,
     core_ip: ipaddress.IPv4Address,
     repository: str,
@@ -430,6 +440,7 @@ def _bootstrap_core(
             image_uri=image_uri,
             cores=profile.cores,
             memory=profile.ram,
+            disks=disks,
             core_ip=core_ip,
             network=stand_main_network,
             boot_network=stand_boot_network,
@@ -472,6 +483,10 @@ def _bootstrap_core(
         infra.delete_stand(stand)
         logger.info(f"Destroyed old Exordos installation: {dev_stand.name}")
 
+    # Prepare IAM settings
+    iam = _iam_default_client_settings()
+    iam["admin_password"] = admin_password
+
     try:
         infra.create_stand(
             dev_stand,
@@ -487,6 +502,7 @@ def _bootstrap_core(
             realm_secret=realm_secret,
             realm_tokens=realm_tokens,
             developer_keys=ssh_public_key,
+            iam=iam,
         )
         logger.info(f"Launched Exordos installation in `{profile.value}` profile")
 
@@ -561,6 +577,20 @@ def _bootstrap_core(
     show_default=True,
     help="Profile for the installation.",
     type=click.Choice([p.value for p in Profile]),
+)
+@click.option(
+    "--root-disk-size",
+    default=10,
+    show_default=True,
+    type=int,
+    help="Root disk size in GB",
+)
+@click.option(
+    "--data-disk-size",
+    default=10,
+    show_default=True,
+    type=int,
+    help="Data disk size in GB",
 )
 @click.option(
     "--name",
@@ -751,6 +781,8 @@ def bootstrap_cmd(
     ctx: click.Context,
     inventory: str,
     profile: str,
+    root_disk_size: int,
+    data_disk_size: int,
     name: str,
     launch_mode: LaunchModeType,
     stand_spec: str | None,
@@ -932,6 +964,7 @@ def bootstrap_cmd(
             stand_spec=stand_spec,
             stand_main_network=stand_main_network,
             stand_boot_network=stand_boot_network,
+            disks=[root_disk_size, data_disk_size],
             force=force,
             core_ip=core_ip,
             repository=repository,

--- a/exordos/infra/libvirt/libvirt.py
+++ b/exordos/infra/libvirt/libvirt.py
@@ -326,7 +326,12 @@ def create_domain(
         tgt_image_path = os.path.join(pool_path, image_name)
         delete_volume(pool, image_name)
         create_volume(
-            pool, image_name, disks[0].size, source_path=image, fmt=img_format
+            pool,
+            image_name,
+            disks[0].size,
+            source_path=image,
+            fmt=img_format,
+            target_image_path=tgt_image_path,
         )
         disks_xml = disk_template.format(
             device="vda",
@@ -657,6 +662,7 @@ def create_volume(
     size_gb: int,
     fmt: str = "qcow2",
     source_path: str | None = None,
+    target_image_path: str | None = None,
 ) -> None:
     args = [
         "sudo",
@@ -693,8 +699,17 @@ def create_volume(
                 stdout=subprocess.DEVNULL,
             )
         else:
+            if target_image_path is None:
+                ValueError("Need to specify `target_image_path`!")
+
             subprocess.check_call(
                 ["sudo", "virsh", "vol-upload", "--pool", pool, name, source_path],
+                stdout=subprocess.DEVNULL,
+            )
+
+            # Actualize uploaded volume with desired size instead of size of the image.
+            subprocess.check_call(
+                ["sudo", "qemu-img", "resize", target_image_path, f"{size_gb}G"],
                 stdout=subprocess.DEVNULL,
             )
 

--- a/exordos/stand/models.py
+++ b/exordos/stand/models.py
@@ -198,6 +198,7 @@ class Stand:
         boot_network: Network,
         cores: int = 1,
         memory: int = 1024,
+        disks: list[str] | None = None,
         name: str = "dev-stand",
         bootstrap_name: str = "bootstrap",
         hypervisors: tp.Collection[Hypervisor] = (),
@@ -206,6 +207,19 @@ class Stand:
             Port(mac=Port.gen_mac(), ip=core_ip),
             Port(mac=Port.gen_mac()),
         ]
+        if disks is None:
+            disks = [
+                Disk(size=10, label="root-volume"),
+                Disk(size=10, label="data"),
+            ]
+        else:
+            if len(disks) != 2:
+                raise ValueError("Core node requires exactly 2 disks!")
+            disks = [
+                Disk(size=int(disks[0]), label="root-volume"),
+                Disk(size=int(disks[1]), label="data"),
+            ]
+
         return cls(
             name=name,
             network=network,
@@ -217,6 +231,7 @@ class Stand:
                     image_uri=image_uri,
                     cores=cores,
                     memory=memory,
+                    disks=disks,
                     ports=ports,
                 )
             ],


### PR DESCRIPTION
The following key features added
- Two options for the `bootstrap` command. The options allow to specify size for the root and data disks.
- Generate IAM default client settings for every new realm.