### PR TITLE
feat(builder): add profile_version for packer images

### DIFF
--- a/exordos/builder/base.py
+++ b/exordos/builder/base.py
@@ -36,6 +36,7 @@ class Image:
 
     script: str
     profile: c.ImageProfileType = "ubuntu_24"
+    profile_version: str = "latest"
     formats: list[str] = dataclasses.field(default_factory=lambda: ["raw"])
     name: str | None = None
     envs: list[str] | None = None

--- a/exordos/builder/packer.py
+++ b/exordos/builder/packer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import glob
 import importlib.resources as resources
 import os
+import re
 import shutil
 import subprocess
 import typing as tp
@@ -118,6 +119,28 @@ def _get_profile_files(base: str) -> list[tp.Any]:
                     profile_files.append(item)
 
     return profile_files
+
+
+def _profile_has_variable(base: str, var_name: str) -> bool:
+    """Check if profile has a specific variable defined in its HCL files."""
+    profile_files = _get_profile_files(base)
+    var_pattern = re.compile(
+        rf'^\s*variable\s+["\']?{re.escape(var_name)}["\']?\s*{{',
+        re.MULTILINE,
+    )
+
+    for bfile in profile_files:
+        # Check only .pkr.hcl files (skip plugins.pkr.hcl)
+        if not str(bfile).endswith(".pkr.hcl") or "plugins" in str(bfile):
+            continue
+        try:
+            content = bfile.read_text()
+            if var_pattern.search(content):
+                return True
+        except Exception:
+            continue
+
+    return False
 
 
 class PackerBuilder(base.DummyImageBuilder):
@@ -251,6 +274,10 @@ class PackerBuilder(base.DummyImageBuilder):
             )
 
         override["img_format"] = "raw"
+
+        # Only pass profile_version if the profile HCL defines this variable
+        if _profile_has_variable(image.profile, "profile_version"):
+            override["profile_version"] = image.profile_version
 
         # Write the packer variables
         variables = PackerVariable.variable_file_content(override)

--- a/exordos/packer/exordos_base/exordos-base.pkr.hcl
+++ b/exordos/packer/exordos_base/exordos-base.pkr.hcl
@@ -34,13 +34,18 @@ variable img_format {
   default = "raw"
 }
 
+variable profile_version {
+  type    = string
+  default = "latest"
+}
+
 data "sshkey" "install" {
   name = "packer"
 }
 
 source "qemu" "exordos-base" {
-  iso_url                   = "https://repo.exordos.com/exordos-base/latest/exordos-base.qcow2"
-  iso_checksum              = "file:https://repo.exordos.com/exordos-base/latest/SHA256SUMS"
+  iso_url                   = "https://repo.exordos.com/exordos-base/${var.profile_version}/exordos-base.qcow2"
+  iso_checksum              = "file:https://repo.exordos.com/exordos-base/${var.profile_version}/SHA256SUMS"
   accelerator               = "kvm"
   cpu_model                 = "host"
   boot_wait                 = "5s"


### PR DESCRIPTION
Add optional profile_version parameter (default: "latest") to Image config. Pass it to packer and use in exordos_base iso URLs.

Closes #192

```yaml
  elements:
    ...
      images:
      - name: exordos-core
        format: qcow2
        # OS profile for the image
        profile: exordos_base
        profile_version: 1.0.0 # "latest" by default
  ```