### PR TITLE
Deep refactoring of build command

### DIFF
--- a/exordos/builder/base.py
+++ b/exordos/builder/base.py
@@ -22,6 +22,8 @@ import os
 import pathlib
 import typing as tp
 
+import yaml
+
 from exordos import constants as c
 
 
@@ -80,7 +82,9 @@ class Image:
         return formats
 
     @classmethod
-    def from_config(cls, image_config: dict[str, tp.Any], work_dir: str) -> "Image":
+    def from_config(
+        cls, image_config: dict[str, tp.Any], work_dir: pathlib.Path
+    ) -> "Image":
         """Create an image from configuration."""
         image_config = image_config.copy()
         script = image_config.pop("script")
@@ -103,7 +107,7 @@ class Config:
     path: str
 
     @classmethod
-    def from_config(cls, config: dict[str, tp.Any], work_dir: str) -> "Config":
+    def from_config(cls, config: dict[str, tp.Any], work_dir: pathlib.Path) -> "Config":
         """Create a config from configuration."""
         abs_path = os.path.join(work_dir, config["path"])
         return cls(abs_path=abs_path, path=config["path"])
@@ -117,19 +121,22 @@ class Artifact:
     path: str
 
     @classmethod
-    def from_config(cls, config: dict[str, tp.Any], work_dir: str) -> "Artifact":
+    def from_config(
+        cls, config: dict[str, tp.Any], work_dir: pathlib.Path
+    ) -> "Artifact":
         """Create an artifact from configuration."""
         abs_path = os.path.join(work_dir, config["path"])
         return cls(abs_path=abs_path, path=config["path"])
 
 
-class Element(tp.NamedTuple):
+@dataclasses.dataclass
+class Element:
     """Element representation."""
 
-    manifest: tp.Optional[str] = None
-    images: tp.Optional[tp.List[Image]] = None
-    artifacts: tp.Optional[tp.List[Artifact]] = None
-    configs: tp.Optional[tp.List[Config]] = None
+    manifest: pathlib.Path | None = None
+    images: list[Image] = dataclasses.field(default_factory=list)
+    artifacts: list[Artifact] = dataclasses.field(default_factory=list)
+    configs: list[Config] = dataclasses.field(default_factory=list)
 
     def __str__(self):
         if self.manifest:
@@ -141,9 +148,14 @@ class Element(tp.NamedTuple):
 
         return f"<Element {str(self)}>"
 
