### PR TITLE
feat(repo): add repository proxy CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,14 @@ Closes #123
 - **Title**: Use imperative, present tense: "Add feature", not "Added feature"
 - **Description**: Clear summary of changes
 
+## Verification
+
+When verifying changes, follow these rules:
+
+- **Linting**: Run `tox -e ruff`. Do not invoke `ruff` directly — always go through tox.
+- **Type checking**: Do NOT run `tox -e mypy` (or mypy in any form). Skip type checking entirely.
+- **Tests**: Prefer `tox -e py312` or `pytest exordos/tests/unit/` for the relevant test scope.
+
 ## Additional Guidelines
 
 ### License

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,14 @@ realms:
     check_updates: true
     endpoint: http://10.40.0.2:11010
     skip_tls_verify: true
+repositories:
+  my-repo:
+    driver: nginx
+    url: http://repo.example.com:8080/
+    auth: [user, pass]
+  local-repo:
+    driver: nginx
+    url: http://10.20.0.2:8080/repo/
 developer_key_path: ~/.ssh/id_rsa.pub
 ```
 
@@ -51,9 +59,39 @@ The path to your ssh key.
 You can change the path to the ssh key by config or by setting the command line argument `--developer_key_path` or `-i`
 or by environment variable `GEN_DEV_KEYS`.
 
-## Init
+## Repositories
 
-You can interactively init the config file by running the following command:
+Repositories are used to store and distribute build artifacts. You can manage them in the config file under the `repositories` key, or by using the `exordos settings repo` commands.
+
+### List repositories
+
+```bash
+exordos settings repo list
+```
+
+Show repositories in JSON format with sensitive data:
+
+```bash
+exordos settings repo list -o json --show-sensitive
+```
+
+### Add a repository
+
+```bash
+exordos settings repo add my-repo --driver nginx --url http://repo.example.com:8080/ --username user --password pass
+```
+
+The credentials are stored as `auth: [user, pass]` in the configuration file.
+
+### Delete a repository
+
+```bash
+exordos settings repo delete my-repo
+```
+
+## Initialization
+
+You can interactively initialize the config file by running the following command:
 
 ```bash
 exordos settings init

--- a/docs/config.ru.md
+++ b/docs/config.ru.md
@@ -27,6 +27,14 @@ realms:
     check_updates: true
     endpoint: http://10.40.0.2:11010
     skip_tls_verify: true
+repositories:
+  my-repo:
+    driver: nginx
+    url: http://repo.example.com:8080/
+    auth: [user, pass]
+  local-repo:
+    driver: nginx
+    url: http://10.20.0.2:8080/repo/
 developer_key_path: ~/.ssh/id_rsa.pub
 ```
 
@@ -50,6 +58,36 @@ exordos --config ~/.exordos.yaml elements list
 
 Вы можете изменить путь к SSH-ключу через конфигурацию или установив аргумент командной строки `--developer_key_path` или `-i`
 или через переменную окружения `GEN_DEV_KEYS`.
+
+## Репозитории
+
+Репозитории используются для хранения и распространения артефактов сборки. Вы можете управлять ими в файле конфигурации через ключ `repositories` или с помощью команд `exordos settings repo`.
+
+### Список репозиториев
+
+```bash
+exordos settings repo list
+```
+
+Показать репозитории в формате JSON с чувствительными данными:
+
+```bash
+exordos settings repo list -o json --show-sensitive
+```
+
+### Добавить репозиторий
+
+```bash
+exordos settings repo add my-repo --driver nginx --url http://repo.example.com:8080/ --username user --password pass
+```
+
+Учётные данные сохраняются как `auth: [user, pass]` в файле конфигурации.
+
+### Удалить репозиторий
+
+```bash
+exordos settings repo delete my-repo
+```
 
 ## Инициализация
 

--- a/exordos/builder/base.py
+++ b/exordos/builder/base.py
@@ -21,6 +21,7 @@ import json
 import os
 import pathlib
 import typing as tp
+import uuid
 
 import yaml
 
@@ -46,6 +47,21 @@ class Image:
     def format(self) -> str:
         """Return the primary (first) image format."""
         return self.formats[0]
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Return all image names with their extensions."""
+        if self.name is None:
+            return tuple()
+
+        result = []
+        for fmt in self.formats:
+            if fmt in ("gz", "zst"):
+                # Compression formats are applied to raw images
+                result.append(f"{self.name}.raw.{fmt}")
+            else:
+                result.append(f"{self.name}.{fmt}")
+        return tuple(result)
 
     @classmethod
     def _resolve_formats(cls, raw_format_str: str) -> list[str]:
@@ -132,7 +148,7 @@ class Artifact:
 
 @dataclasses.dataclass
 class Element:
-    """Element representation."""
+    """Element representation in the exordos.yaml configuration."""
 
     manifest: pathlib.Path | None = None
     images: list[Image] = dataclasses.field(default_factory=list)
@@ -184,27 +200,74 @@ class Element:
         )
 
 
-class ElementInventory(tp.NamedTuple):
+@dataclasses.dataclass
+class ElementInventory:
     """Element inventory."""
 
     file_name = pathlib.Path("inventory.json")
 
+    # Base namespace for the element index. Per-category namespaces are
+    # derived from this one so each category gets a stable, distinct UUID
+    # space.
+    _INDEX_NAMESPACE = uuid.uuid5(
+        uuid.UUID("3b621be9-1acf-42db-a686-6f3bede48527"), "exordos"
+    )
+
     name: str
     version: str
-    images: tp.Collection[pathlib.Path] = tuple()
-    manifests: tp.Collection[pathlib.Path] = tuple()
-    configs: tp.Collection[pathlib.Path] = tuple()
-    templates: tp.Collection[pathlib.Path] = tuple()
-    artifacts: tp.Collection[pathlib.Path] = tuple()
+    images: tp.Collection[pathlib.Path] = dataclasses.field(default_factory=tuple)
+    manifests: tp.Collection[pathlib.Path] = dataclasses.field(default_factory=tuple)
+    configs: tp.Collection[pathlib.Path] = dataclasses.field(default_factory=tuple)
+    templates: tp.Collection[pathlib.Path] = dataclasses.field(default_factory=tuple)
+    artifacts: tp.Collection[pathlib.Path] = dataclasses.field(default_factory=tuple)
+    # Derived automatically in __post_init__; never set externally.
+    index: dict[str, dict[str, str]] = dataclasses.field(
+        init=False, default_factory=dict
+    )
+
+    def __post_init__(self) -> None:
+        """Compute the element index automatically."""
+        self.index = self.compute_index()
 
     @classmethod
     def categories(cls) -> tuple[str, str, str, str, str]:
         return "images", "manifests", "configs", "templates", "artifacts"
 
+    @classmethod
+    def compute_index_entry(
+        cls, category: str, name: str, version: str, path: pathlib.Path
+    ) -> str:
+        """Compute a single index key for one item.
+
+        Returns the UUID (as a string) that maps to ``path.name`` under
+        the given ``category`` for element ``name``/``version``.
+        """
+        namespace = uuid.uuid5(cls._INDEX_NAMESPACE, category)
+        key = f"{name}-{version}-{path.name}"
+        return str(uuid.uuid5(namespace, key))
+
+    def compute_index(self) -> dict[str, dict[str, str]]:
+        """Build the index: ``{category: {uuid: file_name}}``.
+
+        Each category gets its own UUID namespace derived from the base
+        namespace. The key for an item is ``uuid5(category_namespace,
+        f"{name}-{version}-{basename}")``.
+        """
+        index: dict[str, dict[str, str]] = {}
+        for category in self.categories():
+            entries: dict[str, str] = {}
+            for path in getattr(self, category):
+                entries[
+                    self.compute_index_entry(category, self.name, self.version, path)
+                ] = path.name
+            index[category] = entries
+        return index
+
     def to_dict(self) -> dict[str, tp.Any]:
         data = {
             "name": self.name,
             "version": self.version,
+            "index": self.index,
         }
         for category in self.categories():
             data[category] = [str(p) for p in getattr(self, category)]

--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import gzip
+import itertools
 import json
 import os
 import pathlib
@@ -23,6 +24,7 @@ import shutil
 import subprocess
 import tempfile
 import typing as tp
+import uuid as sys_uuid
 
 import jinja2
 import rich_click as click
@@ -34,6 +36,10 @@ from exordos.logger import AbstractLogger
 from exordos.logger import DummyLogger
 from exordos.repo import fs as repo_fs
 from exordos.spec import schema
+
+
+def _urn_image(uuid: str | sys_uuid.UUID) -> str:
+    return f"urn:images:{uuid}"
 
 
 class SimpleBuilder:
@@ -181,6 +187,84 @@ class SimpleBuilder:
 
         return image_paths
 
+    def _build_images_dict(
+        self,
+        element_images: list[base.Image],
+        element_name: str,
+        element_version: str,
+    ) -> dict[str, str]:
+        """Build images dictionary with URI mappings for manifest templates.
+
+        Creates a mapping from image name variants to URIs that can be used in
+        Jinja2 manifest templates. The mapping includes:
+        - Base name without extension (for single images or ZST images)
+        - Full name with dots and hyphens replaced by underscores
+
+        Args:
+            element_images: List of Image objects from the element
+            element_name: Name of the element
+            element_version: Version of the element
+
+        Returns:
+            Dictionary mapping image name variants to URIs.
+
+        Example:
+            If element_images has formats ["qcow2", "raw"] with name "foo":
+            {
+                "foo": "urn:images:{uuid}",
+                "foo_qcow2": "urn:images:{uuid}",
+                "foo_raw": "urn:images:{uuid}"
+            }
+
+            If element_images has formats ["raw.zst", "qcow2"] with name "bar":
+            {
+                "bar": "urn:images:{uuid}",
+                "bar_raw_zst": "urn:images:{uuid}",
+                "bar_qcow2": "urn:images:{uuid}"
+            }
+        """
+        images: dict[str, str] = {}
+
+        image_names = list(
+            itertools.chain.from_iterable(img.names for img in element_images)
+        )
+
+        def add_image(name: str, include_no_ext: bool = False) -> None:
+            idx = base.ElementInventory.compute_index_entry(
+                "images",
+                element_name,
+                element_version,
+                pathlib.Path(name),
+            )
+            if include_no_ext:
+                # Remove all known image extensions from the end
+                base_name = name
+                for ext in [".raw.zst", ".raw.gz", ".raw", ".qcow2", ".gz", ".zst"]:
+                    if base_name.endswith(ext):
+                        base_name = base_name[: -len(ext)]
+                        break
+                image_no_ext = base_name.replace("-", "_").lower()
+                images[image_no_ext] = _urn_image(idx)
+            image_ext = name.replace("-", "_").replace(".", "_").lower()
+            images[image_ext] = _urn_image(idx)
+
+        if len(image_names) == 1:
+            add_image(image_names[0], include_no_ext=True)
+        # ZST image is more preferred. Allow to use it without extension
+        elif any(i.endswith(".zst") for i in image_names):
+            zst_added = False
+            for image_name in image_names:
+                if image_name.endswith(".zst"):
+                    add_image(image_name, include_no_ext=not zst_added)
+                    zst_added = True
+                else:
+                    add_image(image_name)
+        else:
+            for image_name in image_names:
+                add_image(image_name)
+
+        return images
+
     def _build_manifest(
         self,
         element: base.Element,
@@ -190,14 +274,23 @@ class SimpleBuilder:
         """Build manifests for the element."""
         orig_manifest_path = self._exordos_dir / element.manifest
 
+        # Compute images indexes
+        images = self._build_images_dict(
+            element.images,
+            manifest_vars["name"],
+            manifest_vars["version"],
+        )
+
         # Render templated manifests
         jinja2_extensions = (".jinja2", ".j2")
+
         if str(element.manifest).endswith(jinja2_extensions):
             # Render Jinja2 manifest
             with open(orig_manifest_path) as f:
                 template = jinja2.Template(f.read())
             rendered_manifest = template.render(
                 manifests=[element.manifest.name],
+                images=images,
                 **manifest_vars,
             )
 

--- a/exordos/cmd/base.py
+++ b/exordos/cmd/base.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import annotations
 
+from collections.abc import Callable
 import time
 
 import questionary
@@ -31,9 +32,25 @@ from exordos.common.table import show_data
 
 
 def add_dynamic_parents(parents: list[str] | None = None):
+    """Add required parent UUID options for nested collections.
+
+    For a nested collection such as
+    ``v1/repo/repositories/{repository_uuid}/elements/`` this decorator
+    injects one required ``--<parent>-uuid`` option per parent name. The
+    captured UUIDs are then used by the command to build the full collection
+    URL.
+
+    Example:
+        >>> @add_dynamic_parents(parents=["repository"])
+        ... @click.pass_context
+        ... def list_cmd(ctx: click.Context, repository_uuid: str, **kwargs):
+        ...     collection = f"v1/repo/repositories/{repository_uuid}/elements/"
+    """
+
     def decorator(f):
         if parents is None:
             return f
+
         for parent in parents:
             f = click.option(
                 f"--{parent}-uuid",
@@ -55,6 +72,8 @@ def create_entity_group(
     add_delete_command: bool = True,
     add_clear_command: bool = False,
     parents: list[str] | None = None,
+    post_fetch_handler: Callable[[list[dict], dict], list[dict]] | None = None,
+    extra_options: list[click.Option] | None = None,
 ) -> ClickAliasedGroup:
     """Create a universal click group for entity management."""
 
@@ -125,15 +144,29 @@ def create_entity_group(
             if watch:
                 with Live(refresh_per_second=4) as live:
                     while True:
-                        entities = base_client.list_entities(client, url, **filters)
+                        entities = base_client.list_entities(
+                            client,
+                            url,
+                            **filters,
+                        )
+                        if post_fetch_handler:
+                            entities = post_fetch_handler(entities, kwargs)
                         live.update(
                             fill_table(entities, fields_map, fields), refresh=True
                         )
                         time.sleep(interval)
             else:
-                entities = base_client.list_entities(client, url, **filters)
+                entities = base_client.list_entities(
+                    client,
+                    url,
+                    **filters,
+                )
+                if post_fetch_handler:
+                    entities = post_fetch_handler(entities, kwargs)
                 print_table(fill_table(entities, fields_map, fields), output)
 
+        if extra_options:
+            list_cmd.params.extend(extra_options)
         entity_group.add_command(list_cmd, aliases=["l"])
 
     # Show command
@@ -178,7 +211,11 @@ def create_entity_group(
             required=True,
         )
         @click.option(
-            "--yes", "-y", "y", help="Automatically answer yes for all questions", is_flag=True
+            "--yes",
+            "-y",
+            "y",
+            help="Automatically answer yes for all questions",
+            is_flag=True,
         )
         @add_dynamic_parents(parents)
         @click.pass_context

--- a/exordos/cmd/cli.py
+++ b/exordos/cmd/cli.py
@@ -31,6 +31,7 @@ from exordos.cmd.compute import compute_group
 from exordos.cmd.compute.hypervisors import commands as hypervisors_commands
 from exordos.cmd.compute.nodes import commands as nodes_commands
 from exordos.cmd.configs import commands as configs_commands
+from exordos.cmd.deploy import commands as deploy_commands
 from exordos.cmd.dns import dns_group
 from exordos.cmd.em import em_group
 from exordos.cmd.em.elements import commands as elements_commands
@@ -308,6 +309,7 @@ exordos.add_command(configs_commands.configs_group)
 exordos.add_command(settings_commands.settings_group)
 exordos.add_command(repo_commands.repository_group)
 exordos.add_command(repo_commands.push_cmd)
+exordos.add_command(deploy_commands.deploy_cmd)
 
 exordos.add_command(initialization_commands.init_cmd)
 

--- a/exordos/cmd/deploy/commands.py
+++ b/exordos/cmd/deploy/commands.py
@@ -1,0 +1,433 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import ipaddress
+import json
+import pathlib
+import socket
+import typing as tp
+import uuid as sys_uuid
+
+import questionary
+import rich_click as click
+
+from exordos import constants as c
+from exordos.clients import base_client
+from exordos.common import status as status_lib
+from exordos.repo import fs as repo_fs
+from exordos.repo import local_server
+from exordos.repo import utils as repo_utils
+
+if tp.TYPE_CHECKING:
+    from exordos.common.cmd_context import ContextObject
+
+DEFAULT_REPO_NAME = "exordos-dev-repo"
+DEFAULT_PRIORITY = 4096
+DEFAULT_TIMEOUT = 600.0
+
+
+def _load_build_inventory(element_dir: pathlib.Path) -> dict[str, dict]:
+    build_repo = repo_fs.FSRepoDriver(str(element_dir))
+    inventory_path = pathlib.Path(build_repo.elements_path) / "inventory.json"
+    if not inventory_path.exists():
+        raise click.ClickException(
+            f"No build output found at '{element_dir}'. Run `exordos build` first."
+        )
+    with open(inventory_path) as f:
+        return json.load(f)["elements"]
+
+
+def _find_local_ip_in_network(
+    network: ipaddress.IPv4Network,
+) -> ipaddress.IPv4Address | None:
+    """Find a local interface IP address that belongs to *network*.
+
+    Uses a connected UDP socket so the OS selects the source interface
+    for *network* without sending any packets.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.settimeout(0.1)
+            s.connect((str(network.network_address), 1))
+            local_ip = ipaddress.IPv4Address(s.getsockname()[0])
+            if local_ip in network:
+                return local_ip
+    except OSError:
+        pass
+    return None
+
+
+def _is_local_realm(config: dict[str, tp.Any]) -> bool:
+    """Check whether the current realm is local.
+
+    A realm is considered local when:
+      1. ``local: true`` is set in the realm configuration.
+      2. If ``meta.cidr`` is present, a local interface has an IP in that
+         network.
+    """
+    current_realm = config.get("current-realm")
+    if not current_realm:
+        return False
+
+    realm_config = config.get("realms", {}).get(current_realm)
+    if not realm_config:
+        return False
+
+    if not realm_config.get("local", False):
+        return False
+
+    meta = realm_config.get("meta", {})
+    cidr_str = meta.get("cidr")
+    if cidr_str:
+        try:
+            network = ipaddress.IPv4Network(cidr_str)
+        except ValueError:
+            return False
+        return _find_local_ip_in_network(network) is not None
+
+    return True
+
+
+def _get_local_host_bind(config: dict[str, tp.Any]) -> str:
+    """Return the bind address for the local HTTP server.
+
+    Uses the host IP from the current realm's ``meta.cidr`` network.
+    Raises an error if no local IP matching the realm CIDR is found.
+    """
+    current_realm = config.get("current-realm")
+    if current_realm:
+        realm_config = config.get("realms", {}).get(current_realm, {})
+        cidr_str = realm_config.get("meta", {}).get("cidr")
+        if cidr_str:
+            try:
+                network = ipaddress.IPv4Network(cidr_str)
+                local_ip = _find_local_ip_in_network(network)
+                if local_ip is not None:
+                    return str(local_ip)
+            except ValueError:
+                pass
+    raise click.ClickException(
+        "Unable to determine a local IP address reachable from the realm. "
+        "Ensure the current realm has a valid 'meta.cidr' set and this "
+        "machine has an interface in that network."
+    )
+
+
+def _cleanup_existing_repo_elements(
+    client: tp.Any,
+    repository: dict[str, tp.Any],
+    e_name: str,
+    e_version: str,
+    timeout: float,
+    force: bool,
+) -> None:
+    existing_repo_elements = base_client.list_entities(
+        client,
+        c.REPOSITORY_ELEMENT_COLLECTION,
+        name=e_name,
+        version=e_version,
+        repository=repository["uuid"],
+    )
+    if not existing_repo_elements:
+        return
+
+    if not force:
+        raise click.ClickException(
+            f"Element '{e_name}' ({e_version}) already exists in repository. "
+            "Use --force to reinstall."
+        )
+    for element in existing_repo_elements:
+        status = element.get("status")
+        if status not in ("AVAILABLE",):
+            base_client.action_entity(
+                client,
+                c.REPOSITORY_ELEMENT_COLLECTION,
+                "uninstall",
+                element["uuid"],
+            )
+            with status_lib.status_done(
+                f"Cleaning up {e_name} ({e_version}), waiting to become AVAILABLE..."
+            ):
+                repo_utils.wait_for_repo_element(
+                    client, repository["uuid"], e_name, e_version, "AVAILABLE", timeout
+                )
+        base_client.delete_entity(
+            client, c.REPOSITORY_ELEMENT_COLLECTION, element["uuid"]
+        )
+
+
+def _deploy_element(
+    client: tp.Any,
+    repository: dict[str, tp.Any],
+    e_name: str,
+    e_version: str,
+    timeout: float,
+    force: bool = False,
+) -> None:
+    """Deploy an element to a realm via the given repository.
+
+    Workflow:
+        1. Clean up existing repository elements with the same name and
+           version (uninstall + delete). Requires ``force`` when such
+           elements exist, otherwise raises ``click.ClickException``.
+        2. Refresh the repository and wait for the target element to
+           become AVAILABLE.
+        3. Decide how to apply the element:
+            - If an element with the same name is already INSTALLED
+              (any version), call ``upgrade`` on it pointing at the new
+              version.
+            - Otherwise call ``install`` on the new element directly.
+        4. Wait for the element to become ACTIVE and report success.
+
+    Args:
+        client: API client used to communicate with the realm.
+        repository: Repository entity dict the element is deployed from.
+        e_name: Element name to deploy.
+        e_version: Element version to deploy.
+        timeout: Maximum time in seconds to wait for repository sync and
+            element state transitions.
+        force: When True, removes existing repository elements with the
+            same name and version before deploying. When False and such
+            elements exist, raises ``click.ClickException``.
+
+    Raises:
+        click.ClickException: If existing elements are found without
+            ``force``, or if the element fails to reach the expected
+            state within ``timeout``.
+    """
+    _cleanup_existing_repo_elements(
+        client, repository, e_name, e_version, timeout, force
+    )
+
+    base_client.action_entity(
+        client, c.REPOSITORY_COLLECTION, "refresh", repository["uuid"]
+    )
+
+    with status_lib.status_done(f"Waiting for {e_name} ({e_version}) to sync..."):
+        repo_element = repo_utils.wait_for_repo_element(
+            client, repository["uuid"], e_name, e_version, "AVAILABLE", timeout
+        )
+
+    # Check if an element with the same name is already installed.
+    # Query the EM elements collection to see if the element exists there.
+    # If so, upgrade it to the new version; otherwise install fresh.
+    em_elements = base_client.list_entities(client, c.ELEMENT_COLLECTION, name=e_name)
+    installed = next(iter(em_elements), None)
+
+    if installed:
+        manifest_ref = installed.get("manifest", "")
+        if not manifest_ref:
+            raise click.ClickException(
+                f"Element {installed['name']} has no manifest reference"
+            )
+        manifest_uuid = manifest_ref.rstrip("/").split("/")[-1]
+        base_client.action_entity(
+            client,
+            c.REPOSITORY_ELEMENT_COLLECTION,
+            "upgrade",
+            manifest_uuid,
+            target=repo_element["uuid"],
+        )
+    else:
+        base_client.action_entity(
+            client,
+            c.REPOSITORY_ELEMENT_COLLECTION,
+            "install",
+            repo_element["uuid"],
+        )
+
+    with status_lib.status_done(f"Waiting for {e_name} to become ACTIVE..."):
+        repo_utils.wait_for_element_active(
+            client,
+            e_name,
+            e_version,
+            timeout,
+            stable_checks=repo_utils.STABLE_CHECKS,
+        )
+
+    click.echo(
+        f"Element {click.style(f'{e_name} ({e_version})', fg='green')} "
+        "was deployed successfully"
+    )
+
+
+@click.command(
+    "deploy",
+    help=(
+        "Deploy a built element to a realm. The element must already be "
+        "built (`exordos build`). With no --repository, the local build "
+        "output is served in-process and installed directly -- no push "
+        "needed. With --repository, the build is pushed first, exactly "
+        "like `exordos push`, then installed."
+    ),
+)
+@click.option(
+    "-e",
+    "--element-dir",
+    default=lambda: pathlib.Path(c.DEF_GEN_OUTPUT_DIR_NAME),
+    type=click.Path(path_type=pathlib.Path),
+    help="Directory where element artifacts are stored (output of `exordos build`)",
+)
+@click.option(
+    "-t",
+    "--repository",
+    "repository",
+    default=None,
+    help=(
+        "Repository name (key from the `repositories` section in "
+        "~/.exordos/exordosctl.yaml). Selects push mode: push the build "
+        "to this repository first, then install. If omitted, local mode "
+        "is used instead (no push)."
+    ),
+)
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    default=sys_uuid.UUID(int=0),
+    help="Project UUID, required only if the dev repository doesn't exist yet",
+)
+@click.option(
+    "--dev-repo-name",
+    default=DEFAULT_REPO_NAME,
+    show_default=True,
+    help="Name of the local dev repository used to publish deployed elements",
+)
+@click.option(
+    "--dev-repo-priority",
+    type=int,
+    default=DEFAULT_PRIORITY,
+    show_default=True,
+    help="Priority of the local dev repository (0-4096)",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Force push even if the element already exists (push mode only)",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=DEFAULT_TIMEOUT,
+    show_default=True,
+    help="Seconds to wait for repository sync and element install to complete",
+)
+@click.option(
+    "--element",
+    default=None,
+    help=(
+        "Name of the element to deploy from the build inventory. "
+        "If omitted and multiple elements are available, an interactive "
+        "prompt is shown. If only one element exists, it is selected "
+        "automatically."
+    ),
+)
+@click.option(
+    "-c",
+    "--exordosctl-cfg-file",
+    default=c.CONFIG_FILE,
+    help="Name of the exordosctl configuration file",
+)
+@click.pass_obj
+def deploy_cmd(
+    obj: "ContextObject",
+    element_dir: pathlib.Path,
+    repository: str | None,
+    project_id: sys_uuid.UUID,
+    dev_repo_name: str,
+    dev_repo_priority: int,
+    force: bool,
+    timeout: float,
+    element: str | None,
+    exordosctl_cfg_file: str,
+) -> None:
+    inventory_elements = _load_build_inventory(element_dir)
+    client = base_client.get_user_api_client(obj.auth_data)
+
+    available = sorted(inventory_elements.keys())
+    if element is not None:
+        if element not in inventory_elements:
+            raise click.ClickException(
+                f"Element '{element}' not found in build inventory. "
+                f"Available: {', '.join(available)}"
+            )
+        e_name = element
+    elif len(available) > 1:
+        e_name = questionary.select(
+            "Select element to deploy",
+            choices=available,
+        ).ask()
+        if not e_name:
+            click.echo("No element selected, aborting")
+            return
+    else:
+        e_name = available[0]
+
+    # FIXME: In the build repo only a single version is available.
+    e_version = tuple(inventory_elements[e_name].keys())[0]
+
+    # Local mode: serve the build directory over a temporary HTTP server
+    # and install the element directly from it. This only works with a
+    # local realm where there is direct network connectivity between the
+    # host and the realm's Core VM.
+    if not repository and _is_local_realm(obj.cfg):
+        bind_host = _get_local_host_bind(obj.cfg)
+
+        with local_server.serve_directory(element_dir, bind_host) as base_url:
+            url = f"{base_url}{c.ELEMENT_REPO_PATH}/"
+            driver_spec = {"kind": "nginx", "url": url}
+            repository_spec = repo_utils.ensure_repository(
+                client,
+                dev_repo_name,
+                driver_spec,
+                project_id,
+                dev_repo_priority,
+                sync_mode="copy",
+            )
+            _deploy_element(client, repository_spec, e_name, e_version, timeout, force)
+            return
+
+    if not repository:
+        raise click.ClickException(
+            "No repository specified and not a local realm. "
+            "Cannot deploy without a repository."
+        )
+
+    # Push mode: full deploy cycle for remote repositories.
+    # 1. Push the build artifacts to the remote repository.
+    # 2. Add or actualize the repository entry in the realm.
+    # 3. Install the element from the repository.
+    repo_driver = repo_utils.load_repo_driver_from_settings(
+        exordosctl_cfg_file,
+        repository,
+    )
+    repo_utils.do_push(repo_driver, element_dir, force=force, latest=False)
+
+    url = f"{repo_driver.elements_path.rstrip('/')}/"
+    if not url.startswith(("http://", "https://")):
+        raise click.ClickException(
+            f"Push target '{repository}' isn't network-reachable "
+            f"({url}). `exordos deploy` push mode requires a driver that "
+            "produces an HTTP(S) URL the target realm can fetch from."
+        )
+
+    driver_spec = {"kind": "nginx", "url": url}
+    repository_spec = repo_utils.ensure_repository(
+        client, repository, driver_spec, project_id, dev_repo_priority, sync_mode="lazy"
+    )
+    _deploy_element(client, repository_spec, e_name, e_version, timeout, force)

--- a/exordos/cmd/em/elements/commands.py
+++ b/exordos/cmd/em/elements/commands.py
@@ -16,13 +16,14 @@
 from __future__ import annotations
 
 import os
+import pathlib
 import subprocess
 import tempfile
 import time
 import typing as tp
 import uuid as sys_uuid
 
-from bazooka import exceptions as bazooka_exc
+from packaging import version as packaging_version
 import questionary
 from rich.prompt import Confirm
 from rich.text import Text
@@ -30,15 +31,15 @@ import rich_click as click
 
 from exordos import utils
 from exordos.clients import base_client
-from exordos.clients import repo as repo_lib
 from exordos.cmd.base import create_entity_group
 from exordos.common import compute
 from exordos.common import ssh
+from exordos.common import version as version_lib
 from exordos.common.table import get_table
 from exordos.common.table import print_table
 from exordos.common.table import show_data
 import exordos.constants as c
-from exordos.logger import ClickLogger
+from exordos.repo import utils as repo_utils
 
 if tp.TYPE_CHECKING:
     from exordos.clients.base import CollectionBaseClient
@@ -46,6 +47,9 @@ if tp.TYPE_CHECKING:
 
 ENTITY = "element"
 ENTITY_COLLECTION = c.ELEMENT_COLLECTION
+DEFAULT_UPLOAD_REPO_NAME = "exordos-upload-repo"
+DEFAULT_PRIORITY = 4096
+DEFAULT_TIMEOUT = 600.0
 FIELDS_MAP = {
     "UUID": "uuid",
     "Name": "name",
@@ -141,173 +145,143 @@ def show_element_ips(ctx: click.Context, name: str) -> None:
         click.echo(node["default_network"].get("ipv4", None))
 
 
-def _apply_with_cleanup(
-    client: "CollectionBaseClient",
-    manifest_data: dict[str, tp.Any],
-    install_only: bool = False,
-    update_manifest: bool = False,
-    **kwargs: tp.Any,
-) -> dict[str, tp.Any]:
-    """Apply a manifest and clean up old versions on success."""
+def _get_sort_key(
+    element: dict[str, tp.Any], repo_priorities: dict[str, int]
+) -> tuple[int, packaging_version.Version]:
+    """Get sort key for element: (repository_priority, version).
 
-    found_manifest_uuids = [
-        item["uuid"]
-        for item in base_client.list_entities(
-            client, c.MANIFEST_COLLECTION, name=manifest_data["name"]
-        )
-    ]
-    if update_manifest:
-        manifest_uuid = kwargs["manifest_uuid"]
-        manifest_data.pop("created_at", None)
-        manifest_data.pop("updated_at", None)
-        manifest_data.pop("status", None)
-        manifest_data.pop("uuid", None)
-        try:
-            manifest_data = base_client.update_entity(
-                client, c.MANIFEST_COLLECTION, manifest_uuid, manifest_data
-            )
-        except bazooka_exc.NotFoundError:
-            manifest_data = base_client.add_entity(
-                client, c.MANIFEST_COLLECTION, manifest_data
-            )
-        manifest_data["uuid"] = manifest_uuid
-    else:
-        manifest_data = base_client.add_entity(
-            client, c.MANIFEST_COLLECTION, manifest_data
-        )
-    manifest_uuid = manifest_data["uuid"]
+    Args:
+        element: Element dictionary containing version and repository reference.
+        repo_priorities: Dictionary mapping repository UUID to priority value.
 
-    try:
-        if install_only:
-            base_client.action_entity(
-                client, c.MANIFEST_COLLECTION, "install", manifest_uuid
-            )
-        else:
-            base_client.action_entity(
-                client, c.MANIFEST_COLLECTION, "upgrade", manifest_uuid
-            )
-    except Exception:
-        base_client.delete_entity(client, c.MANIFEST_COLLECTION, manifest_uuid)
-        raise
-
-    for found_manifest_uuid in found_manifest_uuids:
-        if found_manifest_uuid != manifest_uuid:
-            base_client.delete_entity(
-                client, c.MANIFEST_COLLECTION, found_manifest_uuid
-            )
-
-    return manifest_data
-
-
-def upgrade_manifest(
-    client: "CollectionBaseClient",
-    repository: str,
-    path_or_name: str,
-    install_only: bool = False,
-    version: str | None = None,
-    update_manifest: bool = False,
-    **kwargs: tp.Any,
-) -> dict[str, tp.Any]:
-    """Install or update element from a YAML file or repository.
-
-    The command will install the element if it's not installed or update it
-    if it's installed.
+    Returns:
+        Tuple of (repository_priority, version) for sorting.
+        Higher values indicate higher priority.
     """
+    version_obj = packaging_version.parse(element["version"])
 
-    if os.path.exists(path_or_name):
-        if not os.path.isfile(path_or_name):
-            raise click.ClickException(f"{path_or_name} is not a file")
-        manifest = utils.load_yaml(path_or_name)
-    else:
-        manifest = repo_lib.Repository(repository).get_manifest(path_or_name, version)
-
-    requirements: dict = manifest.get("requirements", {})
-
-    installed = bool(
-        base_client.list_entities(client, ENTITY_COLLECTION, name=manifest["name"])
-    )
-
-    if installed and install_only:
-        raise click.ClickException(f"Element {manifest['name']} is already installed")
-
-    # Install element if no requirements
-    if not requirements:
-        new_manifest = _apply_with_cleanup(
-            client, manifest, install_only, update_manifest, **kwargs
-        )
-        return new_manifest
-
-    # Resolve dependencies
-    installed_elements = {
-        e["name"] for e in base_client.list_entities(client, ENTITY_COLLECTION)
-    }
-    required_elements = [
-        item for item in requirements.keys() if item not in installed_elements
-    ]
-    all_installed_elements = required_elements.copy()
-    all_installed_elements.append(manifest["name"])
-    click.echo(
-        f"The following elements will be {'installed' if install_only else 'upgraded'} first: "
-        f"{click.style(', '.join(all_installed_elements), fg='green')}"
-    )
-
-    while required_elements:
-        requirement = required_elements.pop()
-        if requirement not in installed_elements:
-            click.echo(
-                f"The following dependency element will be installed: {requirement}"
-            )
-        req_manifest = repo_lib.Repository(repository).get_manifest(requirement)
-
-        # Determine requirements for the element
-        req_requirements = req_manifest.get("requirements", {})
-        req_required_elements = [
-            item for item in req_requirements.keys() if item not in installed_elements
-        ]
-        required_elements.extend(req_required_elements)
-        required_elements = list(set(required_elements))
-
-        # NOTE(akremenetsky): We should install the element since there are
-        # unresolved dependencies but for the simplicity we will install it here
-        req_manifest = base_client.add_entity(
-            client, c.MANIFEST_COLLECTION, req_manifest
-        )
+    repo_priority = 0
+    repository_ref = element.get("repository")
+    if repository_ref:
         try:
-            base_client.action_entity(
-                client, c.MANIFEST_COLLECTION, "install", req_manifest["uuid"]
-            )
-        except bazooka_exc.BaseHTTPException as e:
-            if e.code == 400 and e.cause.response.json().get("code") == 1000:
-                required_elements.insert(0, req_manifest["name"])
-                continue
-            else:
-                raise
-        installed_name = f"{req_manifest['name']} ({req_manifest['version']})"
-        click.echo(
-            f"Element {click.style(installed_name, fg='green')} was installed successfully"
+            repo_uuid = repository_ref.rstrip("/").split("/")[-1]
+            if utils.is_valid_uuid(repo_uuid):
+                repo_priority = repo_priorities.get(repo_uuid, 0)
+        except Exception:
+            pass
+
+    return (repo_priority, version_obj)
+
+
+def _select_element_by_name(
+    client: "CollectionBaseClient",
+    name: str,
+    version_filter: str | None,
+    exclude_uuid: str | None = None,
+) -> dict[str, tp.Any]:
+    """Select the best element by name, sorting by (repository_priority, version).
+
+    Filters out development versions unless version_filter is specified.
+    Sorts elements by repository priority (higher is better) and version
+    (higher is better), then returns the highest priority element.
+
+    Args:
+        client: API client for making requests.
+        name: Element name to search for.
+        version_filter: Optional version string to filter by.
+            If None, only stable versions are considered.
+
+    Returns:
+        Dictionary representing the selected element.
+
+    Raises:
+        click.ClickException: If no elements found or no stable versions available.
+    """
+    elements = base_client.list_entities(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, name=name
+    )
+
+    if exclude_uuid:
+        elements = [e for e in elements if e["uuid"] != exclude_uuid]
+
+    if not elements:
+        raise click.ClickException(f"No elements found with name '{name}'")
+
+    # Fetch all repositories once to build priority cache
+    repo_priorities: dict[str, int] = {}
+    try:
+        repositories = base_client.list_entities(client, c.REPOSITORY_COLLECTION)
+        for repo in repositories:
+            repo_priorities[repo["uuid"]] = repo.get("priority", 0)
+    except Exception:
+        pass
+
+    # Filter out development versions unless version is explicitly provided
+    if version_filter is None:
+        elements = [e for e in elements if version_lib.is_stable_version(e["version"])]
+
+    if not elements:
+        raise click.ClickException(
+            f"No stable versions found for element '{name}'. "
+            "Use --version to install a development version."
         )
 
-        installed_elements.add(req_manifest["name"])
+    # Filter by version if specified
+    if version_filter:
+        elements = [e for e in elements if e["version"] == version_filter]
+        if not elements:
+            raise click.ClickException(
+                f"No elements found with name '{name}' and version '{version_filter}'"
+            )
 
-        # TODO(akremenetsky): The installation is stuck for some reason
-        # so we need to wait a bit. Solve the issue in GC and remove this
-        # sleep.
-        time.sleep(3)
+    # Sort by (repository_priority, version) - higher is better
+    elements.sort(key=lambda e: _get_sort_key(e, repo_priorities), reverse=True)
 
-    new_manifest = _apply_with_cleanup(
-        client, manifest, install_only, update_manifest, **kwargs
+    return elements[0]
+
+
+def _select_current_element_by_name(
+    client: "CollectionBaseClient", name: str
+) -> dict[str, tp.Any]:
+    """Select current installed element by name (ACTIVE or IN_PROGRESS status).
+
+    Args:
+        client: API client for making requests.
+        name: Element name to search for.
+
+    Returns:
+        Dictionary representing the current element.
+
+    Raises:
+        click.ClickException: If no active or in-progress elements found.
+    """
+    elements = base_client.list_entities(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, name=name
     )
-    return new_manifest
+
+    active_elements = [
+        e
+        for e in elements
+        if e.get("status") in ("ACTIVE", "IN_PROGRESS")
+        or e.get("installation_state") == "INSTALLED"
+    ]
+
+    if not active_elements:
+        raise click.ClickException(
+            f"No installed element found with name '{name}'. "
+            "Use install command to install the element first."
+        )
+
+    if len(active_elements) > 1:
+        raise click.ClickException(
+            f"Multiple installed elements found with name '{name}'. "
+            "Please specify the UUID of the element to update."
+        )
+
+    return active_elements[0]
 
 
 @click.command("install", help="Install element")
-@click.option(
-    "-r",
-    "--repository",
-    default=f"{c.ELEMENT_REPO_URL}/",
-    show_default=True,
-    help="Repository endpoint",
-)
 @click.option(
     "-v",
     "--version",
@@ -315,29 +289,90 @@ def upgrade_manifest(
     required=False,
     help="version of the element",
 )
-@click.argument("path_or_name", required=False)
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    default=sys_uuid.UUID(int=0),
+    help="Project UUID, required only if the upload repository doesn't exist yet",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=DEFAULT_TIMEOUT,
+    show_default=True,
+    help="Seconds to wait for repository upload and element sync to complete",
+)
+@click.argument("uuid_or_name_or_path", required=False)
 @click.pass_context
 def install_cmd(
-    ctx: click.Context, repository: str, version: str | None, path_or_name: str | None
+    ctx: click.Context,
+    version: str | None,
+    project_id: sys_uuid.UUID,
+    timeout: float,
+    uuid_or_name_or_path: str | None,
 ) -> None:
-    """Install manifest from a YAML file"""
-    if not path_or_name:
-        all_elements = repo_lib.Repository(c.ELEMENT_REPO_URL).get_all_elements()
-        path_or_name = questionary.select(
-            "Select manifest to install",
-            choices=all_elements,
+    """Install element from repository API by UUID, name, or manifest path"""
+    if not uuid_or_name_or_path:
+        all_elements = base_client.list_entities(
+            base_client.get_user_api_client(ctx.obj.auth_data),
+            c.REPOSITORY_ELEMENT_COLLECTION,
+        )
+        element_names = sorted(set(e["name"] for e in all_elements))
+        uuid_or_name_or_path = questionary.select(
+            "Select element to install",
+            choices=element_names,
         ).ask()
-        if not path_or_name:
-            click.echo("No manifest selected, aborting")
+        if not uuid_or_name_or_path:
+            click.echo("No element selected, aborting")
             return
-    manifest = upgrade_manifest(
-        base_client.get_user_api_client(ctx.obj.auth_data),
-        repository,
-        path_or_name,
-        install_only=True,
-        version=version,
+
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+
+    if os.path.isfile(uuid_or_name_or_path):
+        manifest_path = pathlib.Path(uuid_or_name_or_path)
+        manifest_data = utils.load_yaml(str(manifest_path))
+        name = manifest_data.get("name")
+        e_version = manifest_data.get("version")
+
+        driver_spec = {"kind": "database"}
+        repository = repo_utils.ensure_repository(
+            client,
+            DEFAULT_UPLOAD_REPO_NAME,
+            driver_spec,
+            project_id,
+            DEFAULT_PRIORITY,
+            sync_mode="copy",
+        )
+
+        repo_utils.do_upload(client, DEFAULT_UPLOAD_REPO_NAME, manifest_path)
+
+        click.echo(f"Waiting for {name} ({e_version}) to become AVAILABLE...")
+        repo_element = repo_utils.wait_for_repo_element(
+            client, repository["uuid"], name, e_version, "AVAILABLE", timeout
+        )
+
+        base_client.action_entity(
+            client, c.REPOSITORY_ELEMENT_COLLECTION, "install", repo_element["uuid"]
+        )
+
+        installed_name = f"{name} ({e_version})"
+        click.echo(
+            f"Element {click.style(installed_name, fg='green')} was installed successfully"
+        )
+        return
+
+    if utils.is_valid_uuid(uuid_or_name_or_path):
+        element = client.get(c.REPOSITORY_ELEMENT_COLLECTION, uuid=uuid_or_name_or_path)
+    else:
+        element = _select_element_by_name(client, uuid_or_name_or_path, version)
+
+    element_uuid = element["uuid"]
+    base_client.action_entity(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, "install", element_uuid
     )
-    installed_name = f"{manifest['name']} ({manifest['version']})"
+
+    installed_name = f"{element['name']} ({element['version']})"
     click.echo(
         f"Element {click.style(installed_name, fg='green')} was installed successfully"
     )
@@ -345,115 +380,170 @@ def install_cmd(
 
 @click.command("update", help="Update element")
 @click.option(
-    "-r",
-    "--repository",
-    default=f"{c.ELEMENT_REPO_URL}/",
-    show_default=True,
-    help="Repository endpoint",
-)
-@click.option(
     "-v",
     "--version",
     type=str,
     required=False,
     help="version of the element",
 )
-@click.argument("path_or_name")
+@click.option(
+    "--yes", "-y", "y", help="Automatically answer yes for all questions", is_flag=True
+)
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    default=sys_uuid.UUID(int=0),
+    help="Project UUID, required only if the upload repository doesn't exist yet",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=DEFAULT_TIMEOUT,
+    show_default=True,
+    help="Seconds to wait for repository upload and element sync to complete",
+)
+@click.argument("uuid_or_name_or_path", required=False)
 @click.pass_context
 def update_cmd(
-    ctx: click.Context, repository: str, version: str | None, path_or_name: str
+    ctx: click.Context,
+    version: str | None,
+    y: bool,
+    project_id: sys_uuid.UUID,
+    timeout: float,
+    uuid_or_name_or_path: str | None,
 ) -> None:
-    """Update manifest from a YAML file"""
-    manifest = upgrade_manifest(
-        base_client.get_user_api_client(ctx.obj.auth_data),
-        repository,
-        path_or_name,
-        version=version,
+    """Update element from repository API by UUID, name, or manifest path"""
+    if not uuid_or_name_or_path:
+        all_elements = base_client.list_entities(
+            base_client.get_user_api_client(ctx.obj.auth_data),
+            c.REPOSITORY_ELEMENT_COLLECTION,
+        )
+        element_names = sorted(set(e["name"] for e in all_elements))
+        uuid_or_name_or_path = questionary.select(
+            "Select element to update",
+            choices=element_names,
+        ).ask()
+        if not uuid_or_name_or_path:
+            click.echo("No element selected, aborting")
+            return
+
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+
+    if os.path.isfile(uuid_or_name_or_path):
+        manifest_path = pathlib.Path(uuid_or_name_or_path)
+        manifest_data = utils.load_yaml(str(manifest_path))
+        name = manifest_data.get("name")
+        e_version = manifest_data.get("version")
+
+        current_element = _select_current_element_by_name(client, name)
+
+        if not (
+            y
+            or questionary.confirm(
+                f"Update {current_element['name']} "
+                f"({current_element['version']} -> {e_version})?"
+            ).ask()
+        ):
+            return
+
+        driver_spec = {"kind": "database"}
+        repository = repo_utils.ensure_repository(
+            client,
+            DEFAULT_UPLOAD_REPO_NAME,
+            driver_spec,
+            project_id,
+            DEFAULT_PRIORITY,
+            sync_mode="copy",
+        )
+
+        repo_utils.do_upload(client, DEFAULT_UPLOAD_REPO_NAME, manifest_path)
+
+        click.echo(f"Waiting for {name} ({e_version}) to become AVAILABLE...")
+        target_element = repo_utils.wait_for_repo_element(
+            client, repository["uuid"], name, e_version, "AVAILABLE", timeout
+        )
+
+        base_client.action_entity(
+            client,
+            c.REPOSITORY_ELEMENT_COLLECTION,
+            "upgrade",
+            current_element["uuid"],
+            target=target_element["uuid"],
+        )
+
+        installed_name = (
+            f"{current_element['name']} ({current_element['version']} -> {e_version})"
+        )
+        click.echo(
+            f"Element {click.style(installed_name, fg='green')} was updated successfully"
+        )
+        return
+
+    if utils.is_valid_uuid(uuid_or_name_or_path):
+        current_element = client.get(
+            c.REPOSITORY_ELEMENT_COLLECTION, uuid=uuid_or_name_or_path
+        )
+    else:
+        current_element = _select_current_element_by_name(client, uuid_or_name_or_path)
+
+    target_element = _select_element_by_name(
+        client, current_element["name"], version, exclude_uuid=current_element["uuid"]
+    )
+
+    if not (
+        y
+        or questionary.confirm(
+            f"Update {current_element['name']} "
+            f"({current_element['version']} -> {target_element['version']})?"
+        ).ask()
+    ):
+        return
+
+    base_client.action_entity(
+        client,
+        c.REPOSITORY_ELEMENT_COLLECTION,
+        "upgrade",
+        current_element["uuid"],
+        target=target_element["uuid"],
+    )
+
+    installed_name = (
+        f"{current_element['name']} ({current_element['version']}"
+        f" -> {target_element['version']})"
     )
     click.echo(
-        f"Element {click.style(manifest['name'], fg='green')} was successfully updated to version {click.style(manifest['version'], fg='green')}"
+        f"Element {click.style(installed_name, fg='green')} was updated successfully"
     )
 
 
-@click.command("uninstall", help="Uninstall manifest by UUID, path or name")
-@click.argument("path_uuid_name", type=str)
+@click.command("uninstall", help="Uninstall element by UUID or name")
+@click.argument("uuid_or_name", type=str)
 @click.option(
     "--yes", "-y", "y", help="Automatically answer yes for all questions", is_flag=True
 )
 @click.pass_context
-def uninstall_cmd(ctx: click.Context, path_uuid_name: str, y: bool) -> None:
-    """Uninstall manifest by UUID, path or name"""
+def uninstall_cmd(ctx: click.Context, uuid_or_name: str, y: bool) -> None:
+    """Uninstall element by UUID or name"""
     client = base_client.get_user_api_client(ctx.obj.auth_data)
-    log = ClickLogger()
 
-    if not (y or questionary.confirm(f"Delete {ENTITY} {path_uuid_name}?").ask()):
+    if not (y or questionary.confirm(f"Delete {ENTITY} {uuid_or_name}?").ask()):
         return
 
-    def _uninstall(element_uuid: str, element_name: str = None) -> None:
-        base_client.action_entity(
-            client, c.MANIFEST_COLLECTION, "uninstall", element_uuid
-        )
-        base_client.delete_entity(client, c.MANIFEST_COLLECTION, element_uuid)
-        log.important(
-            f"Element {element_name or element_uuid} uninstalled successfully"
-        )
+    if utils.is_valid_uuid(uuid_or_name):
+        element = client.get(c.REPOSITORY_ELEMENT_COLLECTION, uuid=uuid_or_name)
+        element_uuid = element["uuid"]
+    else:
+        element = _select_current_element_by_name(client, uuid_or_name)
+        element_uuid = element["uuid"]
 
-    # UUID
-    if utils.is_valid_uuid(path_uuid_name):
-        _uninstall(path_uuid_name)
-        return
+    base_client.action_entity(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, "uninstall", element_uuid
+    )
 
-    # Name
-    name = path_uuid_name
-
-    manifests = base_client.list_entities(client, c.MANIFEST_COLLECTION, name=name)
-    if len(manifests) == 1:
-        uuid = manifests[0]["uuid"]
-        _uninstall(uuid, name)
-        return
-    elif len(manifests) > 1:
-        raise click.ClickException(f"Multiple elements found with name {name}")
-
-    # Path
-    if os.path.exists(path_uuid_name):
-        manifest = utils.load_yaml(path_uuid_name)
-        if "uuid" in manifest:
-            filters = {"uuid": manifest["uuid"]}
-        elif "name" in manifest:
-            filters = {"name": manifest["name"]}
-        else:
-            raise click.ClickException("Manifest must have uuid or name")
-
-        manifests = base_client.list_entities(client, c.MANIFEST_COLLECTION, **filters)
-        if len(manifests) == 1:
-            uuid = manifests[0]["uuid"]
-            _uninstall(uuid, manifests[0]["name"])
-            return
-        if len(manifests) > 1:
-            raise click.ClickException(f"Multiple elements found with name {name}")
-        log.warning(f"manifest {list(filters.values())[0]} not found")
-        return
-
-    log.warning(f"Element {path_uuid_name} not found")
-
-
-@ee_group.command("available", help="Print available elements in repository")
-def available_elements() -> None:
-    """Update manifest from a YAML file"""
-    elements = repo_lib.Repository(c.ELEMENT_REPO_URL).get_all_elements()
-    for e in elements:
-        click.echo(e)
-
-
-@ee_group.command("versions", help="Print available elements in repository")
-@click.argument("name")
-def versions(name) -> None:
-    """Update manifest from a YAML file"""
-    element_versions = repo_lib.Repository(
-        c.ELEMENT_REPO_URL
-    ).get_element_versions_by_inventory(name)
-    for version in element_versions:
-        click.echo(version)
+    click.echo(
+        f"Element {click.style(element['name'], fg='green')} was uninstalled successfully"
+    )
 
 
 def edit_data(data: str, editor: str = "nano") -> tp.Tuple[str, dict]:
@@ -482,37 +572,41 @@ def edit_data(data: str, editor: str = "nano") -> tp.Tuple[str, dict]:
     type=click.Choice(["nano", "vim"], case_sensitive=False),
     help="Editor (nano or vim)",
 )
-@click.option(
-    "-r",
-    "--repository",
-    default=f"{c.ELEMENT_REPO_URL}/",
-    show_default=True,
-    help="Repository endpoint",
-)
 @click.pass_context
-def edit(ctx: click.Context, uuid_name: str, editor: str, repository: str) -> None:
+def edit(ctx: click.Context, uuid_name: str, editor: str) -> None:
     client = base_client.get_user_api_client(ctx.obj.auth_data)
-    data = base_client.get_entity(client, c.MANIFEST_COLLECTION, uuid_name)
+    element = base_client.get_entity(client, c.ELEMENT_COLLECTION, uuid_name)
+    manifest_ref = element.get("manifest", "")
+    if not manifest_ref:
+        raise click.ClickException(
+            f"Element {element['name']} has no manifest reference"
+        )
+    manifest_uuid = manifest_ref.rstrip("/").split("/")[-1]
+    repo_element = base_client.get_entity(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, manifest_uuid
+    )
+    manifest = repo_element.get("manifest", {})
     tf_path = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".yaml", mode="a+", delete=False) as tf:
-            utils.dump_yaml(data, tf)
+            utils.dump_yaml(manifest, tf)
             tf.flush()
             tf_path = tf.name
             subprocess.call([editor, tf_path])
             tf.seek(0)
-            manifest = upgrade_manifest(
-                client,
-                repository,
-                tf_path,
-                update_manifest=True,
-                manifest_uuid=data["uuid"],
-            )
+            updated_manifest = utils.load_yaml(tf_path)
+        base_client.action_entity(
+            client,
+            c.REPOSITORY_ELEMENT_COLLECTION,
+            "edit",
+            repo_element["uuid"],
+            manifest=updated_manifest,
+        )
     finally:
         if tf_path and os.path.exists(tf_path):
             os.remove(tf_path)
     click.echo(
-        f"Element {click.style(manifest['name'], fg='green')} was successfully edited"
+        f"Element {click.style(element['name'], fg='green')} was successfully edited"
     )
 
 
@@ -526,13 +620,6 @@ def edit(ctx: click.Context, uuid_name: str, editor: str, repository: str) -> No
     default="nano",
     type=click.Choice(["nano", "vim"], case_sensitive=False),
     help="Editor (nano or vim)",
-)
-@click.option(
-    "-r",
-    "--repository",
-    default=f"{c.ELEMENT_REPO_URL}/",
-    show_default=True,
-    help="Repository endpoint",
 )
 @click.option(
     "--resource-type",
@@ -551,7 +638,6 @@ def define(
     ctx: click.Context,
     uuid_name: str,
     editor: str,
-    repository: str,
     resource_type: str,
     resource_name: str,
 ) -> None:
@@ -582,13 +668,23 @@ def define(
         for k, v in resource_def.items()
         if not v.get("readOnly", False)
     }
-    manifest = base_client.get_entity(client, c.MANIFEST_COLLECTION, uuid_name)
+    element = base_client.get_entity(client, c.ELEMENT_COLLECTION, uuid_name)
+    manifest_ref = element.get("manifest", "")
+    if not manifest_ref:
+        raise click.ClickException(
+            f"Element {element['name']} has no manifest reference"
+        )
+    manifest_uuid = manifest_ref.rstrip("/").split("/")[-1]
+    repo_element = base_client.get_entity(
+        client, c.REPOSITORY_ELEMENT_COLLECTION, manifest_uuid
+    )
+    manifest = repo_element.get("manifest", {})
+    if "resources" not in manifest:
+        manifest["resources"] = {}
     if resource_type not in manifest["resources"]:
         manifest["resources"][resource_type] = {}
     if not resource_name:
-        default_resource_name = (
-            f"{manifest['name']}_{resource_ref.split('_')[0].lower()}"
-        )
+        default_resource_name = f"{manifest.get('name', element['name'])}_{resource_ref.split('_')[0].lower()}"
         resource_name = questionary.text(
             "Enter resource name", default=default_resource_name
         ).ask()
@@ -619,19 +715,21 @@ def define(
 
             tf_path = tf.name
             subprocess.call([editor, f"+{line_num}", tf_path])
-            manifest = upgrade_manifest(
-                client,
-                repository,
-                tf_path,
-                update_manifest=True,
-                manifest_uuid=manifest["uuid"],
-            )
+            tf.seek(0)
+            updated_manifest = utils.load_yaml(tf_path)
+        base_client.action_entity(
+            client,
+            c.REPOSITORY_ELEMENT_COLLECTION,
+            "edit",
+            repo_element["uuid"],
+            manifest=updated_manifest,
+        )
     finally:
         if tf_path and os.path.exists(tf_path):
             os.remove(tf_path)
 
     click.echo(
-        f"Element {click.style(manifest['name'], fg='green')} was successfully edited"
+        f"Element {click.style(element['name'], fg='green')} was successfully edited"
     )
 
 
@@ -642,20 +740,58 @@ def define(
 @click.pass_context
 def clear(ctx: click.Context, y: bool) -> bool:  # pragma: no cover
     client = base_client.get_user_api_client(ctx.obj.auth_data)
-    entities = base_client.list_entities(client, ENTITY_COLLECTION)
-    was_uninstalled = False
-    for entity in entities:
-        if entity["name"] in c.BASE_ELEMENTS:
-            click.echo(f"Skipping base element {entity['name']}")
-            continue
-        if y or Confirm.ask(f"Do you want to uninstall {entity['name']}?"):
-            uninstalled_name = f"{entity['name']} ({entity['version']})"
+
+    if not (y or click.confirm("Do you want to uninstall all non-base elements?")):
+        return False
+
+    def get_installed_elements():
+        repo_elements = base_client.list_entities(
+            client, c.REPOSITORY_ELEMENT_COLLECTION
+        )
+        return [
+            e
+            for e in repo_elements
+            if e.get("status") in ("IN_PROGRESS", "ACTIVE")
+            and e.get("name") not in c.BASE_ELEMENTS
+        ]
+
+    installed = get_installed_elements()
+    max_attempts = len(installed) + 1
+
+    for attempt in range(1, max_attempts + 1):
+        if not installed:
+            break
+
+        click.echo(
+            f"Uninstall attempt {attempt}/{max_attempts}: "
+            f"{len(installed)} element(s) remaining"
+        )
+        for element in installed:
+            uninstalled_name = f"{element['name']} ({element['version']})"
             click.echo(
-                f"Uninstalling element {click.style(uninstalled_name, fg='green')}"
+                f"  Uninstalling element {click.style(uninstalled_name, fg='green')}"
             )
-            base_client.delete_entity(client, ENTITY_COLLECTION, entity["uuid"])
-            was_uninstalled = True
-    return was_uninstalled
+            try:
+                base_client.action_entity(
+                    client,
+                    c.REPOSITORY_ELEMENT_COLLECTION,
+                    "uninstall",
+                    element["uuid"],
+                )
+            except Exception:
+                pass
+
+        time.sleep(0.2)
+        installed = get_installed_elements()
+
+    if installed:
+        remaining = ", ".join(e["name"] for e in installed)
+        raise click.ClickException(
+            f"Failed to uninstall all elements. Remaining: {remaining}"
+        )
+
+    click.echo("All non-base elements were successfully uninstalled")
+    return True
 
 
 @ee_group.command(

--- a/exordos/cmd/em/manifests/commands.py
+++ b/exordos/cmd/em/manifests/commands.py
@@ -115,4 +115,23 @@ def validate_cmd(repository: str, path_or_name: str) -> None:
     click.echo(f"Manifest {click.style(name, fg='green')} validated successfully")
 
 
+@click.command("uninstall", help=f"Uninstall {ENTITY} by UUID or name")
+@click.argument(
+    "uuid_or_name",
+    type=str,
+    required=True,
+)
+@click.pass_context
+def uninstall_cmd(ctx: click.Context, uuid_or_name: str) -> None:
+    """Uninstall manifest by UUID or name"""
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    manifest = base_client.get_entity(client, ENTITY_COLLECTION, uuid_or_name)
+
+    base_client.action_entity(client, ENTITY_COLLECTION, "uninstall", manifest["uuid"])
+
+    name = f"{manifest['name']} ({manifest['version']})"
+    click.echo(f"Manifest {click.style(name, fg='green')} was uninstalled successfully")
+
+
 manifests_group.add_command(show_cmd, aliases=["get", "g"])
+manifests_group.add_command(uninstall_cmd)

--- a/exordos/cmd/realms/commands.py
+++ b/exordos/cmd/realms/commands.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import dataclasses
+import ipaddress
 import os
 
 import requests
@@ -27,7 +28,21 @@ from exordos.common.table import print_table
 from exordos.infra.driver import libvirt as libvirt_infra
 from exordos.infra.libvirt import libvirt
 from exordos.logger import ClickLogger
+from exordos.stand import models as stand_models
 from exordos.utils import get_ip_from_url
+
+
+def get_stand_core_ip(
+    stand: "stand_models.Stand",
+) -> str | ipaddress.IPv4Address | None:
+    """Return the core VM's IP address for a local libvirt stand.
+
+    Shared by the realm listing/deletion commands here and by
+    `exordos deploy`'s bind-address auto-detection.
+    """
+    if stand.network.dhcp:
+        return libvirt.get_domain_ip(stand.bootstraps[0].name)
+    return stand.network.cidr[2]
 
 
 @click.group("realms", cls=ClickAliasedGroup, help="Manage realms")
@@ -71,10 +86,7 @@ def ssh_cmd(realm: str | None, username: str) -> None:
     else:
         raise click.UsageError("No exordos realm found")
 
-    if dev_stand.network.dhcp:
-        ip_address = libvirt.get_domain_ip(dev_stand.bootstraps[0].name)
-    else:
-        ip_address = dev_stand.network.cidr[2]
+    ip_address = get_stand_core_ip(dev_stand)
 
     os.system(f"ssh {username}@{ip_address}")
 
@@ -107,10 +119,7 @@ def list_cmd(ctx: click.Context) -> None:
 
     # Get the list of local realms by libvirt
     for stand in infra.list_stands():
-        if stand.network.dhcp:
-            ip = libvirt.get_domain_ip(stand.bootstraps[0].name)
-        else:
-            ip = stand.network.cidr[2]
+        ip = get_stand_core_ip(stand)
         realms[str(ip)] = Realm(stand.name, str(ip), "local", "Active")
 
     # Get the list of remote realms by config
@@ -180,10 +189,7 @@ def delete_cmd(ctx: click.Context, name: str) -> None:
             endpoint = config_realm.get("endpoint", "")
             config_ip = get_ip_from_url(endpoint)
             for stand in local_stands:
-                if stand.network.dhcp:
-                    ip = libvirt.get_domain_ip(stand.bootstraps[0].name)
-                else:
-                    ip = stand.network.cidr[2]
+                ip = get_stand_core_ip(stand)
                 if str(ip) == config_ip:
                     clear_local_realm()
                     click.echo(f"Deleting local realm {stand.name}...")

--- a/exordos/cmd/repo/commands.py
+++ b/exordos/cmd/repo/commands.py
@@ -15,23 +15,50 @@
 #    under the License.
 from __future__ import annotations
 
-import json
 import pathlib
 import typing as tp
+import uuid as sys_uuid
 
-import rich.status as rich_status
 import rich_click as click
 
 from exordos import constants as c
-from exordos.builder import base as base_builder
-from exordos.common.table import get_table
-from exordos.common.table import print_table
-from exordos.repo import base as base_repo
-from exordos.repo import fs as repo_fs
+from exordos.clients import base_client
+from exordos.cmd.base import create_entity_group
+from exordos.cmd.repo.elements import commands as elements_commands
+from exordos.common.table import show_data
 from exordos.repo import utils as repo_utils
 
 if tp.TYPE_CHECKING:
     from exordos.common.cmd_context import ContextObject
+
+
+# Repository management constants and functions
+REPOSITORY_ENTITY = "repository"
+REPOSITORY_FIELDS_MAP = {
+    "UUID": "uuid",
+    "Project": "project_id",
+    "Name": "name",
+    "Priority": "priority",
+    "Refresh Rate": "refresh_rate",
+    "Sync mode": "sync_mode",
+    "URI": lambda x: x.get("driver_spec", {}).get("url", ""),
+    "Status": "status",
+}
+
+
+def _build_driver_spec(
+    url: str | None,
+    username: str | None,
+    password: str | None,
+) -> dict[str, str] | None:
+    if url is None:
+        return None
+    spec = {"kind": "nginx", "url": url}
+    if username is not None:
+        spec["username"] = username
+    if password is not None:
+        spec["password"] = password
+    return spec
 
 
 @click.group("repo", help="Manage Exordos repository")
@@ -39,142 +66,285 @@ def repository_group():
     pass
 
 
-@repository_group.command("init", help="Initialize the repository")
-@click.option(
-    "-c",
-    "--exordos-cfg-file",
-    default=c.DEF_GEN_CFG_FILE_NAME,
-    help="Name of the project configuration file",
+# Repository list and delete commands (from create_entity_group)
+_repository_group = create_entity_group(
+    REPOSITORY_ENTITY,
+    c.REPOSITORY_COLLECTION,
+    REPOSITORY_FIELDS_MAP,
+    None,
+    add_list_command=True,
+    add_show_command=True,
+    add_delete_command=True,
 )
-@click.option(
-    "-t",
-    "--target",
-    default=None,
-    help="Target repository to push to",
-)
-@click.option(
-    "-f",
-    "--force",
-    show_default=True,
-    is_flag=True,
-    help="Force init even if the repo already exists",
-)
-@click.argument("project_dir", type=click.Path(), default=".")
-@click.pass_obj
-def repo_init_cmd(
-    obj: "ContextObject",
-    exordos_cfg_file: str,
-    target: str | None,
-    force: bool,
-    project_dir: str,
-) -> None:
 
-    driver = repo_utils.load_repo_driver(
-        exordos_cfg_file, target, project_dir, obj.cfg_path
+# Add list and delete commands to main repo group
+repository_group.add_command(_repository_group.commands["list"], aliases=["l"])
+repository_group.add_command(_repository_group.commands["show"], aliases=["get", "g"])
+repository_group.add_command(_repository_group.commands["delete"], aliases=["d"])
+
+
+@click.command("add", help=f"Add a new {REPOSITORY_ENTITY}")
+@click.pass_context
+@click.option(
+    "-u",
+    "--uuid",
+    type=click.UUID,
+    default=None,
+    help=f"UUID of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    required=True,
+    help=f"UUID of the project in which to deploy the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "-n",
+    "--name",
+    type=str,
+    default="",
+    help=f"Name of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "-D",
+    "--description",
+    type=str,
+    default="",
+    help=f"Description of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "--priority",
+    type=int,
+    default=2048,
+    help=f"Priority of the {REPOSITORY_ENTITY} (0-4096)",
+)
+@click.option(
+    "--refresh-rate",
+    type=int,
+    default=3600,
+    help=f"Refresh rate of the {REPOSITORY_ENTITY} in seconds",
+)
+@click.option(
+    "--sync-mode",
+    type=click.Choice(["copy", "lazy"]),
+    default="lazy",
+    help=f"Sync mode of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "--repo-url",
+    type=str,
+    required=True,
+    help="URL of the repository. Example: https://repo.exordos.com/exordos-elements/",
+)
+@click.option(
+    "--repo-user",
+    type=str,
+    default=None,
+    help="Username for the repository",
+)
+@click.option(
+    "--repo-password",
+    type=str,
+    default=None,
+    help="Password for the repository",
+)
+def repository_add_cmd(
+    ctx: click.Context,
+    uuid: sys_uuid.UUID | None,
+    project_id: sys_uuid.UUID,
+    name: str,
+    description: str,
+    priority: int,
+    refresh_rate: int,
+    sync_mode: str,
+    repo_url: str,
+    repo_user: str | None,
+    repo_password: str | None,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    if uuid is None:
+        uuid = sys_uuid.uuid4()
+    data = {
+        "uuid": str(uuid),
+        "project_id": str(project_id),
+        "name": name,
+        "description": description,
+        "priority": priority,
+        "refresh_rate": refresh_rate,
+        "sync_mode": sync_mode,
+    }
+    driver_spec = _build_driver_spec(repo_url, repo_user, repo_password)
+    if driver_spec is not None:
+        data["driver_spec"] = driver_spec
+    entity = base_client.add_entity(client, c.REPOSITORY_COLLECTION, data)
+    show_data(entity)
+
+
+@click.command("update", help=f"Update {REPOSITORY_ENTITY}")
+@click.pass_context
+@click.argument(
+    "uuid",
+    type=str,
+    required=True,
+)
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    default=None,
+    help=f"UUID of the project in which to deploy the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "-n",
+    "--name",
+    type=str,
+    default=None,
+    help=f"Name of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "-D",
+    "--description",
+    type=str,
+    default=None,
+    help=f"Description of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "--status",
+    type=click.Choice(["NEW", "ACTIVE", "IN_PROGRESS", "DISABLED", "ERROR"]),
+    default=None,
+    help=f"Status of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "--priority",
+    type=int,
+    default=None,
+    help=f"Priority of the {REPOSITORY_ENTITY} (0-4096)",
+)
+@click.option(
+    "--refresh-rate",
+    type=int,
+    default=None,
+    help=f"Refresh rate of the {REPOSITORY_ENTITY} in seconds",
+)
+@click.option(
+    "--sync-mode",
+    type=click.Choice(["copy", "lazy"]),
+    default=None,
+    help=f"Sync mode of the {REPOSITORY_ENTITY}",
+)
+@click.option(
+    "--repo-url",
+    type=str,
+    default=None,
+    help="URL of the repository. Example: https://repo.exordos.com/exordos-elements/",
+)
+@click.option(
+    "--repo-user",
+    type=str,
+    default=None,
+    help="Username for the repository",
+)
+@click.option(
+    "--repo-password",
+    type=str,
+    default=None,
+    help="Password for the repository",
+)
+def repository_update_cmd(
+    ctx: click.Context,
+    uuid: str,
+    project_id: sys_uuid.UUID | None,
+    name: str | None,
+    description: str | None,
+    status: str | None,
+    priority: int | None,
+    refresh_rate: int | None,
+    sync_mode: str | None,
+    repo_url: str | None,
+    repo_user: str | None,
+    repo_password: str | None,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    data = {}
+    if project_id is not None:
+        data["project_id"] = str(project_id)
+    if name is not None:
+        data["name"] = name
+    if description is not None:
+        data["description"] = description
+    if status is not None:
+        data["status"] = status
+    if priority is not None:
+        data["priority"] = priority
+    if refresh_rate is not None:
+        data["refresh_rate"] = refresh_rate
+    if sync_mode is not None:
+        data["sync_mode"] = sync_mode
+
+    driver_spec = _build_driver_spec(repo_url, repo_user, repo_password)
+    if driver_spec is not None:
+        data["driver_spec"] = driver_spec
+
+    entity = base_client.update_entity(client, c.REPOSITORY_COLLECTION, uuid, data)
+    show_data(entity)
+
+
+repository_group.add_command(repository_add_cmd, aliases=["a"])
+repository_group.add_command(repository_update_cmd, aliases=["u"])
+
+
+@click.command("refresh", help=f"Refresh {REPOSITORY_ENTITY}")
+@click.pass_context
+@click.argument(
+    "name_or_uuid",
+    type=str,
+    required=True,
+)
+def repository_refresh_cmd(
+    ctx: click.Context,
+    name_or_uuid: str,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    entity_uuid = base_client._get_entity_uuid(
+        client, c.REPOSITORY_COLLECTION, name_or_uuid
+    )
+    base_client.action_entity(client, c.REPOSITORY_COLLECTION, "refresh", entity_uuid)
+    click.echo(
+        f"Repository {click.style(name_or_uuid, fg='green')} was refreshed successfully"
     )
 
-    try:
-        driver.init_repo()
-    except base_repo.RepoAlreadyExistsError:
-        if force:
-            driver.delete_repo()
-            driver.init_repo()
-            return
 
-        click.secho(
-            "Repository already exists.",
-            fg="red",
-        )
+repository_group.add_command(repository_refresh_cmd)
 
 
-@repository_group.command("delete", help="Delete the repository")
+@click.command("upload", help=f"Upload element to {REPOSITORY_ENTITY}")
+@click.pass_context
 @click.option(
-    "-c",
-    "--exordos-cfg-file",
-    default=c.DEF_GEN_CFG_FILE_NAME,
-    help="Name of the project configuration file",
+    "-r",
+    "--repository",
+    type=str,
+    required=True,
+    help="Repository name or UUID to upload element to",
 )
-@click.option(
-    "-t",
-    "--target",
-    default=None,
-    help="Target repository to push to",
+@click.argument(
+    "manifest",
+    type=pathlib.Path,
+    required=True,
 )
-@click.argument("project_dir", type=click.Path(), default=".")
-@click.pass_obj
-def repo_delete_cmd(
-    obj: "ContextObject",
-    exordos_cfg_file: str,
-    target: str | None,
-    project_dir: str,
+def repository_upload_cmd(
+    ctx: click.Context,
+    repository: str,
+    manifest: pathlib.Path,
 ) -> None:
-    driver = repo_utils.load_repo_driver(
-        exordos_cfg_file, target, project_dir, obj.cfg_path
-    )
-    driver.delete_repo()
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    repo_utils.do_upload(client, repository, manifest)
 
 
-@repository_group.command("list", help="List elements in the repository")
-@click.option(
-    "-c",
-    "--exordos-cfg-file",
-    default=c.DEF_GEN_CFG_FILE_NAME,
-    help="Name of the project configuration file",
-)
-@click.option(
-    "-t",
-    "--target",
-    default=None,
-    help="Target repository to push to",
-)
-@click.option(
-    "-e",
-    "--element",
-    default=None,
-    help="Element to list",
-)
-@click.argument("project_dir", type=click.Path(), default=".")
-@click.pass_obj
-def repo_list_cmd(
-    obj: "ContextObject",
-    exordos_cfg_file: str,
-    target: str | None,
-    element: str | None,
-    project_dir: str,
-) -> None:
-    table = get_table()
-    driver = repo_utils.load_repo_driver(
-        exordos_cfg_file, target, project_dir, obj.cfg_path
-    )
-    try:
-        elements = driver.list()
-    except base_repo.RepoNotFoundError:
-        click.secho("Repository not found", fg="red")
-        return
+repository_group.add_command(repository_upload_cmd)
 
-    click.secho(f"Repository: {driver.name}", fg="green")
-    if element is not None:
-        if element not in elements:
-            raise click.UsageError(f"Element {element} not found")
-
-        table.add_column("version")
-
-        for version in sorted(elements[element]):
-            table.add_row(version)
-
-        print_table(table)
-        return
-
-    table.add_column("name")
-    table.add_column("last version")
-    table.add_column("versions")
-
-    for element in elements:
-        table.add_row(
-            element, sorted(elements[element])[-1], str(len(elements[element]))
-        )
-
-    print_table(table)
+# Add elements subgroup
+repository_group.add_command(elements_commands.elements_group, aliases=["e"])
 
 
 @repository_group.command("push", help="Push the element to the repository")
@@ -196,7 +366,7 @@ def repo_list_cmd(
     help=(
         "Additional params to pass to the driver. "
         "The format is 'key=value'. For example: --driver-params "
-        'url=http://repo.local.genesis-core.tech:8080/ --driver-params auth=["user","password"]'
+        'url=http://repo.local.exordos.com:8080/ --driver-params auth=["user","password"]'
     ),
 )
 @click.option(
@@ -242,38 +412,4 @@ def push_cmd(
     repo_driver = repo_utils.load_repo_driver(
         exordos_cfg_file, target, project_dir, obj.cfg_path, driver, driver_params
     )
-
-    # Every build creates a local repo with built elements into it.
-    build_repo = repo_fs.FSRepoDriver(element_dir)
-    build_repo_dir = pathlib.Path(build_repo.elements_path)
-
-    with open(build_repo_dir / "inventory.json") as f:
-        repo_inventory = json.load(f)
-        repo_elements = repo_inventory["elements"]
-
-    for e_name in repo_elements:
-        # FIXME(akremenetsky): In the build repo only single version is available
-        e_version = tuple(repo_elements[e_name].keys())[0]
-        e_dir = build_repo_dir / e_name / e_version
-        e_inventory = base_builder.ElementInventory.from_dict(
-            repo_elements[e_name][e_version]
-        )
-        e_inventory = e_inventory.replace_with_abspath(e_dir)
-
-        try:
-            with rich_status.Status("Push the element to the repo...", spinner="dots"):
-                repo_driver.push(e_inventory, latest=latest)
-        except base_repo.ElementAlreadyExistsError:
-            if force:
-                repo_driver.remove(e_inventory)
-                with rich_status.Status(
-                    "Push the element to the repo...", spinner="dots"
-                ):
-                    repo_driver.push(e_inventory, latest=latest)
-                    continue
-
-            click.secho(
-                f"Element {e_inventory.name} version "
-                f"{e_inventory.version} already exists.",
-                fg="red",
-            )
+    repo_utils.do_push(repo_driver, element_dir, force, latest)

--- a/exordos/cmd/repo/elements/commands.py
+++ b/exordos/cmd/repo/elements/commands.py
@@ -1,0 +1,105 @@
+#    Copyright 2025 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import re
+import uuid as sys_uuid
+
+from packaging import version as packaging_version
+import rich_click as click
+
+from exordos import constants as c
+from exordos.cmd.base import create_entity_group
+
+ELEMENT_ENTITY = "repo element"
+
+
+def _extract_repository_uuid(x):
+    repo_ref = x.get("repository")
+    if not repo_ref or not isinstance(repo_ref, str):
+        return ""
+
+    try:
+        return str(sys_uuid.UUID(repo_ref[-36:]))
+    except ValueError:
+        return repo_ref
+
+
+ELEMENT_FIELDS_MAP = {
+    "UUID": "uuid",
+    "Project": "project_id",
+    "Name": "name",
+    "Version": "version",
+    "Repository": _extract_repository_uuid,
+    "Status": "status",
+}
+
+_STABLE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_HIDDEN_STATUSES = {"NEW", "AVAILABLE", None}
+
+
+def _filter_and_sort_elements(entities: list[dict], kwargs: dict) -> list[dict]:
+    if not kwargs.get("dev"):
+        entities = [
+            e
+            for e in entities
+            if _STABLE_VERSION_RE.match(str(e.get("version", "")))
+            or e.get("status") not in _HIDDEN_STATUSES
+        ]
+
+    def _parse_version(version):
+        try:
+            return packaging_version.parse(version)
+        except packaging_version.InvalidVersion:
+            return packaging_version.parse("0")
+
+    return sorted(
+        entities,
+        key=lambda e: (
+            e.get("name", ""),
+            _parse_version(e.get("version", "0")),
+        ),
+    )
+
+
+_DEV_OPTION = click.Option(
+    ["--dev"],
+    is_flag=True,
+    default=False,
+    help="Show all versions including dev",
+)
+
+
+@click.group("elements", help="Manage repo elements")
+def elements_group():
+    pass
+
+
+# Add list command to elements subgroup
+_elements_group = create_entity_group(
+    ELEMENT_ENTITY,
+    c.REPOSITORY_ELEMENT_COLLECTION,
+    ELEMENT_FIELDS_MAP,
+    None,
+    add_list_command=True,
+    add_show_command=True,
+    add_delete_command=False,
+    post_fetch_handler=_filter_and_sort_elements,
+    extra_options=[_DEV_OPTION],
+)
+
+elements_group.add_command(_elements_group.commands["list"], aliases=["l"])
+elements_group.add_command(_elements_group.commands["show"], aliases=["get", "g"])

--- a/exordos/cmd/settings/commands.py
+++ b/exordos/cmd/settings/commands.py
@@ -15,13 +15,16 @@
 #    under the License.
 from __future__ import annotations
 
+import copy
 import json
 import os
+import typing as tp
 
 import rich_click as click
 import yaml
 
 from exordos import constants as c
+from exordos.cmd.aliases import ClickAliasedGroup
 from exordos.cmd.settings.config import get_current_realm
 from exordos.cmd.settings.config import save_config
 
@@ -88,17 +91,18 @@ def use_realm(ctx: click.Context, realm: str) -> None:
 @click.pass_context
 def list_realms(ctx: click.Context, output: str, show_sensitive: bool) -> None:
     config = ctx.obj.cfg
+    realms = copy.deepcopy(config.get("realms", {}))
 
     if not show_sensitive:
-        for realm in config.get("realms", {}).values():
+        for realm in realms.values():
             for context in realm.get("contexts", {}).values():
                 context["password"] = "*"
                 context["user"] = "*"
 
     if output == "json":
-        click.echo(json.dumps(config.get("realms", {}), indent=2))
+        click.echo(json.dumps(realms, indent=2))
     else:
-        click.echo(yaml.dump(config.get("realms", {}), default_flow_style=False))
+        click.echo(yaml.dump(realms, default_flow_style=False))
 
 
 @settings_group.command("set-realm", help="Set a realm entry in settings")
@@ -125,6 +129,19 @@ def list_realms(ctx: click.Context, output: str, show_sensitive: bool) -> None:
     help="Skip TLS certificate verification",
 )
 @click.option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="Mark the realm as local",
+)
+@click.option(
+    "-m",
+    "--meta",
+    multiple=True,
+    type=str,
+    help="Arbitrary key=value metadata for the realm (can be repeated)",
+)
+@click.option(
     "--current",
     is_flag=True,
     default=False,
@@ -137,6 +154,8 @@ def set_realm(
     endpoint: str | None,
     check_updates: bool,
     skip_tls_verify: bool,
+    local: bool,
+    meta: tuple[str, ...],
     current: bool,
 ) -> None:
     config = ctx.obj.cfg
@@ -144,12 +163,26 @@ def set_realm(
     if "realms" not in config:
         config["realms"] = {}
 
-    realm_config = {
+    meta_dict: dict[str, str] = {}
+    if realm in config["realms"]:
+        meta_dict = config["realms"][realm].get("meta", {})
+    for item in meta:
+        if "=" not in item:
+            raise click.ClickException(
+                f"Invalid meta value '{item}', expected key=value format"
+            )
+        key, _, value = item.partition("=")
+        meta_dict[key.strip()] = value.strip()
+
+    realm_config: dict[str, tp.Any] = {
         "endpoint": endpoint,
         "check_updates": check_updates,
         "skip_tls_verify": skip_tls_verify,
+        "local": local,
         "contexts": {},
     }
+    if meta_dict:
+        realm_config["meta"] = meta_dict
     if realm in config["realms"]:
         realm_config["contexts"] = config["realms"][realm].get("contexts", {})
     config["realms"][realm] = realm_config
@@ -175,6 +208,113 @@ def delete_realm(ctx: click.Context, realm: str) -> None:
     del config["realms"][realm]
     save_config(config, ctx.obj.cfg_path)
     click.echo(f"realm '{realm}' deleted")
+
+
+@click.group(
+    "repo",
+    cls=ClickAliasedGroup,
+    help="Manage repository entries in the settings file",
+)
+def repo_group():
+    pass
+
+
+@repo_group.command("list", help="List repositories from the settings file")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["json", "yaml"]),
+    default="yaml",
+    help="Output format",
+)
+@click.option(
+    "--show-sensitive",
+    is_flag=True,
+    default=False,
+    help="Show sensitive data",
+)
+@click.pass_context
+def list_repos(ctx: click.Context, output: str, show_sensitive: bool) -> None:
+    config = ctx.obj.cfg
+    repositories = copy.deepcopy(config.get("repositories", {}))
+
+    if not show_sensitive:
+        for repo in repositories.values():
+            if "auth" in repo:
+                repo["auth"] = ["*", "*"]
+
+    if output == "json":
+        click.echo(json.dumps(repositories, indent=2))
+    else:
+        click.echo(yaml.dump(repositories, default_flow_style=False))
+
+
+@repo_group.command("add", help="Add a repository entry to the settings file")
+@click.argument("repo", type=str, required=True)
+@click.option(
+    "-d",
+    "--driver",
+    required=True,
+    type=str,
+    help="Driver kind for the repository, e.g. nginx",
+)
+@click.option(
+    "-u",
+    "--url",
+    required=True,
+    type=str,
+    help="URL of the repository",
+)
+@click.option(
+    "--username",
+    type=str,
+    default=None,
+    help="Username for the repository",
+)
+@click.option(
+    "--password",
+    type=str,
+    default=None,
+    help="Password for the repository",
+)
+@click.pass_context
+def add_repo(
+    ctx: click.Context,
+    repo: str,
+    driver: str,
+    url: str,
+    username: str | None,
+    password: str | None,
+) -> None:
+    config = ctx.obj.cfg
+
+    if "repositories" not in config:
+        config["repositories"] = {}
+
+    repo_config: dict[str, tp.Any] = {"driver": driver, "url": url}
+    if username is not None and password is not None:
+        repo_config["auth"] = [username, password]
+    config["repositories"][repo] = repo_config
+
+    save_config(config, ctx.obj.cfg_path)
+    click.echo(f"repo '{repo}' set")
+
+
+@repo_group.command("delete", help="Delete a repository from the settings file")
+@click.argument("repo", type=str, required=True)
+@click.pass_context
+def delete_repo(ctx: click.Context, repo: str) -> None:
+    config = ctx.obj.cfg
+
+    if "repositories" not in config or repo not in config["repositories"]:
+        raise click.ClickException(f"repo '{repo}' not found")
+
+    del config["repositories"][repo]
+    save_config(config, ctx.obj.cfg_path)
+    click.echo(f"repo '{repo}' deleted")
+
+
+settings_group.add_command(repo_group)
 
 
 @settings_group.command("set", help="Set an individual value in a settings file")

--- a/exordos/cmd/settings/config.py
+++ b/exordos/cmd/settings/config.py
@@ -91,6 +91,13 @@ def get_current_realm(config: dict) -> dict | None:
     return config.get("current-realm")
 
 
+def get_repo(config: dict, repo: str) -> dict:
+    """Return a repository entry from settings by name."""
+    if "repositories" not in config or repo not in config["repositories"]:
+        return {}
+    return config["repositories"][repo]
+
+
 def get_realm(config: dict, realm: str | None = None) -> dict:
     if not realm:
         realm = get_current_realm(config)

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -14,7 +14,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import contextlib
 import fnmatch
 import hashlib
 import ipaddress
@@ -29,7 +28,6 @@ import typing as tp
 import urllib.parse
 
 import requests
-import rich.console
 import rich.panel
 import rich.progress
 import rich.status
@@ -41,40 +39,24 @@ from exordos import utils
 from exordos.backup import base as backup_base
 from exordos.backup import local as backup_local
 from exordos.builder import base as base_builder
+from exordos.cmd.settings import config as settings_config
 from exordos.cmd.stand.constants import BackupPeriod
 from exordos.cmd.stand.constants import Profile
+from exordos.common import status as status_lib
 from exordos.common import version as version_lib
 import exordos.constants as c
 from exordos.infra.driver import libvirt as libvirt_infra
 from exordos.infra.libvirt import libvirt
 from exordos.logger import ClickLogger
-from exordos.logger import DummyLogger
 from exordos.repo import fs as repo_fs
 from exordos.stand import models as stand_models
-
-
-@contextlib.contextmanager
-def _status_done(message: str) -> tp.Generator[rich.status.Status, None, None]:
-    """Context manager that shows a spinner while the body executes.
-
-    Silences :class:`ClickLogger` output during the block so intermediate
-    log messages don't interleave with the spinner.  On successful exit
-    replaces the spinner line with a green checkmark followed by *message*.
-    """
-    _real = ClickLogger.__instance__
-    ClickLogger.__instance__ = DummyLogger()
-    try:
-        with rich.status.Status(message, spinner="dots") as status:
-            yield status
-    finally:
-        ClickLogger.__instance__ = _real
-    rich.console.Console().print(f"[green]\u2713[/green] {message}")
 
 
 def _print_bootstrap_summary(
     installation_name: str,
     admin_password: str,
     core_ip: ipaddress.IPv4Address | None,
+    realm_updated: bool = False,
 ) -> None:
     console = rich.console.Console()
     table = rich.table.Table(show_header=False, box=None, padding=(0, 2))
@@ -87,6 +69,13 @@ def _print_bootstrap_summary(
 
     if core_ip is not None:
         table.add_row("Connection", f"[green]ssh ubuntu@{core_ip}[/green]")
+
+    if realm_updated:
+        table.add_row(
+            "Settings",
+            f"[green]Realm '{installation_name}' saved to "
+            f"~/.exordos/exordosctl.yaml[/green]",
+        )
 
     console.print(
         rich.panel.Panel(
@@ -480,7 +469,7 @@ def _bootstrap_core(
     disks: list[int] | None,
     force: bool,
     core_ip: ipaddress.IPv4Address,
-    repository: str,
+    repository: tp.Tuple[str, ...],
     admin_password: str,
     save_admin_password_file: str | None,
     manifest_path: str,
@@ -615,6 +604,54 @@ def _bootstrap_core(
     return dev_stand.network.cidr[2]
 
 
+def _update_realm_config(
+    realm_name: str,
+    realm_ip: ipaddress.IPv4Address,
+    cidr: ipaddress.IPv4Network,
+    admin_password: str,
+    cfg_path: str = c.CONFIG_FILE,
+) -> None:
+    """Update the realm entry in exordosctl.yaml after bootstrap."""
+    logger = ClickLogger()
+
+    try:
+        with open(cfg_path, "r") as f:
+            config = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        config = {}
+
+    if "realms" not in config:
+        config["realms"] = {}
+
+    existing = config["realms"].get(realm_name, {})
+    existing_meta = existing.get("meta", {})
+
+    config["realms"][realm_name] = {
+        "endpoint": f"http://{realm_ip}/api/core",
+        "check_updates": existing.get("check_updates", True),
+        "skip_tls_verify": existing.get("skip_tls_verify", True),
+        "local": True,
+        "meta": {**existing_meta, "cidr": str(cidr)},
+        "contexts": existing.get("contexts", {}),
+        "current-context": existing.get("current-context"),
+    }
+
+    if not config["realms"][realm_name]["contexts"]:
+        config["realms"][realm_name]["contexts"] = {
+            "admin": {
+                "user": "admin",
+                "password": admin_password,
+            }
+        }
+        config["realms"][realm_name]["current-context"] = "admin"
+
+    if not config.get("current-realm"):
+        config["current-realm"] = realm_name
+
+    settings_config.save_config(config, cfg_path)
+    logger.info(f"Realm '{realm_name}' configuration updated in {cfg_path}")
+
+
 @click.command("bootstrap", help="Bootstrap exordos locally")
 @click.option(
     "-i",
@@ -732,9 +769,10 @@ def _bootstrap_core(
 @click.option(
     "-r",
     "--repository",
-    default=f"{c.EXORDOS_REPO_URL}/",
+    multiple=True,
+    default=(f"{c.ELEMENT_REPO_URL}/",),
     type=str,
-    help="Default element repository",
+    help="Default element repository (can be specified multiple times)",
     show_default=True,
 )
 @click.option(
@@ -863,7 +901,16 @@ def _bootstrap_core(
     "--elements",
     multiple=True,
     type=str,
-    help="Elements to install. Can be specified multiple times. Example: --elements empty --elements dbaas",
+    help=(
+        "Elements to install. Can be specified multiple times. "
+        "Example: --elements empty --elements dbaas"
+    ),
+)
+@click.option(
+    "--no-update-realm",
+    is_flag=True,
+    default=False,
+    help="Do not update the realm configuration in exordosctl.yaml after bootstrap",
 )
 @click.pass_context
 def bootstrap_cmd(
@@ -882,7 +929,7 @@ def bootstrap_cmd(
     boot_bridge: str | None,
     force: bool,
     no_wait: bool,
-    repository: str,
+    repository: tp.Tuple[str, ...],
     admin_password: str | None,
     save_admin_password_file: str | None,
     hyper_connection_uri: str,
@@ -899,6 +946,7 @@ def bootstrap_cmd(
     settings: bool,
     ssh_public_key: tp.Tuple[str, ...],
     elements: tp.Tuple[str, ...],
+    no_update_realm: bool,
 ) -> None:
     if not inventory:
         raise click.UsageError("No inventory specified")
@@ -1060,7 +1108,7 @@ def bootstrap_cmd(
             fg="cyan",
         )
     else:
-        with _status_done("Registering realm in ecosystem..."):
+        with status_lib.status_done("Registering realm in ecosystem..."):
             realm_uuid, realm_secret, realm_tokens = _register_core(
                 ecosystem_endpoint=ecosystem_endpoint,
                 disable_telemetry=disable_telemetry,
@@ -1081,7 +1129,7 @@ def bootstrap_cmd(
         if subprocess.call(["sudo", "-v"]) != 0:
             raise click.ClickException("Failed to obtain sudo privileges. Aborting.")
 
-    with _status_done(f"Launching Exordos installation '{name}'... "):
+    with status_lib.status_done(f"Launching Exordos installation '{name}'... "):
         core_ip_result = _bootstrap_core(
             image_path=image_path,
             image_uri=image_uri,
@@ -1109,10 +1157,24 @@ def bootstrap_cmd(
             elements=list(elements) if elements else None,
         )
 
+    realm_updated = False
+    if not no_update_realm:
+        realm_ip = core_ip_result if core_ip_result is not None else core_ip
+        if realm_ip is not None:
+            _update_realm_config(
+                realm_name=name,
+                realm_ip=realm_ip,
+                cidr=cidr,
+                admin_password=admin_password,
+                cfg_path=ctx.obj.cfg_path,
+            )
+            realm_updated = True
+
     _print_bootstrap_summary(
         installation_name=name,
         admin_password=admin_password,
         core_ip=core_ip_result,
+        realm_updated=realm_updated,
     )
 
     if settings:

--- a/exordos/common/status.py
+++ b/exordos/common/status.py
@@ -1,0 +1,43 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import contextlib
+import typing as tp
+
+import rich.console
+import rich.status
+
+from exordos.logger import ClickLogger
+from exordos.logger import DummyLogger
+
+
+@contextlib.contextmanager
+def status_done(message: str) -> tp.Generator[rich.status.Status, None, None]:
+    """Show a spinner while the body executes and print a checkmark on success.
+
+    Silences :class:`ClickLogger` output during the block so intermediate
+    log messages don't interleave with the spinner. On successful exit
+    replaces the spinner line with a green checkmark followed by *message*.
+    """
+    _real = ClickLogger.__instance__
+    ClickLogger.__instance__ = DummyLogger()
+    try:
+        with rich.status.Status(message, spinner="dots") as status:
+            yield status
+    finally:
+        ClickLogger.__instance__ = _real
+    rich.console.Console().print(f"[green]\u2713[/green] {message}")

--- a/exordos/constants.py
+++ b/exordos/constants.py
@@ -58,6 +58,9 @@ RESOURCE_COLLECTION = "/v1/em/resources/"
 IMPORTS_COLLECTION = "/v1/em/imports/"
 EXPORTS_COLLECTION = "/v1/em/exports/"
 
+REPOSITORY_COLLECTION = "/v1/repo/repositories/"
+REPOSITORY_ELEMENT_COLLECTION = "/v1/repo/elements/"
+
 PROFILE_COLLECTION = "/v1/vs/profiles/"
 VALUE_COLLECTION = "/v1/vs/values/"
 VARIABLE_COLLECTION = "/v1/vs/variables/"

--- a/exordos/repo/base.py
+++ b/exordos/repo/base.py
@@ -57,6 +57,12 @@ class AbstractRepoDriver(abc.ABC):
         """Return the name of the repo."""
         ...
 
+    @property
+    @abc.abstractmethod
+    def elements_path(self) -> str:
+        """Return the base path/URL for elements in the repo."""
+        ...
+
     @abc.abstractmethod
     def init_repo(self) -> None:
         """Initialize the repo."""

--- a/exordos/repo/local_server.py
+++ b/exordos/repo/local_server.py
@@ -1,0 +1,58 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import contextlib
+import functools
+import http.server
+import pathlib
+import threading
+import typing as tp
+
+
+class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+    """A SimpleHTTPRequestHandler that doesn't spam stderr per request."""
+
+    def log_message(self, format: str, *args: tp.Any) -> None:
+        pass
+
+
+@contextlib.contextmanager
+def serve_directory(
+    path: pathlib.Path | str, host: str, port: int = 0
+) -> tp.Iterator[str]:
+    """Serve `path` read-only over plain HTTP in a background thread.
+
+    This is enough for the platform's repository driver, which only issues
+    deterministic GETs (inventory.json, manifests, artifacts) -- no WebDAV
+    or directory-listing support is required for reading.
+
+    Yields the base URL (e.g. ``http://10.20.0.1:41231/``) once the server
+    is accepting connections. The server is stopped when the context exits.
+    """
+    handler = functools.partial(_QuietHandler, directory=str(path))
+    server = http.server.ThreadingHTTPServer((host, port), handler)
+    bound_port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield f"http://{host}:{bound_port}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/exordos/repo/utils.py
+++ b/exordos/repo/utils.py
@@ -16,9 +16,62 @@
 
 from __future__ import annotations
 
+import json
+import os
+import pathlib
+import time
+import typing as tp
+import uuid as sys_uuid
+
+import rich.status as rich_status
+import rich_click as click
+import yaml
+
 from exordos import utils
+from exordos.builder import base as base_builder
+from exordos.clients import base_client
 import exordos.constants as c
 from exordos.repo import base as base_repo
+from exordos.repo import fs as repo_fs
+
+POLL_INTERVAL = 2.0
+STABLE_CHECKS = 10
+
+
+def load_repo_driver_from_settings(
+    exordosctl_cfg_file: str,
+    target: str,
+) -> base_repo.AbstractRepoDriver:
+    """Build a repo driver from a repository entry in the settings file.
+
+    Returns None if no matching repository is found in settings.
+    """
+    if not exordosctl_cfg_file or not os.path.exists(exordosctl_cfg_file):
+        raise base_repo.UnableLoadDriverError(
+            f"Settings file {exordosctl_cfg_file} not found"
+        )
+
+    with open(exordosctl_cfg_file, "r") as f:
+        config = yaml.safe_load(f) or {}
+
+    repos = config.get("repositories", {})
+    if not repos or target not in repos:
+        raise base_repo.UnableLoadDriverError(
+            f"Repository {target} not found in settings"
+        )
+    repo = repos[target]
+
+    driver_kind = repo.get("driver")
+    if not driver_kind:
+        raise base_repo.UnableLoadDriverError(
+            f"Driver not specified for repository {target}"
+        )
+
+    driver_class = utils.load_from_entry_point(c.EP_REPO_DRIVERS, driver_kind)
+    params: dict = dict(repo)
+    params.pop("driver", None)
+    params["name"] = target
+    return driver_class(**params)
 
 
 def load_repo_driver(
@@ -35,18 +88,12 @@ def load_repo_driver(
         return driver_class(name=target, **params)
 
     try:
-        gen_config, _ = utils.get_exordos_config(
-            project_dir, exordos_cfg_file, exordosctl_cfg_file
-        )
+        gen_config, _ = utils.get_exordos_config(project_dir, exordos_cfg_file)
     except FileNotFoundError:
-        raise base_repo.UnableLoadDriverError(
-            f"exordos configuration file {exordos_cfg_file} not found in {project_dir}"
-        )
+        return load_repo_driver_from_settings(exordosctl_cfg_file, target)
 
     if not gen_config or "push" not in gen_config or not gen_config["push"]:
-        raise base_repo.UnableLoadDriverError(
-            "No push section found in the configuration"
-        )
+        return load_repo_driver_from_settings(exordosctl_cfg_file, target)
 
     pushes = gen_config["push"]
 
@@ -76,3 +123,235 @@ def load_repo_driver(
     driver: base_repo.AbstractRepoDriver = driver_class(name=target, **push)
 
     return driver
+
+
+def do_push(
+    repo_driver: base_repo.AbstractRepoDriver,
+    element_dir: pathlib.Path,
+    force: bool,
+    latest: bool,
+) -> None:
+    """Push every element found in a local build output dir to a repo driver.
+
+    Shared by `push_cmd` and `deploy_cmd` so both go through the exact same
+    push logic.
+    """
+    # Every build creates a local repo with built elements into it.
+    build_repo = repo_fs.FSRepoDriver(element_dir)
+    build_repo_dir = pathlib.Path(build_repo.elements_path)
+
+    with open(build_repo_dir / "inventory.json") as f:
+        repo_inventory = json.load(f)
+        repo_elements = repo_inventory["elements"]
+
+    for e_name in repo_elements:
+        # FIXME(akremenetsky): In the build repo only single version is available
+        e_version = tuple(repo_elements[e_name].keys())[0]
+        e_dir = build_repo_dir / e_name / e_version
+        e_inventory = base_builder.ElementInventory.from_dict(
+            repo_elements[e_name][e_version]
+        )
+        e_inventory = e_inventory.replace_with_abspath(e_dir)
+
+        try:
+            with rich_status.Status("Push the element to the repo...", spinner="dots"):
+                repo_driver.push(e_inventory, latest=latest)
+        except base_repo.ElementAlreadyExistsError:
+            if force:
+                repo_driver.remove(e_inventory)
+                with rich_status.Status(
+                    "Push the element to the repo...", spinner="dots"
+                ):
+                    repo_driver.push(e_inventory, latest=latest)
+                    continue
+
+            click.secho(
+                f"Element {e_inventory.name} version "
+                f"{e_inventory.version} already exists.",
+                fg="red",
+            )
+
+
+def do_upload(
+    client: tp.Any,
+    repository: str,
+    manifest: pathlib.Path,
+) -> None:
+    """Upload an element manifest to a repository via the API.
+
+    Shared logic for `repository_upload_cmd` so the upload can be reused
+    from other commands (e.g. `deploy`).
+    """
+    if not manifest.exists():
+        raise click.ClickException(f"Manifest file {manifest} does not exist")
+
+    entity_uuid = base_client._get_entity_uuid(
+        client, c.REPOSITORY_COLLECTION, repository
+    )
+
+    manifest_data = utils.load_yaml(str(manifest))
+    if not isinstance(manifest_data, dict):
+        raise click.ClickException("Manifest file must be a valid YAML dictionary")
+    name = manifest_data.get("name")
+    version = manifest_data.get("version")
+    description = manifest_data.get("description", "")
+
+    if not name:
+        raise click.ClickException("Manifest must contain 'name' field")
+    if not version:
+        raise click.ClickException("Manifest must contain 'version' field")
+
+    base_client.action_entity(
+        client,
+        c.REPOSITORY_COLLECTION,
+        "upload",
+        entity_uuid,
+        element_name=name,
+        element_version=version,
+        manifest=manifest_data,
+        description=description,
+    )
+    click.echo(
+        f"Element {click.style(f'{name}:{version}', fg='green')} was uploaded "
+        f"successfully to repository {click.style(repository, fg='green')}"
+    )
+
+
+def extract_repository_uuid(element: dict[str, tp.Any]) -> str:
+    """Extract repository UUID from a repository element."""
+    repo_ref = element.get("repository")
+    if not repo_ref or not isinstance(repo_ref, str):
+        return ""
+    return repo_ref.rstrip("/").split("/")[-1]
+
+
+def wait_for_repo_element(
+    client: tp.Any,
+    repository_uuid: str,
+    name: str,
+    version: str,
+    status: str | list[str],
+    timeout: float,
+) -> dict[str, tp.Any]:
+    """Wait for a repository element with the given name and version to appear."""
+    deadline = time.monotonic() + timeout
+    status = {status} if isinstance(status, str) else set(status)
+
+    while True:
+        elements = base_client.list_entities(
+            client, c.REPOSITORY_ELEMENT_COLLECTION, name=name, version=version
+        )
+        for element in elements:
+            if (
+                extract_repository_uuid(element) == str(repository_uuid)
+                and element.get("status") in status
+            ):
+                return element
+
+        if time.monotonic() > deadline:
+            raise click.ClickException(
+                f"Timed out waiting for element '{name}' ({version}) to become "
+                f"{status} in the repository catalog. Check `exordos repo show "
+                f"{repository_uuid}` for sync errors."
+            )
+        time.sleep(POLL_INTERVAL)
+
+
+def wait_for_element_active(
+    client: tp.Any,
+    name: str,
+    version: str,
+    timeout: float,
+    stable_checks: int = 1,
+) -> None:
+    """Wait for an element to reach ACTIVE status.
+
+    The backend may briefly flip status ACTIVE -> IN_PROGRESS -> ACTIVE.
+    ``stable_checks`` requires the status to be ACTIVE for that many
+    consecutive polls before returning.  Any non-ACTIVE status resets
+    the counter.
+    """
+    deadline = time.monotonic() + timeout
+    active_streak = 0
+    while True:
+        elements = base_client.list_entities(
+            client, c.ELEMENT_COLLECTION, name=name, version=version
+        )
+        if elements:
+            status = elements[0].get("status")
+            if status == "ACTIVE":
+                active_streak += 1
+                if active_streak >= stable_checks:
+                    return
+            else:
+                active_streak = 0
+                if status == "ERROR":
+                    raise click.ClickException(
+                        f"Element '{name}' failed to install (status ERROR)"
+                    )
+
+        if time.monotonic() > deadline:
+            raise click.ClickException(
+                f"Timed out waiting for element '{name}' to become ACTIVE"
+            )
+        time.sleep(POLL_INTERVAL)
+
+
+def find_repository(client: tp.Any, name: str) -> dict[str, tp.Any] | None:
+    filters: dict[str, tp.Any] = {"name": name}
+    entities = base_client.list_entities(client, c.REPOSITORY_COLLECTION, **filters)
+    if not entities:
+        return None
+    if len(entities) > 1:
+        raise click.ClickException(
+            f"Multiple repositories found with name '{name}'. Please clean "
+            "them up manually (`exordos repo list` / `exordos repo delete`) "
+            "before deploying."
+        )
+    return entities[0]
+
+
+def ensure_repository(
+    client: tp.Any,
+    name: str,
+    driver_spec: dict[str, tp.Any],
+    project_id: sys_uuid.UUID,
+    priority: int,
+    sync_mode: str,
+) -> dict[str, tp.Any]:
+    """Point the well-known dev repository at `driver_spec`, creating it if needed.
+
+    A single stable repository is reused across deploys (rather than
+    creating/deleting an ephemeral one each time) so an already-installed
+    element's provenance never depends on a repository that no longer
+    exists.
+    """
+    existing = find_repository(client, name)
+
+    if existing is not None:
+        return base_client.update_entity(
+            client,
+            c.REPOSITORY_COLLECTION,
+            existing["uuid"],
+            {
+                "driver_spec": driver_spec,
+                "priority": priority,
+                "sync_mode": sync_mode,
+                "refresh_rate": 31536000,
+            },
+        )
+
+    return base_client.add_entity(
+        client,
+        c.REPOSITORY_COLLECTION,
+        {
+            "uuid": str(sys_uuid.uuid4()),
+            "project_id": str(project_id),
+            "name": name,
+            "description": "Managed by `exordos deploy`",
+            "priority": priority,
+            "refresh_rate": 31536000,
+            "sync_mode": sync_mode,
+            "driver_spec": driver_spec,
+        },
+    )