+    def name(self, exordos_dir: pathlib.Path) -> str | None:
+        with open(exordos_dir / self.manifest, "r") as f:
+            manifest = yaml.safe_load(f)
+        return manifest.get("name")
+
     @classmethod
     def from_config(
-        cls, element_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, element_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "Element":
         """Create an element from configuration."""
         image_configs = element_config.pop("images", [])
@@ -156,8 +168,18 @@ class Element(tp.NamedTuple):
         artifacts = [
             Artifact.from_config(artifact, work_dir) for artifact in artifacts_configs
         ]
+
+        # Convert manifest to Path if present
+        manifest = element_config.pop("manifest", None)
+        if manifest is not None:
+            manifest = pathlib.Path(manifest)
+
         return cls(
-            images=images, configs=configs, artifacts=artifacts, **element_config
+            images=images,
+            configs=configs,
+            artifacts=artifacts,
+            manifest=manifest,
+            **element_config,
         )
 
 
@@ -186,6 +208,23 @@ class ElementInventory(tp.NamedTuple):
         for category in self.categories():
             data[category] = [str(p) for p in getattr(self, category)]
         return data
+
+    def replace_with_abspath(self, inventory_dir: pathlib.Path) -> "ElementInventory":
+        """Create a copy of inventory but with abs path."""
+        kwargs = {
+            "name": self.name,
+            "version": self.version,
+        }
+        for category in self.categories():
+            abs_paths = []
+            for p in getattr(self, category):
+                if p.is_absolute():
+                    abs_paths.append(p)
+                else:
+                    # Resolve to absolute path relative to inventory_dir
+                    abs_paths.append((inventory_dir / category / p).resolve())
+            kwargs[category] = abs_paths
+        return ElementInventory(**kwargs)
 
     def save(self, path: pathlib.Path) -> None:
         """Save the element inventory to a path."""
@@ -239,7 +278,7 @@ class AbstractDependency(abc.ABC):
     This class defines the interface for a dependency item.
     """
 
-    dependencies_store: tp.List["AbstractDependency"] = []
+    dependencies_store: list["AbstractDependency"] = []
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__()
@@ -260,13 +299,13 @@ class AbstractDependency(abc.ABC):
 
     @abc.abstractclassmethod
     def from_config(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "AbstractDependency":
         """Create a dependency item from configuration."""
 
     @classmethod
     def find_dependency(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> tp.Optional["AbstractDependency"]:
         """Probe all dependencies to find the right one."""
         for dep in cls.dependencies_store:
@@ -289,7 +328,7 @@ class AbstractImageBuilder(abc.ABC):
         self,
         image_dir: str,
         image: Image,
-        deps: tp.List[AbstractDependency],
+        deps: list[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
         output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
@@ -316,7 +355,7 @@ class AbstractImageBuilder(abc.ABC):
         self,
         image_dir: str,
         image: Image,
-        deps: tp.List[AbstractDependency],
+        deps: list[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
         output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:
@@ -336,7 +375,7 @@ class DummyImageBuilder(AbstractImageBuilder):
         self,
         image_dir: str,
         image: Image,
-        deps: tp.List[AbstractDependency],
+        deps: list[AbstractDependency],
         developer_keys: tp.Optional[str] = None,
         output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
     ) -> None:

--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -18,42 +18,46 @@ from __future__ import annotations
 import gzip
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
 import typing as tp
 
 import jinja2
-import yaml
+import rich_click as click
 
 from exordos import constants as c
 from exordos.builder import base
 from exordos.logger import AbstractLogger
 from exordos.logger import DummyLogger
+from exordos.repo import fs as repo_fs
 
 
 class SimpleBuilder:
     """Simple element builder."""
 
-    DEP_KEY = "deps"
-    ELEMENT_KEY = "elements"
+    DEPS_KEY = "deps"
+    ELEMENTS_KEY = "elements"
 
     def __init__(
         self,
-        work_dir: str,
-        deps: tp.List[base.AbstractDependency],
-        elements: tp.List[base.Element],
+        exordos_dir: pathlib.Path,
+        deps: list[base.AbstractDependency],
+        elements: list[base.Element],
         image_builder: base.AbstractImageBuilder,
         logger: tp.Optional[AbstractLogger] = None,
-        elements_output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
+        elements_output_dir: pathlib.Path = pathlib.Path(c.DEF_GEN_OUTPUT_DIR_NAME),
+        version: str = "0.0.0",
     ) -> None:
         super().__init__()
         self._deps = deps
         self._elements = elements
         self._image_builder = image_builder
-        self._work_dir = work_dir
+        self._exordos_dir = exordos_dir
         self._logger = logger or DummyLogger()
         self._elements_output_dir = elements_output_dir
+        self._version = version
 
         if not os.path.exists(self._elements_output_dir):
             os.makedirs(self._elements_output_dir)
@@ -61,42 +65,27 @@ class SimpleBuilder:
     def _build_config_artifact(
         self,
         config_artifact: base.Config | base.Artifact,
-        output_dir: str,
-        inventory_mode: bool = False,
-    ) -> str:
+        output_dir: pathlib.Path,
+    ) -> pathlib.Path:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        dst_path = output_dir / pathlib.Path(config_artifact.path).name
+        shutil.copy(config_artifact.abs_path, dst_path)
 
-        # Determine config/artifact output directory
-        if inventory_mode:
-            _output_dir = os.path.join(self._elements_output_dir, output_dir)
-        else:
-            _output_dir = self._elements_output_dir
-
-        # Move config/artifact to the final location
-        if not os.path.exists(_output_dir):
-            os.makedirs(_output_dir)
-        dst_path = os.path.abspath(
-            os.path.join(_output_dir, os.path.basename(config_artifact.path))
-        )
-        src_path = config_artifact.abs_path
-        shutil.copy(src_path, _output_dir)
-
-        return dst_path
+        return pathlib.Path(dst_path.name)
 
     def _convert_image(
         self,
-        raw_src: str,
+        raw_src: pathlib.Path,
         img_name: str,
         fmt: str,
-        images_output_dir: str,
     ) -> str:
         """Convert a RAW image to the requested format and return the final path."""
         if fmt == "raw":
-            tgt = os.path.join(images_output_dir, f"{img_name}.raw")
-            shutil.move(raw_src, tgt)
-            return os.path.abspath(tgt)
+            # Do nothing
+            return f"{img_name}.raw"
         elif fmt == "qcow2":
             self._logger.info(f"Converting {img_name} to qcow2")
-            tgt = os.path.join(images_output_dir, f"{img_name}.qcow2")
+            tgt = raw_src.parent / f"{img_name}.qcow2"
             subprocess.run(
                 [
                     "qemu-img",
@@ -113,21 +102,21 @@ class SimpleBuilder:
                 ],
                 check=True,
             )
-            return os.path.abspath(tgt)
+            return tgt.name
         elif fmt == "gz":
             self._logger.info(f"Compressing {img_name} to {img_name}.raw.gz")
-            tgt = os.path.join(images_output_dir, f"{img_name}.raw.gz")
+            tgt = raw_src.parent / f"{img_name}.raw.gz"
             with (
                 open(raw_src, "rb") as f_in,
                 gzip.open(tgt, "wb", compresslevel=5) as f_out,
             ):
                 shutil.copyfileobj(f_in, f_out)
-            return os.path.abspath(tgt)
+            return tgt.name
         elif fmt == "zst":
             # Using subprocess with zstd utility instead of Python's compression.zstd
             # because: 1) it works on Python <3.14, 2) allows multi-threading via -T0
             self._logger.info(f"Compressing {img_name} to {img_name}.raw.zst")
-            tgt = os.path.join(images_output_dir, f"{img_name}.raw.zst")
+            tgt = raw_src.parent / f"{img_name}.raw.zst"
             subprocess.run(
                 [
                     "zstd",
@@ -142,67 +131,86 @@ class SimpleBuilder:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            return os.path.abspath(tgt)
+            return tgt.name
         else:
             raise ValueError(f"Unsupported image format: {fmt}")
 
     def _build_image(
         self,
         img: base.Image,
-        build_dir: str | None,
-        output_dir: str,
-        developer_keys: str,
-        inventory_mode: bool = False,
-    ) -> tp.List[str]:
-
-        # Determine images output directory
-        if inventory_mode:
-            images_output_dir = os.path.join(self._elements_output_dir, "images")
-        else:
-            images_output_dir = self._elements_output_dir
-
-        # The build_dir is used only for debugging purposes to observe
-        # the content of the image. In production, the image is built
-        # in a temporary directory.
-        if build_dir is not None:
+        output_dir: pathlib.Path,
+        developer_keys: str | None = None,
+    ) -> list[pathlib.Path]:
+        with tempfile.TemporaryDirectory() as temp_dir:
             self._image_builder.run(
-                build_dir,
+                temp_dir,
                 img,
                 self._deps,
                 developer_keys,
-                output_dir,
+                str(output_dir),
             )
-        else:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                self._image_builder.run(
-                    temp_dir,
-                    img,
-                    self._deps,
-                    developer_keys,
-                    output_dir,
-                )
-
-        # Move the image to the final location
-        if not os.path.exists(images_output_dir):
-            os.makedirs(images_output_dir)
 
         # A builder always produces a RAW image. Convert to each requested format.
-        raw_src = os.path.join(output_dir, f"{img.name}.raw")
-
-        # Move "raw" in the end as it will be moved
-        if "raw" in img.formats:
-            img_formats = [f for f in img.formats if f != "raw"] + ["raw"]
-        else:
-            img_formats = img.formats
+        raw_src = output_dir / f"{img.name}.raw"
 
         result_paths = []
-        for fmt in img_formats:
-            path = self._convert_image(raw_src, img.name, fmt, images_output_dir)
-            result_paths.append(path)
+        for fmt in img.formats:
+            path = self._convert_image(raw_src, img.name, fmt)
+            result_paths.append(pathlib.Path(path))
 
-        # TODO(akremenetsky): Should we clear raw format?
+        if "raw" not in img.formats:
+            os.unlink(raw_src)
 
         return result_paths
+
+    def _build_images(
+        self,
+        element: base.Element,
+        output_dir: pathlib.Path,
+        developer_keys: str | None = None,
+    ) -> list[pathlib.Path]:
+        """Build images for the element."""
+        image_paths = []
+        for img in element.images:
+            _paths = self._build_image(img, output_dir, developer_keys)
+            image_paths.extend(_paths)
+
+        return image_paths
+
+    def _build_manifest(
+        self,
+        element: base.Element,
+        manifests_dir: pathlib.Path,
+        manifest_vars: dict[str, tp.Any] | None = None,
+    ) -> list[pathlib.Path]:
+        """Build manifests for the element."""
+        orig_manifest_path = self._exordos_dir / element.manifest
+
+        # Render templated manifests
+        jinja2_extensions = (".jinja2", ".j2")
+        if str(element.manifest).endswith(jinja2_extensions):
+            # Render Jinja2 manifest
+            with open(orig_manifest_path) as f:
+                template = jinja2.Template(f.read())
+            rendered_manifest = template.render(
+                manifests=[element.manifest.name],
+                **manifest_vars,
+            )
+
+            # Remove extension from the manifest name
+            manifest_name = ".".join(element.manifest.name.split(".")[:-1])
+            manifest_path = manifests_dir / manifest_name
+
+            # Save rendered manifest
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(manifest_path, "w") as f:
+                f.write(rendered_manifest)
+        else:
+            manifest_path = manifests_dir / element.manifest.name
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(orig_manifest_path, manifest_path)
+
+        return [pathlib.Path(manifest_path.name)]
 
     def fetch_dependency(self, deps_dir: str) -> None:
         """Fetch common dependencies for elements."""
@@ -214,187 +222,145 @@ class SimpleBuilder:
     def build_element(
         self,
         element: base.Element,
-        build_dir: str | None = None,
+        repo_dir: pathlib.Path,
         developer_keys: str | None = None,
-        build_suffix: str = "",
-        inventory_mode: bool = False,
         manifest_vars: dict[str, tp.Any] | None = None,
     ) -> base.ElementInventory | None:
         """Build an element."""
         self._logger.info(f"Building element: {element}")
-        image_paths, configs, artifacts = [], [], []
+        configs, artifacts = [], []
 
-        if element.artifacts:
-            for artifact in element.artifacts:
-                _path = self._build_config_artifact(
-                    artifact,
-                    "artifacts",
-                    inventory_mode,
-                )
-                artifacts.append(_path)
-        if element.configs:
-            for config in element.configs:
-                _path = self._build_config_artifact(
-                    config,
-                    "configs",
-                    inventory_mode,
-                )
-                configs.append(_path)
-        # Build images
-        for img in element.images:
-            if build_suffix and not inventory_mode:
-                img.name = f"{img.name}.{build_suffix}"
-            tmp_img_output = f"_tmp_{img.name}-output"
+        # If manifest is not provided, build only images and return.
+        # We used the `--only-images` flag earlier to skip manifest processing.
+        if not element.manifest:
+            self._build_images(element, repo_dir, developer_keys)
+            return
 
-            try:
-                _paths = self._build_image(
-                    img,
-                    build_dir,
-                    tmp_img_output,
-                    developer_keys,
-                    inventory_mode,
-                )
-                image_paths.extend(_paths)
-            finally:
-                if os.path.exists(tmp_img_output):
-                    shutil.rmtree(tmp_img_output)
+        # Prepare manifest variables
+        manifest_vars = (manifest_vars or {}).copy()
+        manifest_vars["version"] = self._version
 
-        # Save files in the inventory format
-        if inventory_mode:
-            if not element.manifest:
-                raise ValueError("Element must have a manifest")
+        # Determine element name
+        name: str = manifest_vars.get("name") or element.name(self._exordos_dir)
+        if not name:
+            raise click.UsageError("Element name is not provided")
 
-            with open(os.path.join(self._work_dir, element.manifest), "r") as f:
-                manifest = yaml.safe_load(f)
-
-            version = build_suffix
-
-            if manifest_vars:
-                manifest_vars = manifest_vars.copy()
-            else:
-                manifest_vars = {}
-            manifest_vars["version"] = version
-
-            name = (manifest_vars.get("name") or manifest["name"]).strip()
-
-            if name.startswith("{"):
-                raise ValueError(
-                    "Specify manifest name using --manifest-var name=value"
-                )
-            manifest_vars["name"] = name
-
-            # TODO(akremenetsky): This part should be refactored when we
-            # support building of multiple elements.
-            inventory_path = self._elements_output_dir
-
-            manifests_path = os.path.join(inventory_path, "manifests")
-            orig_manifest_path = os.path.join(self._work_dir, element.manifest)
-
-            # Render templated manifests
-            jinja2_extensions = (".jinja2", ".j2")
-            if element.manifest.endswith(jinja2_extensions):
-                # Render Jinja2 manifest
-                with open(orig_manifest_path) as f:
-                    template = jinja2.Template(f.read())
-                rendered_manifest = template.render(
-                    images=[os.path.basename(p) for p in image_paths],
-                    manifests=[os.path.basename(element.manifest)],
-                    **manifest_vars,
-                )
-
-                # Remove extension from the manifest name
-                manifest_name = ".".join(
-                    os.path.basename(element.manifest).split(".")[:-1]
-                )
-                manifest_path = os.path.join(manifests_path, manifest_name)
-
-                # Save rendered manifest
-                os.makedirs(manifests_path, exist_ok=True)
-                with open(manifest_path, "w") as f:
-                    f.write(rendered_manifest)
-            else:
-                manifest_name = os.path.basename(element.manifest)
-                manifest_path = os.path.join(manifests_path, manifest_name)
-                os.makedirs(manifests_path, exist_ok=True)
-                shutil.copyfile(orig_manifest_path, manifest_path)
-
-            manifests = [os.path.abspath(manifest_path)]
-
-            inventory = base.ElementInventory(
-                name=name,
-                version=version,
-                images=image_paths,
-                manifests=manifests,
-                configs=configs,
-                artifacts=artifacts,
+        if name.startswith("{"):
+            raise click.UsageError(
+                "Specify manifest name using --manifest-var name=value"
             )
-            return inventory
+        name = name.strip()
+        manifest_vars["name"] = name
+        manifest_vars["version"] = self._version
+
+        element_dir = repo_dir / name / self._version
+        element_dir.mkdir(parents=True, exist_ok=True)
+
+        # Render manifest
+        manifests_dir = element_dir / "manifests"
+        manifests = self._build_manifest(element, manifests_dir, manifest_vars)
+
+        # Build artifacts and configs
+        for artifact in element.artifacts:
+            artifact_dir = element_dir / "artifacts"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            _path = self._build_config_artifact(artifact, artifact_dir)
+            artifacts.append(_path)
+        for config in element.configs:
+            config_dir = element_dir / "configs"
+            config_dir.mkdir(parents=True, exist_ok=True)
+            _path = self._build_config_artifact(config, config_dir)
+            configs.append(_path)
+
+        # Build images
+        images_dir = element_dir / "images"
+        images = self._build_images(element, images_dir, developer_keys)
+
+        inventory = base.ElementInventory(
+            name=name,
+            version=self._version,
+            images=images,
+            manifests=manifests,
+            configs=configs,
+            artifacts=artifacts,
+        )
+        inventory.save(element_dir)
+        return inventory
 
     def build(
         self,
-        build_dir: str | None = None,
         developer_keys: str | None = None,
-        build_suffix: str = "",
-        inventory_mode: bool = False,
         manifest_vars: dict[str, tp.Any] | None = None,
     ) -> None:
         """Build all elements."""
         self._logger.important("Building elements")
+        repo_dir = self._elements_output_dir
+
+        # Initialize repository if any element has a manifest
+        if any(e.manifest for e in self._elements):
+            repo = repo_fs.FSRepoDriver(self._elements_output_dir)
+            repo.init_repo()
+            repo_dir = pathlib.Path(repo.elements_path)
 
         inventories = []
         for e in self._elements:
             inventory = self.build_element(
                 e,
-                build_dir,
+                repo_dir,
                 developer_keys,
-                build_suffix,
-                inventory_mode,
                 manifest_vars,
             )
             if inventory:
                 inventories.append(inventory)
 
         # Save inventories
+        # TODO(akremenetsky): It's internal logic of repository and it should be
+        # moved into repository models one day.
         if inventories:
-            data = [inventory.to_dict() for inventory in inventories]
-            with open(
-                os.path.join(self._elements_output_dir, "inventory.json"), "w"
-            ) as f:
+            data = {"elements": {}}
+            for inventory in inventories:
+                data["elements"][inventory.name] = {
+                    inventory.version: inventory.to_dict()
+                }
+
+            with open(repo_dir / "inventory.json", "w") as f:
                 json.dump(data, f, indent=2, sort_keys=True)
 
     @classmethod
     def from_config(
         cls,
-        work_dir: str,
-        build_config: tp.Dict[str, tp.Any],
+        exordos_dir: pathlib.Path,
+        build_config: dict[str, tp.Any],
         image_builder: base.AbstractImageBuilder,
-        logger: tp.Optional[AbstractLogger] = None,
-        elements_output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
+        elements_output_dir: pathlib.Path,
+        version: str = "0.0.0",
+        logger: AbstractLogger | None = None,
     ) -> "SimpleBuilder":
         """Create a builder from configuration."""
         # Prepare dependencies entries but do not fetch them
         deps = []
-        dep_configs = build_config.get(cls.DEP_KEY, [])
+        dep_configs = build_config.get(cls.DEPS_KEY, [])
         for dep in dep_configs:
-            dep_item = base.AbstractDependency.find_dependency(dep, work_dir)
+            dep_item = base.AbstractDependency.find_dependency(dep, exordos_dir)
             if dep_item is None:
                 raise ValueError(f"Unable to handle dependency: {dep}. Unknown type.")
             deps.append(dep_item)
 
         # Prepare elements
-        element_configs = build_config.get(cls.ELEMENT_KEY, [])
+        element_configs = build_config.get(cls.ELEMENTS_KEY, [])
         elements = [
-            base.Element.from_config(elem, work_dir) for elem in element_configs
+            base.Element.from_config(elem, exordos_dir) for elem in element_configs
         ]
 
         if not elements:
             raise ValueError("No elements found in configuration")
 
         return cls(
-            work_dir,
+            exordos_dir,
             deps,
             elements,
             image_builder,
             logger,
             elements_output_dir,
+            version,
         )

--- a/exordos/builder/dependency.py
+++ b/exordos/builder/dependency.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import fnmatch
 import os
+import pathlib
 import shutil
 import typing as tp
 
@@ -78,7 +79,7 @@ class LocalPathDependency(base.AbstractDependency):
 
     @classmethod
     def from_config(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "LocalPathDependency":
         """Create a dependency item from configuration."""
         if "path" not in dep_config or "src" not in dep_config["path"]:
@@ -150,7 +151,7 @@ class LocalEnvPathDependency(base.AbstractDependency):
 
     @classmethod
     def from_config(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "LocalEnvPathDependency":
         """Create a dependency item from configuration."""
         if "path" not in dep_config or "env" not in dep_config["path"]:
@@ -209,7 +210,7 @@ class HttpDependency(base.AbstractDependency):
 
     @classmethod
     def from_config(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "HttpDependency":
         """Create a dependency item from configuration."""
         if "http" not in dep_config or "src" not in dep_config["http"]:
@@ -262,7 +263,7 @@ class GitDependency(base.AbstractDependency):
 
     @classmethod
     def from_config(
-        cls, dep_config: tp.Dict[str, tp.Any], work_dir: str
+        cls, dep_config: tp.Dict[str, tp.Any], work_dir: pathlib.Path
     ) -> "GitDependency":
         """Create a dependency item from configuration."""
         if "git" not in dep_config or "src" not in dep_config["git"]:

--- a/exordos/builder/packer.py
+++ b/exordos/builder/packer.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import annotations
 
+import glob
 import importlib.resources as resources
 import os
 import shutil
@@ -150,6 +151,28 @@ class PackerBuilder(base.DummyImageBuilder):
             result.append(f'{name}="{os.environ.get(name, value)}"')
 
         return "\n".join(result)
+
+    def run(
+        self,
+        image_dir: str,
+        image: base.Image,
+        deps: list[base.AbstractDependency],
+        developer_keys: tp.Optional[str] = None,
+        output_dir: str = c.DEF_GEN_OUTPUT_DIR_NAME,
+    ) -> None:
+        """Run the image builder."""
+        # Packer does not allow to build several images into single directory
+        # so create unique directory for every build and then move the image to
+        # the target `output_dir`
+        tmp_output_dir = os.path.join(output_dir, image.name)
+
+        try:
+            super().run(image_dir, image, deps, developer_keys, tmp_output_dir)
+
+            for img in glob.glob(os.path.join(tmp_output_dir, "*")):
+                shutil.move(img, output_dir)
+        finally:
+            shutil.rmtree(tmp_output_dir)
 
     def pre_build(
         self,

--- a/exordos/cmd/builds/commands.py
+++ b/exordos/cmd/builds/commands.py
@@ -16,9 +16,9 @@
 from __future__ import annotations
 
 import os
+import pathlib
 import shutil
 import tempfile
-import typing as tp
 
 import rich_click as click
 
@@ -39,7 +39,6 @@ from exordos.logger import ClickLogger
         "available by default: \n\n"
         "- {{ version }}: version of the element \n\n"
         "- {{ name }}: name of the element \n\n"
-        "- {{ images }}: list of images \n\n"
         "- {{ manifests }}: list of manifests \n\n"
         "\n\n"
         "Additional variables can be passed using the --manifest-var "
@@ -58,29 +57,21 @@ from exordos.logger import ClickLogger
     help="Directory where dependencies will be fetched",
 )
 @click.option(
-    "--build-dir",
-    default=None,
-    help="Directory where temporary build artifacts will be stored",
-)
-@click.option(
     "-o",
     "--output-dir",
-    default=c.DEF_GEN_OUTPUT_DIR_NAME,
+    default=pathlib.Path(c.DEF_GEN_OUTPUT_DIR_NAME),
+    type=click.Path(path_type=pathlib.Path),
     help="Directory where output artifacts will be stored",
 )
 @click.option(
     "-i",
-    "--developer-key-path",
-    default=None,
-    help="Path to developer public key",
-)
-@click.option(
-    "-s",
-    "--version-suffix",
-    default="none",
-    type=click.Choice([s for s in tp.get_args(c.VersionSuffixType)]),
-    show_default=True,
-    help="Version suffix will be used for the build",
+    "--ssh-public-key",
+    multiple=True,
+    type=click.Path(exists=True, path_type=pathlib.Path),
+    help=(
+        "Path to a public SSH key file to inject into the VM. Can be specified "
+        "multiple times. If not provided, no key will be injected."
+    ),
 )
 @click.option(
     "-f",
@@ -88,12 +79,6 @@ from exordos.logger import ClickLogger
     show_default=True,
     is_flag=True,
     help="Rebuild if the output already exists",
-)
-@click.option(
-    "--only-images",
-    show_default=True,
-    is_flag=True,
-    help="Build only images, skip manifests and other artifacts",
 )
 @click.option(
     "--manifest-var",
@@ -110,26 +95,13 @@ def build_cmd(
     ctx: click.Context,
     exordos_cfg_file: str,
     deps_dir: str | None,
-    build_dir: str | None,
-    output_dir: str | None,
-    developer_key_path: str | None,
-    version_suffix: c.VersionSuffixType,
+    output_dir: pathlib.Path,
+    ssh_public_key: tuple[pathlib.Path, ...],
     force: bool,
-    only_images: bool,
     manifest_var: tuple[str, ...],
     project_dir: str,
 ) -> None:
     manifest_vars = utils.convert_input_multiply(manifest_var)
-    inventory = not only_images
-
-    # Leave 'none' for backward compatibility
-    if version_suffix == "none" and inventory:
-        version_suffix = "element"
-        click.secho(
-            "Inventory mode is not supported for 'none' version suffix, "
-            "using 'element' instead",
-            fg="yellow",
-        )
 
     if os.path.exists(output_dir) and not force:
         click.secho(
@@ -141,10 +113,13 @@ def build_cmd(
     elif os.path.exists(output_dir) and force:
         shutil.rmtree(output_dir)
 
-    # Developer keys
-    developer_keys = utils.get_keys_by_path_or_env(
-        developer_key_path, ctx.obj.developer_key_path
-    )
+    # Load SSH keys
+    developer_keys = ""
+    for key_path in ssh_public_key:
+        with open(key_path) as f:
+            developer_keys += f.read().strip() + "\n"
+    if not developer_keys:
+        developer_keys = utils.get_keys_by_path_or_env(None, ctx.obj.developer_key_path)
 
     # Find path to exordos configuration
     try:
@@ -165,24 +140,18 @@ def build_cmd(
         click.secho("No builds found in the configuration", fg="yellow")
         return
 
+    version = utils.get_project_version(project_dir)
+
     logger = ClickLogger()
     packer_image_builder = PackerBuilder(logger)
 
     # Path where exordos.yaml configuration file is located
-    work_dir = os.path.dirname(gen_config_path)
-    # Prepare a build suffix
-    build_suffix = utils.get_version_suffix(version_suffix, project_dir=project_dir)
+    exordos_dir = pathlib.Path(gen_config_path).parent
 
-    for _, build in builds.items():
+    for _, build_cfg in builds.items():
         builder = simple_builder.SimpleBuilder.from_config(
-            work_dir, build, packer_image_builder, logger, output_dir
+            exordos_dir, build_cfg, packer_image_builder, output_dir, version, logger
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             builder.fetch_dependency(deps_dir or temp_dir)
-            builder.build(
-                build_dir,
-                developer_keys,
-                build_suffix,
-                inventory,
-                manifest_vars,
-            )
+            builder.build(developer_keys, manifest_vars)

--- a/exordos/cmd/repo/commands.py
+++ b/exordos/cmd/repo/commands.py
@@ -27,6 +27,7 @@ from exordos.builder import base as base_builder
 from exordos.common.table import get_table
 from exordos.common.table import print_table
 from exordos.repo import base as base_repo
+from exordos.repo import fs as repo_fs
 from exordos.repo import utils as repo_utils
 
 if tp.TYPE_CHECKING:
@@ -207,9 +208,9 @@ def repo_list_cmd(
 @click.option(
     "-e",
     "--element-dir",
-    default=c.DEF_GEN_OUTPUT_DIR_NAME,
+    default=lambda: pathlib.Path(c.DEF_GEN_OUTPUT_DIR_NAME),
     help="Directory where element artifacts are stored",
-    type=click.Path(),
+    type=click.Path(path_type=pathlib.Path),
 )
 @click.option(
     "-f",
@@ -233,40 +234,46 @@ def push_cmd(
     driver: str | None,
     driver_params: tuple[str, ...],
     target: str | None,
-    element_dir: str,
+    element_dir: pathlib.Path,
     force: bool,
     latest: bool,
-    project_dir: str,
+    project_dir: pathlib.Path,
 ) -> None:
     repo_driver = repo_utils.load_repo_driver(
         exordos_cfg_file, target, project_dir, obj.cfg_path, driver, driver_params
     )
 
-    # Push elements
-    path = pathlib.Path(element_dir) / base_builder.ElementInventory.file_name
-    with open(path, "r") as f:
-        inventories = json.load(f)
+    # Every build creates a local repo with built elements into it.
+    build_repo = repo_fs.FSRepoDriver(element_dir)
+    build_repo_dir = pathlib.Path(build_repo.elements_path)
 
-    # Backward compatibility: support both single
-    # inventory and list of inventories
-    if not isinstance(inventories, list):
-        inventories = [inventories]
+    with open(build_repo_dir / "inventory.json") as f:
+        repo_inventory = json.load(f)
+        repo_elements = repo_inventory["elements"]
 
-    for inventory in inventories:
-        element = base_builder.ElementInventory.from_dict(inventory)
+    for e_name in repo_elements:
+        # FIXME(akremenetsky): In the build repo only single version is available
+        e_version = tuple(repo_elements[e_name].keys())[0]
+        e_dir = build_repo_dir / e_name / e_version
+        e_inventory = base_builder.ElementInventory.from_dict(
+            repo_elements[e_name][e_version]
+        )
+        e_inventory = e_inventory.replace_with_abspath(e_dir)
+
         try:
             with rich_status.Status("Push the element to the repo...", spinner="dots"):
-                repo_driver.push(element, latest=latest)
+                repo_driver.push(e_inventory, latest=latest)
         except base_repo.ElementAlreadyExistsError:
             if force:
-                repo_driver.remove(element)
+                repo_driver.remove(e_inventory)
                 with rich_status.Status(
                     "Push the element to the repo...", spinner="dots"
                 ):
-                    repo_driver.push(element, latest=latest)
+                    repo_driver.push(e_inventory, latest=latest)
                     continue
 
             click.secho(
-                f"Element {element.name} version {element.version} already exists.",
+                f"Element {e_inventory.name} version "
+                f"{e_inventory.version} already exists.",
                 fg="red",
             )

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -21,6 +21,7 @@ import json
 import os
 import pathlib
 import secrets
+import shutil
 import subprocess
 import time
 import typing as tp
@@ -38,11 +39,12 @@ from exordos.backup import local as backup_local
 from exordos.builder import base as base_builder
 from exordos.cmd.stand.constants import BackupPeriod
 from exordos.cmd.stand.constants import Profile
-from exordos.common import version
+from exordos.common import version as version_lib
 import exordos.constants as c
 from exordos.infra.driver import libvirt as libvirt_infra
 from exordos.infra.libvirt import libvirt
 from exordos.logger import ClickLogger
+from exordos.repo import fs as repo_fs
 from exordos.stand import models as stand_models
 
 BOOTSTRAP_TAG = "bootstrap"
@@ -61,7 +63,7 @@ def _is_url(value: str) -> bool:
 def _inventory_cache_dir(base_url: str) -> pathlib.Path:
     """Return the local cache directory for a given inventory base URL.
 
-    The path is ``~/.cache/exordos/<name>/<version>/`` derived from the
+    The path is ``~/.cache/exordos/exordos-elements/<name>/<version>/`` derived from the
     last two segments of *base_url*'s path.  Falls back to a SHA-256 hash
     when the URL has fewer than two path segments.
     """
@@ -75,7 +77,11 @@ def _inventory_cache_dir(base_url: str) -> pathlib.Path:
         url_hash = hashlib.sha256(base_url.encode()).hexdigest()[:16]
         element_name = "unknown"
         element_version = url_hash
-    return _INVENTORY_CACHE_BASE / element_name / element_version
+    return (
+        element_name,
+        element_version,
+        _INVENTORY_CACHE_BASE / c.ELEMENT_REPO_PATH / element_name / element_version,
+    )
 
 
 def _download_inventory_json(session: requests.Session, base_url: str) -> dict:
@@ -192,7 +198,17 @@ def _download_inventory_files(
     inventory_local.write_text(json.dumps(raw, indent=2))
 
 
-def _resolve_inventory_from_url(url: str) -> pathlib.Path:
+def _init_cache_repo(repo_driver: repo_fs.FSRepoDriver) -> None:
+    # TODO(akremenetsky): It's internal logic of repository and it should be
+    # moved into repository models one day.
+    repo_inventory_path = _INVENTORY_CACHE_BASE / c.ELEMENT_REPO_PATH / "inventory.json"
+    if not repo_inventory_path.exists():
+        repo_driver.init_repo()
+        with open(repo_inventory_path, "w") as f:
+            json.dump({"elements": {}}, f)
+
+
+def _get_element_inventory_from_url(url: str) -> base_builder.ElementInventory:
     """Download inventory and all artefacts from an Nginx URL, with caching.
 
     Args:
@@ -201,84 +217,42 @@ def _resolve_inventory_from_url(url: str) -> pathlib.Path:
     Returns:
         Local cache directory path accepted by :py:meth:`ElementInventory.load`.
     """
+    repo_driver = repo_fs.FSRepoDriver(_INVENTORY_CACHE_BASE)
+    _init_cache_repo(repo_driver)
+
     base_url = url.rstrip("/")
     if base_url.endswith("/inventory.json"):
         base_url = base_url[: -len("/inventory.json")]
 
-    cache_dir = _inventory_cache_dir(base_url)
+    name, version, cache_dir = _inventory_cache_dir(base_url)
     inventory_local = cache_dir / "inventory.json"
 
     if inventory_local.exists():
         click.secho(f"Using cached inventory from {cache_dir}", fg="cyan")
-        return cache_dir
+        return repo_driver.inventory(name, version)
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     with requests.Session() as session:
-        raw = _download_inventory_json(session, base_url)
-        _download_inventory_files(
-            session, base_url, raw, cache_dir, images_suffix_filter=".qcow2"
-        )
+        try:
+            raw = _download_inventory_json(session, base_url)
+            _download_inventory_files(
+                session, base_url, raw, cache_dir, images_suffix_filter=".qcow2"
+            )
+        except:
+            shutil.rmtree(cache_dir)
+            raise
 
-    return cache_dir
+    # TODO(akremenetsky): It's internal logic of repository and it should be
+    # moved into repository models one day.
+    inventories = repo_driver.inventories()
+    with open(inventory_local) as f:
+        inventories.setdefault(name, {})[version] = json.load(f)
 
+    repo_inventory_path = _INVENTORY_CACHE_BASE / c.ELEMENT_REPO_PATH / "inventory.json"
+    with open(repo_inventory_path, "w") as f:
+        json.dump({"elements": inventories}, f, indent=2, sort_keys=True)
 
-def _ecosystem_realm_url_from_core_url(core_base_url: str) -> str | None:
-    """Derive the ecosystem_realm repository URL from a core element URL.
-
-    Replaces the element-name path segment (e.g. ``core``) with
-    ``ecosystem_realm`` while preserving the version segment and scheme.
-
-    Returns ``None`` when the URL structure is not recognisable.
-    """
-    parsed = urllib.parse.urlparse(core_base_url)
-    parts = [p for p in parsed.path.split("/") if p]
-    if len(parts) < 2:
-        return None
-    version_segment = parts[-1]
-    base_parts = parts[:-2]
-    new_path = "/".join(base_parts + ["ecosystem_realm", version_segment])
-    return urllib.parse.urlunparse(parsed._replace(path=f"/{new_path}"))
-
-
-def _fetch_ecosystem_realm_into_inventory(
-    core_url: str,
-    cache_dir: pathlib.Path,
-) -> None:
-    """Download ecosystem_realm artefacts and merge them into *cache_dir*/inventory.json.
-
-    The ecosystem_realm URL is derived from *core_url* by substituting the
-    element-name segment with ``ecosystem_realm``.  Files are placed into the
-    same *cache_dir* so that :py:meth:`ElementInventory.load` can find them
-    via the merged ``inventory.json``.
-
-    If the ecosystem_realm entry already exists in the cached inventory or the
-    remote URL cannot be determined, the function returns without doing anything.
-    """
-    if core_url.endswith("/inventory.json"):
-        core_url = core_url[: -len("/inventory.json")]
-
-    eco_url = _ecosystem_realm_url_from_core_url(core_url)
-    if eco_url is None:
-        click.secho(
-            "Warning: could not derive ecosystem_realm URL from core URL, skipping",
-            fg="yellow",
-        )
-        return
-
-    inventory_local = cache_dir / "inventory.json"
-    existing_raw = json.loads(inventory_local.read_text())
-    existing_list = existing_raw if isinstance(existing_raw, list) else [existing_raw]
-
-    if any((inv.get("name") == "ecosystem_realm") for inv in existing_list):
-        return
-
-    with requests.Session() as session:
-        eco_raw = _download_inventory_json(session, eco_url)
-        _download_inventory_files(session, eco_url, eco_raw, cache_dir)
-
-    eco_entry = eco_raw if not isinstance(eco_raw, list) else eco_raw[0]
-    existing_list.append(eco_entry)
-    inventory_local.write_text(json.dumps(existing_list, indent=2))
+    return repo_driver.inventory(name, version)
 
 
 def _get_core_image_uri_from_manifest(manifest_path: str) -> str:
@@ -407,7 +381,7 @@ def _bootstrap_core(
     stand_spec: tp.Dict[str, tp.Any] | None,
     stand_main_network: stand_models.Network,
     stand_boot_network: stand_models.Network,
-    disks: list[str] | None,
+    disks: list[int] | None,
     force: bool,
     core_ip: ipaddress.IPv4Address,
     repository: str,
@@ -568,7 +542,6 @@ def _bootstrap_core(
         "0.0.6  "
         "/path/to/core/0.0.6  "
         "https://repository.example.com/exordos-elements/core/0.0.6/  "
-        "https://repository.example.com/exordos-elements/core/0.0.6/inventory.json"
     ),
 )
 @click.option(
@@ -811,15 +784,25 @@ def bootstrap_cmd(
     if not inventory:
         raise click.UsageError("No inventory specified")
 
-    if version.is_version(inventory):
-        inventory = f"{c.ELEMENT_REPO_URL}/core/{inventory.strip()}/"
-
     if _is_url(inventory):
-        inventory_path = _resolve_inventory_from_url(inventory)
-        _fetch_ecosystem_realm_into_inventory(inventory.rstrip("/"), inventory_path)
-        inventory = str(inventory_path)
-    elif not os.path.exists(inventory):
-        raise click.UsageError(f"Inventory path not found: {inventory}")
+        inventory = inventory[:-1] if inventory.endswith("/") else inventory
+        # Detect version
+        inventory = inventory.split("/")[-1]
+
+    if version_lib.is_version(inventory):
+        inventory_instance = _get_element_inventory_from_url(
+            f"{c.ELEMENT_REPO_URL}/core/{inventory.strip()}/"
+        )
+        inventory_eco_instance = _get_element_inventory_from_url(
+            f"{c.ELEMENT_REPO_URL}/ecosystem_realm/{inventory.strip()}/"
+        )
+        eco_manifest_path = str(inventory_eco_instance.manifests[0])
+    else:
+        # Load inventories
+        repo_driver = repo_fs.FSRepoDriver(inventory)
+        inventory_instance = repo_driver.inventory("core")
+        inventory_eco_instance = repo_driver.inventory("ecosystem_realm")
+        eco_manifest_path = str(inventory_eco_instance.manifests[0])
 
     profile = Profile[profile.upper()]
 
@@ -835,9 +818,6 @@ def bootstrap_cmd(
         import secrets
 
         admin_password = secrets.token_urlsafe(16)
-
-    # Load inventory and get image path and image URI.
-    inventory_instance = base_builder.ElementInventory.load(pathlib.Path(inventory))
 
     if not inventory_instance.images:
         raise click.UsageError("No images found in the inventory")
@@ -933,11 +913,6 @@ def bootstrap_cmd(
             disable_telemetry=disable_telemetry,
             org_token=org_token,
         )
-
-    inventory_eco_instance = base_builder.ElementInventory.load(
-        pathlib.Path(inventory), 1
-    )
-    eco_manifest_path = str(inventory_eco_instance.manifests[0])
 
     ssh_public_key_content = None
     if ssh_public_key:

--- a/exordos/infra/libvirt/libvirt.py
+++ b/exordos/infra/libvirt/libvirt.py
@@ -700,7 +700,7 @@ def create_volume(
             )
         else:
             if target_image_path is None:
-                ValueError("Need to specify `target_image_path`!")
+                raise ValueError("Need to specify `target_image_path`!")
 
             subprocess.check_call(
                 ["sudo", "virsh", "vol-upload", "--pool", pool, name, source_path],

--- a/exordos/repo/base.py
+++ b/exordos/repo/base.py
@@ -82,3 +82,7 @@ class AbstractRepoDriver(abc.ABC):
     @abc.abstractmethod
     def list(self) -> dict[str, list[str]]:
         """List the elements in the repo."""
+
+    def inventories(self) -> dict:
+        """Return the repo inventory."""
+        return {}

--- a/exordos/repo/fs.py
+++ b/exordos/repo/fs.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 import shutil
 
 from packaging import version
@@ -176,3 +177,37 @@ class FSRepoDriver(base.AbstractRepoDriver):
             }
         except FileNotFoundError:
             raise base.RepoNotFoundError(f"Repo {self._repo_path} not found.")
+
+    def inventories(self) -> dict:
+        """Return the repo inventory."""
+        with open(pathlib.Path(self.elements_path) / "inventory.json") as f:
+            return json.load(f)["elements"]
+
+    def inventory(
+        self, element_name: str, element_version: str | None = None
+    ) -> builder_base.ElementInventory:
+        inventories = self.inventories()
+        versions: dict = inventories.get(element_name)
+
+        if not versions:
+            raise ValueError(f"No `{element_name}` element found")
+
+        # Get any version of element in the inventory
+        if element_version is None:
+            version, inventory_dict = next(iter(versions.items()))
+            inventory_dir = pathlib.Path(self.elements_path) / element_name / version
+            inventory = builder_base.ElementInventory.from_dict(inventory_dict)
+            return inventory.replace_with_abspath(inventory_dir)
+
+        # Get the particular version of the element
+        inventory_dict = versions.get(element_version)
+        if inventory_dict is None:
+            raise ValueError(
+                f"No `{element_name}` element with version `{element_version}` found"
+            )
+
+        inventory_dir = (
+            pathlib.Path(self.elements_path) / element_name / element_version
+        )
+        inventory = builder_base.ElementInventory.from_dict(inventory_dict)
+        return inventory.replace_with_abspath(inventory_dir)

--- a/exordos/stand/models.py
+++ b/exordos/stand/models.py
@@ -198,7 +198,7 @@ class Stand:
         boot_network: Network,
         cores: int = 1,
         memory: int = 1024,
-        disks: list[str] | None = None,
+        disks: list[int] | None = None,
         name: str = "dev-stand",
         bootstrap_name: str = "bootstrap",
         hypervisors: tp.Collection[Hypervisor] = (),

--- a/exordos/tests/unit/conftest.py
+++ b/exordos/tests/unit/conftest.py
@@ -28,13 +28,16 @@ from exordos.logger import DummyLogger
 
 
 @pytest.fixture
-def simple_builder() -> SimpleBuilder:
-    work_dir = "/tmp/work_dir"
+def simple_builder(tmp_path) -> SimpleBuilder:
+    work_dir = tmp_path / "work_dir"
+    work_dir.mkdir()
     deps = [MagicMock(spec=AbstractDependency) for _ in range(2)]
     elements = [MagicMock(spec=Element) for _ in range(2)]
     image_builder = MagicMock(spec=AbstractImageBuilder)
     logger = DummyLogger()
-    return SimpleBuilder(work_dir, deps, elements, image_builder, logger)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    return SimpleBuilder(work_dir, deps, elements, image_builder, logger, output_dir)
 
 
 @pytest.fixture

--- a/exordos/tests/unit/test_builder.py
+++ b/exordos/tests/unit/test_builder.py
@@ -32,19 +32,23 @@ class TestBuilder:
 
         assert len(simple_builder._deps) > 1
 
-    def test_from_config(self, build_config: tp.Dict[str, tp.Any]) -> None:
-        work_dir = "/tmp/work_dir"
+    def test_from_config(self, build_config: tp.Dict[str, tp.Any], tmp_path) -> None:
+        work_dir = tmp_path / "work_dir"
+        work_dir.mkdir()
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
 
         builder = SimpleBuilder.from_config(
             work_dir,
             build_config,
             MagicMock(),
-            DummyLogger(),
+            output_dir,
+            logger=DummyLogger(),
         )
 
         assert len(builder._deps) == 2
         assert len(builder._elements) == 1
-        assert builder._work_dir == work_dir
+        assert builder._exordos_dir == work_dir
 
     def test_manifest_rendering_jinja2_variables(self, tmp_path) -> None:
         """Ensure Jinja2 variables render correctly."""
@@ -71,28 +75,29 @@ class TestBuilder:
 
         # Prepare builder with no images to focus on manifest rendering
         builder = SimpleBuilder(
-            work_dir=str(work_dir),
+            exordos_dir=work_dir,
             deps=[],
             elements=[],
             image_builder=MagicMock(spec=base.AbstractImageBuilder),
             logger=DummyLogger(),
-            elements_output_dir=str(out_dir),
+            elements_output_dir=out_dir,
+            version="1.2.3",
         )
 
-        element = base.Element(manifest=manifest_rel, images=[])
+        element = base.Element(manifest=pathlib.Path(manifest_rel), images=[])
 
         # Act
         inventory = builder.build_element(
             element=element,
-            build_dir=None,
+            repo_dir=out_dir,
             developer_keys=None,
-            build_suffix="1.2.3",
-            inventory_mode=True,
             manifest_vars={"foo": "FOO", "bar": "BAR"},
         )
 
         # Assert: rendered manifest exists without the .j2 extension
-        manifests_dir = out_dir / "manifests"
+        # The manifest is now stored in a versioned subdirectory
+        element_dir = out_dir / "my-element" / "1.2.3"
+        manifests_dir = element_dir / "manifests"
         rendered_manifest = manifests_dir / "myapp.yaml"
         assert rendered_manifest.exists(), "Rendered manifest file not found"
 
@@ -123,26 +128,26 @@ class TestBuilder:
         manifest_path.write_text('name: svc\nversion: "{{ version }}"\n')
 
         builder = SimpleBuilder(
-            work_dir=str(work_dir),
+            exordos_dir=work_dir,
             deps=[],
             elements=[],
             image_builder=MagicMock(spec=base.AbstractImageBuilder),
             logger=DummyLogger(),
-            elements_output_dir=str(out_dir),
+            elements_output_dir=out_dir,
+            version="0.0.1",
         )
 
-        element = base.Element(manifest=manifest_rel, images=[])
+        element = base.Element(manifest=pathlib.Path(manifest_rel), images=[])
 
         builder.build_element(
             element=element,
-            build_dir=None,
+            repo_dir=out_dir,
             developer_keys=None,
-            build_suffix="0.0.1",
-            inventory_mode=True,
         )
 
         # The output manifest should be saved without the .jinja2 extension
-        assert (out_dir / "manifests" / "service.yaml").exists()
+        # The manifest is now stored in a versioned subdirectory
+        assert (out_dir / "svc" / "0.0.1" / "manifests" / "service.yaml").exists()
 
     def test_build_multiple_manifests_writes_inventory_json(self, tmp_path) -> None:
         work_dir = tmp_path / "work"
@@ -156,47 +161,55 @@ class TestBuilder:
         (work_dir / manifest_2).write_text("name: app2\nversion: 0\n")
 
         builder = SimpleBuilder(
-            work_dir=str(work_dir),
+            exordos_dir=work_dir,
             deps=[],
             elements=[
-                base.Element(manifest=manifest_1, images=[]),
-                base.Element(manifest=manifest_2, images=[]),
+                base.Element(manifest=pathlib.Path(manifest_1), images=[]),
+                base.Element(manifest=pathlib.Path(manifest_2), images=[]),
             ],
             image_builder=MagicMock(spec=base.AbstractImageBuilder),
             logger=DummyLogger(),
-            elements_output_dir=str(out_dir),
+            elements_output_dir=out_dir,
+            version="9.9.9",
         )
 
         builder.build(
-            build_dir=None,
             developer_keys=None,
-            build_suffix="9.9.9",
-            inventory_mode=True,
             manifest_vars=None,
         )
 
-        inventory_json = out_dir / "inventory.json"
+        # Inventory.json is written to the exordos-elements subdirectory
+        inventory_json = out_dir / "exordos-elements" / "inventory.json"
         assert inventory_json.exists()
 
         data = json.loads(inventory_json.read_text())
-        assert isinstance(data, list)
-        assert len(data) == 2
+        # Inventory format is now {"elements": {...}}
+        assert "elements" in data
+        elements = data["elements"]
+        assert isinstance(elements, dict)
+        assert len(elements) == 2
 
-        names = {item["name"] for item in data}
+        names = set(elements.keys())
         assert names == {"app1", "app2"}
 
-        versions = {item["version"] for item in data}
+        # Each element has a version key with the inventory data
+        versions = {elements[name]["9.9.9"]["version"] for name in names}
         assert versions == {"9.9.9"}
 
-        manifest_names = {
-            pathlib.Path(item["manifests"][0]).name
-            for item in data
-            if item["manifests"]
-        }
-        assert manifest_names == {"app1.yaml", "app2.yaml"}
+        # Check manifests are stored correctly
+        for name in names:
+            elem_data = elements[name]["9.9.9"]
+            assert elem_data["manifests"]
+            manifest_name = pathlib.Path(elem_data["manifests"][0]).name
+            assert manifest_name == f"{name}.yaml"
 
-        assert (out_dir / "manifests" / "app1.yaml").exists()
-        assert (out_dir / "manifests" / "app2.yaml").exists()
+        # Manifests are now in versioned subdirectories under exordos-elements
+        assert (
+            out_dir / "exordos-elements" / "app1" / "9.9.9" / "manifests" / "app1.yaml"
+        ).exists()
+        assert (
+            out_dir / "exordos-elements" / "app2" / "9.9.9" / "manifests" / "app2.yaml"
+        ).exists()
 
     def test_image_from_config_single_format(self) -> None:
         """Image.from_config parses a single format string into a one-element list."""
@@ -232,16 +245,16 @@ class TestBuilder:
         raw_src.write_bytes(b"rawdata")
 
         builder = SimpleBuilder(
-            work_dir=str(tmp_path),
+            exordos_dir=tmp_path,
             deps=[],
             elements=[],
             image_builder=MagicMock(spec=base.AbstractImageBuilder),
             logger=DummyLogger(),
-            elements_output_dir=str(tmp_path / "out"),
+            elements_output_dir=tmp_path / "out",
         )
-        result = builder._convert_image(str(raw_src), "my-img", "raw", str(images_dir))
+        result = builder._convert_image(raw_src, "my-img", "raw")
         assert pathlib.Path(result).name == "my-img.raw"
-        assert pathlib.Path(result).exists()
+        assert (raw_src.parent / result).exists()
 
     def test_build_element_multi_format_inventory(self, tmp_path) -> None:
         """build_element lists all requested format variants in inventory images."""
@@ -273,27 +286,29 @@ class TestBuilder:
         mock_builder.run.side_effect = fake_run
 
         builder = SimpleBuilder(
-            work_dir=str(work_dir),
+            exordos_dir=work_dir,
             deps=[],
-            elements=[base.Element(manifest=manifest_rel, images=[img])],
+            elements=[base.Element(manifest=pathlib.Path(manifest_rel), images=[img])],
             image_builder=mock_builder,
             logger=DummyLogger(),
-            elements_output_dir=str(out_dir),
+            elements_output_dir=out_dir,
         )
 
         builder.build(
-            build_dir=None,
             developer_keys=None,
-            build_suffix="1.0.0",
-            inventory_mode=True,
             manifest_vars=None,
         )
 
-        inventory_json = out_dir / "inventory.json"
+        # Inventory.json is written to the exordos-elements subdirectory
+        inventory_json = out_dir / "exordos-elements" / "inventory.json"
         assert inventory_json.exists()
         data = json.loads(inventory_json.read_text())
-        assert isinstance(data, list)
-        images = data[0]["images"]
+        # Inventory format is now {"elements": {...}}
+        assert "elements" in data
+        elements = data["elements"]
+        assert isinstance(elements, dict)
+        # Images are stored under the element name and version
+        images = elements["myapp"]["0.0.0"]["images"]
         image_names = [pathlib.Path(p).name for p in images]
         assert any(n.endswith(".raw") for n in image_names)
         assert any(n.endswith(".raw.gz") for n in image_names)


### PR DESCRIPTION
- The `build` command produces directories structure like for the repository.
- The `push` command was adapted to work with new build output.
- The `bootstrap` command was adapted to work with new build output.