--- a/exordos/tests/functional/cli/test_cli.py
+++ b/exordos/tests/functional/cli/test_cli.py
@@ -105,6 +105,38 @@ class TestCli:
             assert result.exit_code == 0
             assert f"realm '{new_realm}' set" in result.output
 
+    def test_set_realm_with_local_and_meta(self, cli_runner, cli_config_data):
+        new_realm = "test-realm-meta"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            settings_config.save_config(cli_config_data, f.name)
+            result = cli_runner.invoke(
+                cli.exordos,
+                [
+                    "--config",
+                    f.name,
+                    "settings",
+                    "set-realm",
+                    new_realm,
+                    "--endpoint",
+                    "http://example.com",
+                    "--local",
+                    "--meta",
+                    "cidr=10.20.0.0/22",
+                    "--meta",
+                    "region=eu",
+                ],
+            )
+            assert result.exit_code == 0
+            assert f"realm '{new_realm}' set" in result.output
+
+            saved = settings_config.load_config(
+                get_current_context(silent=True), f.name
+            )
+            realm_data = saved["realms"][new_realm]
+            assert realm_data["local"] is True
+            assert realm_data["meta"]["cidr"] == "10.20.0.0/22"
+            assert realm_data["meta"]["region"] == "eu"
+
     def test_delete_realm_command(self, cli_runner, cli_config_data):
         new_realm = "test-realm"
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -208,3 +240,69 @@ class TestCli:
             )
             assert result.exit_code == 0
             assert "Context 'new-new-context' deleted" in result.output
+
+    def test_repo_commands(self, cli_runner):
+        result = cli_runner.invoke(cli.exordos, ["repo", "--help"])
+        assert result.exit_code == 0
+        assert "add" in result.output
+        assert "update" in result.output
+
+    def test_repo_elements_commands(self, cli_runner):
+        result = cli_runner.invoke(cli.exordos, ["repo", "elements", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.output
+        assert "show" in result.output
+
+    def test_list_repos_command(self, cli_runner):
+        result = cli_runner.invoke(
+            cli.exordos, self._def_args + ["settings", "repo", "list"]
+        )
+        assert result.exit_code == 0
+        assert "default-repo" in result.output
+        assert "another-repo" in result.output
+        # password is masked by default
+        assert "admin" not in result.output
+
+    def test_list_repos_show_sensitive(self, cli_runner):
+        result = cli_runner.invoke(
+            cli.exordos,
+            self._def_args + ["settings", "repo", "list", "--show-sensitive"],
+        )
+        assert result.exit_code == 0
+        assert "admin" in result.output
+
+    def test_add_repo_command(self, cli_runner, cli_config_data):
+        new_repo = "test-repo"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            settings_config.save_config(cli_config_data, f.name)
+            result = cli_runner.invoke(
+                cli.exordos,
+                [
+                    "--config",
+                    f.name,
+                    "settings",
+                    "repo",
+                    "add",
+                    new_repo,
+                    "--driver",
+                    "nginx",
+                    "--url",
+                    "http://example.com:8080/",
+                    "--username",
+                    "user",
+                    "--password",
+                    "pass",
+                ],
+            )
+            assert result.exit_code == 0
+            assert f"repo '{new_repo}' set" in result.output
+
+    def test_delete_repo_command(self, cli_runner, cli_config_data):
+        repo = "another-repo"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            settings_config.save_config(cli_config_data, f.name)
+            result = cli_runner.invoke(
+                cli.exordos, ["--config", f.name, "settings", "repo", "delete", repo]
+            )
+            assert result.exit_code == 0
+            assert f"repo '{repo}' deleted" in result.output

--- a/exordos/tests/functional/utils/exordosctl.yaml
+++ b/exordos/tests/functional/utils/exordosctl.yaml
@@ -28,3 +28,11 @@ realms:
         password: slavoniy_password
     current-context: default
 current-realm: default-realm
+repositories:
+  default-repo:
+    driver: nginx
+    url: http://10.20.0.2:8080/repo/
+    auth: [admin, admin]
+  another-repo:
+    driver: nginx
+    url: http://10.30.0.2:8080/repo/

--- a/exordos/tests/unit/test_builder.py
+++ b/exordos/tests/unit/test_builder.py
@@ -17,9 +17,11 @@ import json
 import pathlib
 import typing as tp
 from unittest.mock import MagicMock
+import uuid as sys_uuid
 
 from exordos.builder import base
 from exordos.builder.builder import SimpleBuilder
+from exordos.builder.builder import _urn_image
 from exordos.logger import DummyLogger
 
 
@@ -312,3 +314,222 @@ class TestBuilder:
         image_names = [pathlib.Path(p).name for p in images]
         assert any(n.endswith(".raw") for n in image_names)
         assert any(n.endswith(".raw.gz") for n in image_names)
+
+
+class TestImageNames:
+    """Tests for the Image.names property."""
+
+    def test_names_none_returns_empty(self) -> None:
+        img = base.Image(script="/tmp/install.sh", formats=["raw"], name=None)
+        assert img.names == tuple()
+
+    def test_names_single_raw(self) -> None:
+        img = base.Image(script="/tmp/install.sh", formats=["raw"], name="foo")
+        assert img.names == ("foo.raw",)
+
+    def test_names_qcow2(self) -> None:
+        img = base.Image(script="/tmp/install.sh", formats=["qcow2"], name="foo")
+        assert img.names == ("foo.qcow2",)
+
+    def test_names_gz_appends_raw(self) -> None:
+        """Compression formats are applied to raw images."""
+        img = base.Image(script="/tmp/install.sh", formats=["gz"], name="foo")
+        assert img.names == ("foo.raw.gz",)
+
+    def test_names_zst_appends_raw(self) -> None:
+        img = base.Image(script="/tmp/install.sh", formats=["zst"], name="foo")
+        assert img.names == ("foo.raw.zst",)
+
+    def test_names_multi_format(self) -> None:
+        img = base.Image(
+            script="/tmp/install.sh", formats=["raw", "gz", "qcow2"], name="bar"
+        )
+        assert img.names == ("bar.raw", "bar.raw.gz", "bar.qcow2")
+
+
+class TestElementInventoryIndex:
+    """Tests for ElementInventory index computation."""
+
+    def test_compute_index_entry_is_deterministic(self) -> None:
+        """Same inputs always produce the same UUID."""
+        path = pathlib.Path("foo.raw")
+        first = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", path
+        )
+        second = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", path
+        )
+        assert first == second
+        # Result is a valid UUID string
+        sys_uuid.UUID(first)
+
+    def test_compute_index_entry_differs_per_category(self) -> None:
+        path = pathlib.Path("foo.raw")
+        images_key = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", path
+        )
+        manifests_key = base.ElementInventory.compute_index_entry(
+            "manifests", "elem", "1.0.0", path
+        )
+        assert images_key != manifests_key
+
+    def test_compute_index_entry_differs_per_path(self) -> None:
+        a = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", pathlib.Path("a.raw")
+        )
+        b = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", pathlib.Path("b.raw")
+        )
+        assert a != b
+
+    def test_compute_index_entry_differs_per_version(self) -> None:
+        a = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", pathlib.Path("foo.raw")
+        )
+        b = base.ElementInventory.compute_index_entry(
+            "images", "elem", "2.0.0", pathlib.Path("foo.raw")
+        )
+        assert a != b
+
+    def test_compute_index_builds_all_categories(self) -> None:
+        inv = base.ElementInventory(
+            name="elem",
+            version="1.0.0",
+            images=[pathlib.Path("foo.raw")],
+            manifests=[pathlib.Path("elem.yaml")],
+            configs=[],
+            templates=[],
+            artifacts=[],
+        )
+        index = inv.compute_index()
+        assert set(index.keys()) == set(base.ElementInventory.categories())
+        assert len(index["images"]) == 1
+        assert len(index["manifests"]) == 1
+        assert (
+            index["images"][
+                base.ElementInventory.compute_index_entry(
+                    "images", "elem", "1.0.0", pathlib.Path("foo.raw")
+                )
+            ]
+            == "foo.raw"
+        )
+        assert (
+            index["manifests"][
+                base.ElementInventory.compute_index_entry(
+                    "manifests", "elem", "1.0.0", pathlib.Path("elem.yaml")
+                )
+            ]
+            == "elem.yaml"
+        )
+
+    def test_post_init_populates_index(self) -> None:
+        """Index is computed automatically on construction."""
+        inv = base.ElementInventory(
+            name="elem",
+            version="1.0.0",
+            images=[pathlib.Path("foo.raw")],
+        )
+        assert inv.index
+        assert "images" in inv.index
+        assert len(inv.index["images"]) == 1
+
+    def test_to_dict_includes_index(self) -> None:
+        inv = base.ElementInventory(
+            name="elem",
+            version="1.0.0",
+            images=[pathlib.Path("foo.raw")],
+        )
+        data = inv.to_dict()
+        assert data["name"] == "elem"
+        assert data["version"] == "1.0.0"
+        assert data["index"] == inv.index
+        assert data["images"] == ["foo.raw"]
+
+
+class TestBuildImagesDict:
+    """Tests for SimpleBuilder._build_images_dict and _urn_image."""
+
+    def _builder(self, tmp_path) -> SimpleBuilder:
+        return SimpleBuilder(
+            exordos_dir=tmp_path,
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=tmp_path / "out",
+        )
+
+    def test_urn_image_format(self) -> None:
+        assert _urn_image("abc-123") == "urn:images:abc-123"
+        assert _urn_image(sys_uuid.UUID(int=0)) == f"urn:images:{sys_uuid.UUID(int=0)}"
+
+    def test_single_image_includes_no_ext_key(self, tmp_path) -> None:
+        builder = self._builder(tmp_path)
+        img = base.Image(script="/tmp/install.sh", formats=["qcow2"], name="foo")
+        result = builder._build_images_dict([img], "elem", "1.0.0")
+        # Both the bare name and the name with extension are present
+        assert "foo" in result
+        assert "foo_qcow2" in result
+        # Both point to a valid urn:images:<uuid>
+        for v in result.values():
+            assert v.startswith("urn:images:")
+            sys_uuid.UUID(v[len("urn:images:") :])
+
+    def test_single_zst_image_no_ext_key(self, tmp_path) -> None:
+        builder = self._builder(tmp_path)
+        img = base.Image(script="/tmp/install.sh", formats=["zst"], name="bar")
+        result = builder._build_images_dict([img], "elem", "1.0.0")
+        assert "bar" in result
+        assert "bar_raw_zst" in result
+
+    def test_multi_image_zst_gets_no_ext_key(self, tmp_path) -> None:
+        """When a ZST image is present among many, it gets the bare-name key."""
+        builder = self._builder(tmp_path)
+        img = base.Image(
+            script="/tmp/install.sh", formats=["raw.zst", "qcow2"], name="baz"
+        )
+        # Image.names for zst -> "baz.raw.zst", qcow2 -> "baz.qcow2"
+        result = builder._build_images_dict([img], "elem", "1.0.0")
+        assert "baz" in result  # bare name maps to the zst image
+        assert "baz_raw_zst" in result
+        assert "baz_qcow2" in result
+        # The bare name and the zst-with-ext key point to the same URI
+        assert result["baz"] == result["baz_raw_zst"]
+
+    def test_multi_image_no_zst_no_bare_key(self, tmp_path) -> None:
+        """Without a ZST image, no bare-name key is added."""
+        builder = self._builder(tmp_path)
+        img = base.Image(script="/tmp/install.sh", formats=["raw", "qcow2"], name="qux")
+        result = builder._build_images_dict([img], "elem", "1.0.0")
+        assert "qux" not in result
+        assert "qux_raw" in result
+        assert "qux_qcow2" in result
+
+    def test_multiple_zst_images_all_present(self, tmp_path) -> None:
+        """All ZST images are kept when several are present; only the first
+        gets the bare-name key."""
+        builder = self._builder(tmp_path)
+        img1 = base.Image(script="/tmp/install.sh", formats=["zst"], name="foo")
+        img2 = base.Image(script="/tmp/install.sh", formats=["zst"], name="bar")
+        result = builder._build_images_dict([img1, img2], "elem", "1.0.0")
+        # Both zst images are present with their full-name keys
+        assert "foo_raw_zst" in result
+        assert "bar_raw_zst" in result
+        # Only the first zst image gets the bare-name key
+        assert "foo" in result
+        assert result["foo"] == result["foo_raw_zst"]
+        assert "bar" not in result
+
+    def test_index_matches_compute_index_entry(self, tmp_path) -> None:
+        """The URI uuid matches compute_index_entry for the image path."""
+        builder = self._builder(tmp_path)
+        img = base.Image(script="/tmp/install.sh", formats=["raw"], name="foo")
+        result = builder._build_images_dict([img], "elem", "1.0.0")
+        expected_uuid = base.ElementInventory.compute_index_entry(
+            "images", "elem", "1.0.0", pathlib.Path("foo.raw")
+        )
+        assert result["foo_raw"] == _urn_image(expected_uuid)
+
+    def test_empty_images(self, tmp_path) -> None:
+        builder = self._builder(tmp_path)
+        assert builder._build_images_dict([], "elem", "1.0.0") == {}

--- a/exordos/tests/unit/test_deploy_cli.py
+++ b/exordos/tests/unit/test_deploy_cli.py
@@ -1,0 +1,442 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import contextlib
+import ipaddress
+import json
+import pathlib
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import uuid as sys_uuid
+
+import click
+from click.testing import CliRunner
+import pytest
+
+from exordos.cmd.deploy import commands as deploy_commands
+from exordos.common.cmd_context import ContextObject
+from exordos.repo import utils as repo_utils
+
+
+def _make_build_output(tmp_path: pathlib.Path) -> pathlib.Path:
+    elements_dir = tmp_path / "output" / "exordos-elements"
+    elements_dir.mkdir(parents=True)
+    inventory = {
+        "elements": {
+            "foo": {
+                "1.0.0": {
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "images": [],
+                    "manifests": [],
+                    "configs": [],
+                    "templates": [],
+                    "artifacts": [],
+                }
+            }
+        }
+    }
+    (elements_dir / "inventory.json").write_text(json.dumps(inventory))
+    return tmp_path / "output"
+
+
+def _obj() -> ContextObject:
+    return ContextObject(
+        auth_data={"endpoint": "http://10.20.0.2:11010"},
+        cfg_path=None,
+        developer_key_path=None,
+        cfg={},
+        need_update=None,
+    )
+
+
+class TestLoadBuildInventory:
+    def test_missing_build_raises(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(click.ClickException, match="Run `exordos build` first"):
+            deploy_commands._load_build_inventory(tmp_path / "output")
+
+    def test_loads_inventory(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+        result = deploy_commands._load_build_inventory(output_dir)
+        assert list(result.keys()) == ["foo"]
+        assert list(result["foo"].keys()) == ["1.0.0"]
+
+
+class TestIsLocalRealm:
+    def test_no_current_realm_returns_false(self) -> None:
+        assert deploy_commands._is_local_realm({}) is False
+
+    def test_no_realm_config_returns_false(self) -> None:
+        assert deploy_commands._is_local_realm({"current-realm": "foo"}) is False
+
+    def test_not_local_returns_false(self) -> None:
+        config = {"current-realm": "foo", "realms": {"foo": {"local": False}}}
+        assert deploy_commands._is_local_realm(config) is False
+
+    def test_local_without_cidr_returns_true(self) -> None:
+        config = {"current-realm": "foo", "realms": {"foo": {"local": True}}}
+        assert deploy_commands._is_local_realm(config) is True
+
+    def test_local_with_cidr_and_matching_ip_returns_true(self) -> None:
+        config = {
+            "current-realm": "foo",
+            "realms": {"foo": {"local": True, "meta": {"cidr": "10.20.0.0/22"}}},
+        }
+        with patch.object(
+            deploy_commands,
+            "_find_local_ip_in_network",
+            return_value=ipaddress.IPv4Address("10.20.0.5"),
+        ):
+            assert deploy_commands._is_local_realm(config) is True
+
+    def test_local_with_cidr_but_no_matching_ip_returns_false(self) -> None:
+        config = {
+            "current-realm": "foo",
+            "realms": {"foo": {"local": True, "meta": {"cidr": "10.20.0.0/22"}}},
+        }
+        with patch.object(
+            deploy_commands, "_find_local_ip_in_network", return_value=None
+        ):
+            assert deploy_commands._is_local_realm(config) is False
+
+
+class TestGetLocalHostBind:
+    def test_no_realm_raises(self) -> None:
+        with pytest.raises(click.ClickException, match="Unable to determine"):
+            deploy_commands._get_local_host_bind({})
+
+    def test_realm_with_cidr_and_matching_ip_returns_ip(self) -> None:
+        config = {
+            "current-realm": "foo",
+            "realms": {"foo": {"meta": {"cidr": "10.20.0.0/22"}}},
+        }
+        with patch.object(
+            deploy_commands,
+            "_find_local_ip_in_network",
+            return_value=ipaddress.IPv4Address("10.20.0.5"),
+        ):
+            assert deploy_commands._get_local_host_bind(config) == "10.20.0.5"
+
+    def test_realm_with_cidr_but_no_matching_ip_raises(self) -> None:
+        config = {
+            "current-realm": "foo",
+            "realms": {"foo": {"meta": {"cidr": "10.20.0.0/22"}}},
+        }
+        with patch.object(
+            deploy_commands, "_find_local_ip_in_network", return_value=None
+        ):
+            with pytest.raises(click.ClickException, match="Unable to determine"):
+                deploy_commands._get_local_host_bind(config)
+
+
+class TestFindOrUpdateRepository:
+    def test_creates_when_missing_and_project_id_given(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = []
+        project_id = sys_uuid.uuid4()
+
+        with patch.object(
+            deploy_commands.base_client,
+            "add_entity",
+            return_value={"uuid": "new"},
+        ) as add_entity:
+            result = repo_utils.ensure_repository(
+                client,
+                "exordos-dev-repo",
+                {"kind": "nginx", "url": "http://host:1/exordos-elements/"},
+                project_id,
+                4096,
+                sync_mode="copy",
+            )
+
+        assert result == {"uuid": "new"}
+        _, _, data = add_entity.call_args[0]
+        assert data["project_id"] == str(project_id)
+        assert data["driver_spec"] == {
+            "kind": "nginx",
+            "url": "http://host:1/exordos-elements/",
+        }
+        assert data["sync_mode"] == "copy"
+
+    def test_creates_when_missing_with_default_project_id(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = []
+        project_id = sys_uuid.UUID(int=0)
+
+        with patch.object(
+            deploy_commands.base_client,
+            "add_entity",
+            return_value={"uuid": "new"},
+        ) as add_entity:
+            result = repo_utils.ensure_repository(
+                client,
+                "exordos-dev-repo",
+                {"kind": "nginx", "url": "http://host/"},
+                project_id,
+                4096,
+                sync_mode="copy",
+            )
+
+        assert result == {"uuid": "new"}
+        _, _, data = add_entity.call_args[0]
+        assert data["project_id"] == str(project_id)
+
+    def test_updates_existing(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"uuid": "existing"}]
+
+        with patch.object(
+            deploy_commands.base_client,
+            "update_entity",
+            return_value={"uuid": "existing"},
+        ) as update_entity:
+            result = repo_utils.ensure_repository(
+                client,
+                "exordos-dev-repo",
+                {"kind": "nginx", "url": "http://host/"},
+                None,
+                100,
+                sync_mode="lazy",
+            )
+
+        assert result == {"uuid": "existing"}
+        args, _ = update_entity.call_args
+        assert args[2] == "existing"
+        assert args[3]["priority"] == 100
+        assert args[3]["sync_mode"] == "lazy"
+
+    def test_multiple_matches_raises(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"uuid": "a"}, {"uuid": "b"}]
+        with pytest.raises(click.ClickException, match="Multiple repositories"):
+            repo_utils.ensure_repository(
+                client,
+                "exordos-dev-repo",
+                {"kind": "nginx", "url": "http://host/"},
+                None,
+                100,
+                sync_mode="lazy",
+            )
+
+
+class TestWaitForRepoElement:
+    def test_returns_matching_element(self) -> None:
+        repo_uuid = str(sys_uuid.uuid4())
+        client = MagicMock()
+        client.filter.return_value = [
+            {
+                "name": "foo",
+                "version": "1.0.0",
+                "uuid": "e1",
+                "status": "AVAILABLE",
+                "repository": f"/v1/repo/repositories/{repo_uuid}",
+            }
+        ]
+        result = repo_utils.wait_for_repo_element(
+            client, repo_uuid, "foo", "1.0.0", "AVAILABLE", timeout=5
+        )
+        assert result["uuid"] == "e1"
+
+    def test_times_out_when_not_found(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = []
+        with pytest.raises(click.ClickException, match="Timed out"):
+            repo_utils.wait_for_repo_element(
+                client, "repo-uuid", "foo", "1.0.0", "AVAILABLE", timeout=-1
+            )
+
+
+class TestWaitForElementActive:
+    def test_returns_when_active(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"name": "foo", "status": "ACTIVE"}]
+        repo_utils.wait_for_element_active(client, "foo", "1.0.0", timeout=5)
+
+    def test_raises_on_error_status(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"name": "foo", "status": "ERROR"}]
+        with pytest.raises(click.ClickException, match="failed to install"):
+            repo_utils.wait_for_element_active(client, "foo", "1.0.0", timeout=5)
+
+    def test_times_out(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"name": "foo", "status": "IN_PROGRESS"}]
+        with pytest.raises(click.ClickException, match="Timed out"):
+            repo_utils.wait_for_element_active(client, "foo", "1.0.0", timeout=-1)
+
+    def test_stable_checks_returns_after_consecutive_active(self) -> None:
+        client = MagicMock()
+        client.filter.return_value = [{"name": "foo", "status": "ACTIVE"}]
+        with patch("exordos.repo.utils.time.sleep"):
+            repo_utils.wait_for_element_active(
+                client, "foo", "1.0.0", timeout=30, stable_checks=3
+            )
+        assert client.filter.call_count == 3
+
+    def test_stable_checks_resets_on_non_active(self) -> None:
+        statuses = [
+            {"name": "foo", "status": "ACTIVE"},
+            {"name": "foo", "status": "ACTIVE"},
+            {"name": "foo", "status": "IN_PROGRESS"},
+            {"name": "foo", "status": "ACTIVE"},
+            {"name": "foo", "status": "ACTIVE"},
+            {"name": "foo", "status": "ACTIVE"},
+        ]
+        client = MagicMock()
+        client.filter.side_effect = [
+            [{"name": "foo", "status": s["status"]}] for s in statuses
+        ]
+        with patch("exordos.repo.utils.time.sleep"):
+            repo_utils.wait_for_element_active(
+                client, "foo", "1.0.0", timeout=30, stable_checks=3
+            )
+        assert client.filter.call_count == 6
+
+
+class TestDeployCmdPushMode:
+    def test_rejects_non_http_driver(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+        fake_driver = MagicMock()
+        fake_driver.elements_path = str(tmp_path / "some" / "local" / "path")
+
+        runner = CliRunner()
+        with (
+            patch.object(
+                deploy_commands.base_client,
+                "get_user_api_client",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                deploy_commands.repo_utils,
+                "load_repo_driver_from_settings",
+                return_value=fake_driver,
+            ),
+            patch.object(deploy_commands.repo_utils, "do_push") as do_push_mock,
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd,
+                ["-e", str(output_dir), "-t", "my-target"],
+                obj=_obj(),
+            )
+
+        assert result.exit_code != 0
+        assert "network-reachable" in result.output
+        do_push_mock.assert_called_once()
+
+    def test_pushes_then_deploys_when_http(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+        fake_driver = MagicMock()
+        fake_driver.elements_path = "http://repo.example.com/exordos-elements"
+
+        runner = CliRunner()
+        with (
+            patch.object(
+                deploy_commands.base_client,
+                "get_user_api_client",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                deploy_commands.repo_utils,
+                "load_repo_driver_from_settings",
+                return_value=fake_driver,
+            ),
+            patch.object(deploy_commands.repo_utils, "do_push") as do_push_mock,
+            patch.object(
+                deploy_commands.repo_utils,
+                "ensure_repository",
+                return_value={"uuid": "repo-uuid"},
+            ) as find_repo_mock,
+            patch.object(deploy_commands, "_deploy_element") as deploy_elements_mock,
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd,
+                ["-e", str(output_dir), "-t", "my-target"],
+                obj=_obj(),
+            )
+
+        assert result.exit_code == 0, result.output
+        do_push_mock.assert_called_once()
+        find_repo_mock.assert_called_once()
+        assert find_repo_mock.call_args[0][2] == {
+            "kind": "nginx",
+            "url": "http://repo.example.com/exordos-elements/",
+        }
+        assert find_repo_mock.call_args[1]["sync_mode"] == "lazy"
+        deploy_elements_mock.assert_called_once()
+
+
+class TestDeployCmdLocalMode:
+    def test_errors_without_local_realm(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+
+        runner = CliRunner()
+        with patch.object(
+            deploy_commands.base_client,
+            "get_user_api_client",
+            return_value=MagicMock(),
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd, ["-e", str(output_dir)], obj=_obj()
+            )
+
+        assert result.exit_code != 0
+        assert "not a local realm" in result.output
+
+    def test_local_mode_deploys(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+
+        @contextlib.contextmanager
+        def fake_serve_directory(path, host, port=0):
+            yield f"http://{host}:9999/"
+
+        runner = CliRunner()
+        with (
+            patch.object(
+                deploy_commands.base_client,
+                "get_user_api_client",
+                return_value=MagicMock(),
+            ),
+            patch.object(deploy_commands, "_is_local_realm", return_value=True),
+            patch.object(
+                deploy_commands, "_get_local_host_bind", return_value="192.168.1.5"
+            ),
+            patch.object(
+                deploy_commands.local_server,
+                "serve_directory",
+                side_effect=fake_serve_directory,
+            ),
+            patch.object(
+                deploy_commands.repo_utils,
+                "ensure_repository",
+                return_value={"uuid": "repo-uuid"},
+            ) as find_repo_mock,
+            patch.object(deploy_commands, "_deploy_element") as deploy_elements_mock,
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd,
+                ["-e", str(output_dir)],
+                obj=_obj(),
+            )
+
+        assert result.exit_code == 0, result.output
+        find_repo_mock.assert_called_once()
+        assert find_repo_mock.call_args[0][2] == {
+            "kind": "nginx",
+            "url": "http://192.168.1.5:9999/exordos-elements/",
+        }
+        assert find_repo_mock.call_args[1]["sync_mode"] == "copy"
+        deploy_elements_mock.assert_called_once()

--- a/exordos/tests/unit/test_repo_cli.py
+++ b/exordos/tests/unit/test_repo_cli.py
@@ -1,0 +1,348 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest.mock import MagicMock
+import uuid as sys_uuid
+
+import click
+import pytest
+
+from exordos import utils
+from exordos.cmd.em.elements import commands as em_elements
+from exordos.cmd.repo import commands as repo_commands
+from exordos.cmd.repo.elements import commands as repo_elements
+
+
+class TestUrn:
+    """Tests for exordos.utils.urn."""
+
+    def test_urn_format(self) -> None:
+        assert utils.urn("images", "abc-123") == "urn:images:abc-123"
+
+    def test_urn_namespace(self) -> None:
+        assert utils.urn("foo", "bar") == "urn:foo:bar"
+
+
+class TestBuildDriverSpec:
+    """Tests for exordos.cmd.repo.commands._build_driver_spec."""
+
+    def test_none_url_returns_none(self) -> None:
+        assert repo_commands._build_driver_spec(None, "u", "p") is None
+
+    def test_url_only(self) -> None:
+        spec = repo_commands._build_driver_spec("https://example.com/", None, None)
+        assert spec == {"kind": "nginx", "url": "https://example.com/"}
+
+    def test_url_with_username(self) -> None:
+        spec = repo_commands._build_driver_spec("https://example.com/", "bob", None)
+        assert spec == {
+            "kind": "nginx",
+            "url": "https://example.com/",
+            "username": "bob",
+        }
+
+    def test_url_with_password(self) -> None:
+        spec = repo_commands._build_driver_spec("https://example.com/", None, "secret")
+        assert spec == {
+            "kind": "nginx",
+            "url": "https://example.com/",
+            "password": "secret",
+        }
+
+    def test_url_with_credentials(self) -> None:
+        spec = repo_commands._build_driver_spec("https://example.com/", "bob", "secret")
+        assert spec == {
+            "kind": "nginx",
+            "url": "https://example.com/",
+            "username": "bob",
+            "password": "secret",
+        }
+
+
+class TestExtractRepositoryUuid:
+    """Tests for exordos.cmd.repo.elements.commands._extract_repository_uuid."""
+
+    def test_empty_when_no_repository(self) -> None:
+        assert repo_elements._extract_repository_uuid({}) == ""
+
+    def test_empty_when_repository_empty(self) -> None:
+        assert repo_elements._extract_repository_uuid({"repository": ""}) == ""
+
+    def test_extracts_uuid_from_ref(self) -> None:
+        u = "12345678-1234-1234-1234-123456789abc"
+        ref = f"/v1/repo/repositories/{u}"
+        result = repo_elements._extract_repository_uuid({"repository": ref})
+        assert result == str(sys_uuid.UUID(u))
+
+    def test_returns_raw_when_not_uuid(self) -> None:
+        # A non-UUID tail is returned as-is
+        result = repo_elements._extract_repository_uuid({"repository": "some-name"})
+        assert result == "some-name"
+
+
+class TestFilterAndSortElements:
+    """Tests for exordos.cmd.repo.elements.commands._filter_and_sort_elements."""
+
+    def _elem(self, name, version, status=None):
+        elem = {"name": name, "version": version, "uuid": str(sys_uuid.uuid4())}
+        if status is not None:
+            elem["status"] = status
+        return elem
+
+    def test_filters_dev_versions_by_default(self) -> None:
+        entities = [
+            self._elem("a", "1.0.0"),
+            self._elem("a", "1.0.0-dev+abc.12345678"),
+            self._elem("b", "2.0.0"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {})
+        versions = [e["version"] for e in result]
+        assert "1.0.0-dev+abc.12345678" not in versions
+        assert set(versions) == {"1.0.0", "2.0.0"}
+
+    def test_dev_flag_keeps_all(self) -> None:
+        entities = [
+            self._elem("a", "1.0.0"),
+            self._elem("a", "1.0.0-dev+abc.12345678"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {"dev": True})
+        assert len(result) == 2
+
+    def test_sorted_by_name_then_version(self) -> None:
+        entities = [
+            self._elem("b", "1.0.0"),
+            self._elem("a", "2.0.0"),
+            self._elem("a", "1.0.0"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {})
+        assert [(e["name"], e["version"]) for e in result] == [
+            ("a", "1.0.0"),
+            ("a", "2.0.0"),
+            ("b", "1.0.0"),
+        ]
+
+    def test_keeps_non_release_with_non_hidden_status(self) -> None:
+        entities = [
+            self._elem("a", "1.0.0-dev+abc", status="ERROR"),
+            self._elem("a", "1.0.0-dev+def", status="ACTIVE"),
+            self._elem("a", "1.0.0-dev+ghi", status="IN_PROGRESS"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {})
+        assert {e["version"] for e in result} == {
+            "1.0.0-dev+abc",
+            "1.0.0-dev+def",
+            "1.0.0-dev+ghi",
+        }
+
+    def test_filters_non_release_with_new_or_available_status(self) -> None:
+        entities = [
+            self._elem("a", "1.0.0-dev+abc", status="NEW"),
+            self._elem("a", "1.0.0-dev+def", status="AVAILABLE"),
+            self._elem("a", "1.0.0"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {})
+        assert [e["version"] for e in result] == ["1.0.0"]
+
+    def test_keeps_release_regardless_of_status(self) -> None:
+        entities = [
+            self._elem("a", "1.0.0", status="NEW"),
+            self._elem("a", "2.0.0", status="AVAILABLE"),
+        ]
+        result = repo_elements._filter_and_sort_elements(entities, {})
+        assert {e["version"] for e in result} == {"1.0.0", "2.0.0"}
+
+
+class TestGetSortKey:
+    """Tests for exordos.cmd.em.elements.commands._get_sort_key."""
+
+    def test_priority_from_repository_ref(self) -> None:
+        u = "12345678-1234-1234-1234-123456789abc"
+        element = {
+            "version": "1.0.0",
+            "repository": f"/v1/repo/repositories/{u}",
+        }
+        repo_priorities = {u: 100}
+        priority, version = em_elements._get_sort_key(element, repo_priorities)
+        assert priority == 100
+        assert str(version) == "1.0.0"
+
+    def test_default_priority_zero(self) -> None:
+        element = {"version": "2.0.0"}
+        priority, _ = em_elements._get_sort_key(element, {})
+        assert priority == 0
+
+    def test_unknown_repo_uuid_defaults_to_zero(self) -> None:
+        u = "12345678-1234-1234-1234-123456789abc"
+        element = {
+            "version": "1.0.0",
+            "repository": f"/v1/repo/repositories/{u}",
+        }
+        priority, _ = em_elements._get_sort_key(element, {})
+        assert priority == 0
+
+    def test_invalid_repository_ref_defaults_to_zero(self) -> None:
+        element = {"version": "1.0.0", "repository": "not-a-uuid"}
+        priority, _ = em_elements._get_sort_key(element, {})
+        assert priority == 0
+
+
+class TestSelectElementByName:
+    """Tests for exordos.cmd.em.elements.commands._select_element_by_name."""
+
+    def _client(self, elements, repositories=None):
+        client = MagicMock()
+
+        def fake_filter(collection, **filters):
+            if collection.endswith("/repositories/"):
+                return repositories or []
+            return elements
+
+        client.filter.side_effect = fake_filter
+        return client
+
+    def test_no_elements_raises(self) -> None:
+        client = self._client([])
+        with pytest.raises(click.ClickException, match="No elements found"):
+            em_elements._select_element_by_name(client, "foo", None)
+
+    def test_no_stable_versions_raises(self) -> None:
+        client = self._client(
+            [{"name": "foo", "version": "1.0.0-dev+abc.12345678", "uuid": "u"}]
+        )
+        with pytest.raises(click.ClickException, match="No stable versions"):
+            em_elements._select_element_by_name(client, "foo", None)
+
+    def test_selects_highest_version(self) -> None:
+        elements = [
+            {"name": "foo", "version": "1.0.0", "uuid": "u1", "repository": ""},
+            {"name": "foo", "version": "2.0.0", "uuid": "u2", "repository": ""},
+            {"name": "foo", "version": "1.5.0", "uuid": "u3", "repository": ""},
+        ]
+        client = self._client(elements)
+        selected = em_elements._select_element_by_name(client, "foo", None)
+        assert selected["uuid"] == "u2"
+
+    def test_selects_higher_priority_repo(self) -> None:
+        u_low = "11111111-1111-1111-1111-111111111111"
+        u_high = "22222222-2222-2222-2222-222222222222"
+        elements = [
+            {
+                "name": "foo",
+                "version": "1.0.0",
+                "uuid": "u1",
+                "repository": f"/v1/repo/repositories/{u_low}",
+            },
+            {
+                "name": "foo",
+                "version": "1.0.0",
+                "uuid": "u2",
+                "repository": f"/v1/repo/repositories/{u_high}",
+            },
+        ]
+        repositories = [
+            {"uuid": u_low, "priority": 10},
+            {"uuid": u_high, "priority": 100},
+        ]
+        client = self._client(elements, repositories)
+        selected = em_elements._select_element_by_name(client, "foo", None)
+        assert selected["uuid"] == "u2"
+
+    def test_version_filter_exact_match(self) -> None:
+        elements = [
+            {"name": "foo", "version": "1.0.0", "uuid": "u1", "repository": ""},
+            {"name": "foo", "version": "2.0.0", "uuid": "u2", "repository": ""},
+        ]
+        client = self._client(elements)
+        selected = em_elements._select_element_by_name(client, "foo", "1.0.0")
+        assert selected["uuid"] == "u1"
+
+    def test_version_filter_no_match_raises(self) -> None:
+        elements = [
+            {"name": "foo", "version": "1.0.0", "uuid": "u1", "repository": ""},
+        ]
+        client = self._client(elements)
+        with pytest.raises(click.ClickException, match="No elements found"):
+            em_elements._select_element_by_name(client, "foo", "9.9.9")
+
+    def test_version_filter_allows_dev(self) -> None:
+        """Explicit version filter allows selecting development versions."""
+        elements = [
+            {
+                "name": "foo",
+                "version": "1.0.0-dev+abc.12345678",
+                "uuid": "u1",
+                "repository": "",
+            },
+        ]
+        client = self._client(elements)
+        selected = em_elements._select_element_by_name(
+            client, "foo", "1.0.0-dev+abc.12345678"
+        )
+        assert selected["uuid"] == "u1"
+
+
+class TestSelectCurrentElementByName:
+    """Tests for exordos.cmd.em.elements.commands._select_current_element_by_name."""
+
+    def _client(self, elements):
+        client = MagicMock()
+        client.filter.return_value = elements
+        return client
+
+    def test_no_installed_raises(self) -> None:
+        client = self._client(
+            [{"name": "foo", "version": "1.0.0", "uuid": "u1", "status": "NEW"}]
+        )
+        with pytest.raises(click.ClickException, match="No installed element"):
+            em_elements._select_current_element_by_name(client, "foo")
+
+    def test_selects_active(self) -> None:
+        client = self._client(
+            [{"name": "foo", "version": "1.0.0", "uuid": "u1", "status": "ACTIVE"}]
+        )
+        selected = em_elements._select_current_element_by_name(client, "foo")
+        assert selected["uuid"] == "u1"
+
+    def test_selects_in_progress(self) -> None:
+        client = self._client(
+            [{"name": "foo", "version": "1.0.0", "uuid": "u1", "status": "IN_PROGRESS"}]
+        )
+        selected = em_elements._select_current_element_by_name(client, "foo")
+        assert selected["uuid"] == "u1"
+
+    def test_selects_by_installation_state(self) -> None:
+        client = self._client(
+            [
+                {
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "uuid": "u1",
+                    "status": "NEW",
+                    "installation_state": "INSTALLED",
+                }
+            ]
+        )
+        selected = em_elements._select_current_element_by_name(client, "foo")
+        assert selected["uuid"] == "u1"
+
+    def test_multiple_installed_raises(self) -> None:
+        client = self._client(
+            [
+                {"name": "foo", "version": "1.0.0", "uuid": "u1", "status": "ACTIVE"},
+                {"name": "foo", "version": "2.0.0", "uuid": "u2", "status": "ACTIVE"},
+            ]
+        )
+        with pytest.raises(click.ClickException, match="Multiple installed"):
+            em_elements._select_current_element_by_name(client, "foo")

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -81,14 +81,12 @@ def load_driver(config_file: str, group: str = c.EP_BACKUP_DRIVERS) -> tp.Any:
 def get_exordos_config(
     project_dir: str,
     exordos_cfg_file: str = c.DEF_GEN_CFG_FILE_NAME,
-    exordosctl_cfg_file: str = c.CONFIG_FILE,
 ) -> tp.Tuple[tp.Dict[str, tp.Any], str]:
     """Find the project configuration file."""
     alternatives = [
         os.path.join(project_dir, exordos_cfg_file),
         os.path.join(project_dir, c.DEF_GEN_WORK_DIR_NAME, exordos_cfg_file),
         os.path.join(project_dir, "genesis", "genesis.yaml"),
-        exordosctl_cfg_file,
     ]
 
     for alt in alternatives:
@@ -569,3 +567,7 @@ def is_debugging() -> bool:
         return True
 
     return False
+
+
+def urn(namespace: str, uuid: str) -> str:
+    return f"urn:{namespace}:{uuid}"


### PR DESCRIPTION
- Add repository management commands (add/list/show/delete) via API client
- Add `repo elements` subgroup for repository element operations
- Extend `create_entity_group` with post_fetch_handler and extra_options
- Fix `add_dynamic_parents` decorator to preserve wrapped function metadata
- Add UUID-based index computation to ElementInventory for stable addressing
- Add image URN mapping for Jinja2 manifest templates in SimpleBuilder
- Select elements by repository priority and version in `em elements`
- Add unit tests for builder and repo CLI