### PR TITLE
feat(bootstrap): --realm-spec and --download-only for managed realm n…

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -414,6 +414,41 @@ def _register_core(
     return realm_uuid, realm_secret, tokens_dict
 
 
+REALM_SPEC_REQUIRED_KEYS = (
+    "realm_uuid",
+    "realm_secret",
+    "realm_tokens",
+    "ecosystem_endpoint",
+    "admin_password",
+)
+
+
+def _load_realm_spec(path: str) -> dict:
+    """Load and validate a realm spec delivered by the exordos ecosystem.
+
+    Managed realm nodes receive `/etc/exordos/realm_spec.json` from the
+    ecosystem builder agent (see exordos_ecosystem `docs/realm-manager.md`).
+    The file carries a pre-assigned realm identity, so bootstrap must use
+    it instead of self-registering a new realm.
+    """
+    with open(path) as f:
+        spec = json.load(f)
+
+    spec_version = spec.get("version", 1)
+    if spec_version != 1:
+        raise click.UsageError(
+            f"Unsupported realm spec version: {spec_version}"
+        )
+
+    missing = [key for key in REALM_SPEC_REQUIRED_KEYS if not spec.get(key)]
+    if missing:
+        raise click.UsageError(
+            f"Realm spec {path} misses required keys: {', '.join(missing)}"
+        )
+
+    return spec
+
+
 def _iam_default_client_settings() -> dict:
     return {
         "default_client_uuid": "00000000-0000-0000-0000-000000000000",
@@ -775,6 +810,26 @@ def _bootstrap_core(
     help="Ecosystem's endpoint to connect to",
 )
 @click.option(
+    "--realm-spec",
+    default=None,
+    type=click.Path(exists=True),
+    envvar="REALM_SPEC",
+    help=(
+        "Path to a realm spec file (realm_spec.json) delivered by the "
+        "exordos ecosystem to managed realm nodes. Provides a pre-assigned "
+        "realm identity (uuid, secret, tokens), the ecosystem endpoint and "
+        "the admin password; self-registration is skipped."
+    ),
+)
+@click.option(
+    "--download-only",
+    is_flag=True,
+    help=(
+        "Only resolve and download the element inventories (populating "
+        "the local cache), then exit without bootstrapping."
+    ),
+)
+@click.option(
     "--settings",
     show_default=True,
     is_flag=True,
@@ -819,6 +874,8 @@ def bootstrap_cmd(
     disable_telemetry: bool,
     org_token: str | None,
     ecosystem_endpoint: str,
+    realm_spec: str | None,
+    download_only: bool,
     settings: bool,
     ssh_public_key: tp.Tuple[str, ...],
 ) -> None:
@@ -844,6 +901,30 @@ def bootstrap_cmd(
         inventory_instance = repo_driver.inventory("core")
         inventory_eco_instance = repo_driver.inventory("ecosystem_realm")
         eco_manifest_path = str(inventory_eco_instance.manifests[0])
+
+    if download_only:
+        click.secho(
+            "Element inventories are downloaded and cached. "
+            "Exiting (--download-only).",
+            fg="green",
+        )
+        return
+
+    realm_spec_data = None
+    if realm_spec is not None:
+        if org_token or no_registration:
+            raise click.UsageError(
+                "--realm-spec cannot be combined with --org-token "
+                "or --no-registration"
+            )
+        if launch_mode != "core":
+            raise click.UsageError(
+                "--realm-spec is only supported in 'core' launch mode"
+            )
+        realm_spec_data = _load_realm_spec(realm_spec)
+        admin_password = realm_spec_data["admin_password"]
+        ecosystem_endpoint = realm_spec_data["ecosystem_endpoint"]
+        disable_telemetry = bool(realm_spec_data.get("disable_telemetry", False))
 
     profile = Profile[profile.upper()]
 
@@ -948,12 +1029,24 @@ def bootstrap_cmd(
     )
     hypervisors.append(hypervisor)
 
-    with _status_done("Registering realm in ecosystem..."):
-        realm_uuid, realm_secret, realm_tokens = _register_core(
-            ecosystem_endpoint=ecosystem_endpoint,
-            disable_telemetry=disable_telemetry,
-            org_token=org_token,
+    if realm_spec_data is not None:
+        # Managed realm: the identity was pre-assigned by the ecosystem
+        # and the parent realm row already exists there. The child flips
+        # it to ACTIVE by self-reporting with this uuid+secret.
+        realm_uuid = realm_spec_data["realm_uuid"]
+        realm_secret = realm_spec_data["realm_secret"]
+        realm_tokens = realm_spec_data["realm_tokens"]
+        click.secho(
+            "Using pre-assigned realm identity from the realm spec",
+            fg="cyan",
         )
+    else:
+        with _status_done("Registering realm in ecosystem..."):
+            realm_uuid, realm_secret, realm_tokens = _register_core(
+                ecosystem_endpoint=ecosystem_endpoint,
+                disable_telemetry=disable_telemetry,
+                org_token=org_token,
+            )
 
     ssh_public_key_content = None
     if ssh_public_key:

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -431,16 +431,28 @@ def _load_realm_spec(path: str) -> dict:
     The file carries a pre-assigned realm identity, so bootstrap must use
     it instead of self-registering a new realm.
     """
-    with open(path) as f:
-        spec = json.load(f)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            spec = json.load(f)
+    except json.JSONDecodeError as e:
+        raise click.UsageError(f"Realm spec {path} is not a valid JSON file: {e}")
+    except OSError as e:
+        raise click.ClickException(f"Failed to read realm spec {path}: {e}")
+
+    if not isinstance(spec, dict):
+        raise click.UsageError(f"Realm spec {path} must be a JSON object")
 
     spec_version = spec.get("version", 1)
     if spec_version != 1:
-        raise click.UsageError(
-            f"Unsupported realm spec version: {spec_version}"
-        )
+        raise click.UsageError(f"Unsupported realm spec version: {spec_version}")
 
-    missing = [key for key in REALM_SPEC_REQUIRED_KEYS if not spec.get(key)]
+    # realm_tokens may legitimately be an empty object; only enforce that
+    # it is present. The remaining keys must be non-empty.
+    missing = [
+        key
+        for key in REALM_SPEC_REQUIRED_KEYS
+        if spec.get(key) is None or (key != "realm_tokens" and not spec.get(key))
+    ]
     if missing:
         raise click.UsageError(
             f"Realm spec {path} misses required keys: {', '.join(missing)}"
@@ -904,8 +916,7 @@ def bootstrap_cmd(
 
     if download_only:
         click.secho(
-            "Element inventories are downloaded and cached. "
-            "Exiting (--download-only).",
+            "Element inventories are downloaded and cached. Exiting (--download-only).",
             fg="green",
         )
         return
@@ -914,8 +925,7 @@ def bootstrap_cmd(
     if realm_spec is not None:
         if org_token or no_registration:
             raise click.UsageError(
-                "--realm-spec cannot be combined with --org-token "
-                "or --no-registration"
+                "--realm-spec cannot be combined with --org-token or --no-registration"
             )
         if launch_mode != "core":
             raise click.UsageError(

--- a/exordos/tests/unit/test_cmd_realm_spec.py
+++ b/exordos/tests/unit/test_cmd_realm_spec.py
@@ -79,3 +79,41 @@ class TestLoadRealmSpec:
 
         with pytest.raises(click.UsageError, match="version"):
             _load_realm_spec(str(path))
+
+    def test_empty_realm_tokens_allowed(self, tmp_path) -> None:
+        # An empty realm_tokens object is valid (only presence is required).
+        spec = _valid_spec()
+        spec["realm_tokens"] = {}
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(spec))
+
+        assert _load_realm_spec(str(path))["realm_tokens"] == {}
+
+    def test_empty_string_key_rejected(self, tmp_path) -> None:
+        spec = _valid_spec()
+        spec["admin_password"] = ""
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(spec))
+
+        with pytest.raises(click.UsageError, match="admin_password"):
+            _load_realm_spec(str(path))
+
+    def test_not_a_json_object(self, tmp_path) -> None:
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(["not", "an", "object"]))
+
+        with pytest.raises(click.UsageError, match="must be a JSON object"):
+            _load_realm_spec(str(path))
+
+    def test_invalid_json(self, tmp_path) -> None:
+        path = tmp_path / "realm_spec.json"
+        path.write_text("{not valid json")
+
+        with pytest.raises(click.UsageError, match="not a valid JSON"):
+            _load_realm_spec(str(path))
+
+    def test_unreadable_file(self, tmp_path) -> None:
+        path = tmp_path / "does_not_exist.json"
+
+        with pytest.raises(click.ClickException, match="Failed to read"):
+            _load_realm_spec(str(path))

--- a/exordos/tests/unit/test_cmd_realm_spec.py
+++ b/exordos/tests/unit/test_cmd_realm_spec.py
@@ -1,0 +1,81 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import json
+
+import pytest
+import rich_click as click
+
+from exordos.cmd.stand.commands import _load_realm_spec
+
+
+def _valid_spec() -> dict:
+    # Contract pinned in exordos_ecosystem docs/realm-manager.md
+    return {
+        "version": 1,
+        "realm_uuid": "c0ffee00-0000-4000-8000-000000000000",
+        "realm_name": "customer-realm",
+        "realm_domain": "c0ffee.exordos.io",
+        "realm_secret": "b" * 128,
+        "ecosystem_endpoint": "https://ecosystem.exordos.io",
+        "admin_password": "super-secret-password",
+        "realm_tokens": {
+            "access_token": "at",
+            "refresh_token": "rt",
+        },
+        "disable_telemetry": False,
+    }
+
+
+class TestLoadRealmSpec:
+    def test_valid_spec(self, tmp_path) -> None:
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(_valid_spec()))
+
+        spec = _load_realm_spec(str(path))
+
+        assert spec["realm_uuid"] == "c0ffee00-0000-4000-8000-000000000000"
+        assert spec["realm_secret"] == "b" * 128
+        assert spec["realm_tokens"]["access_token"] == "at"
+        assert spec["ecosystem_endpoint"] == "https://ecosystem.exordos.io"
+        assert spec["admin_password"] == "super-secret-password"
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        [
+            "realm_uuid",
+            "realm_secret",
+            "realm_tokens",
+            "ecosystem_endpoint",
+            "admin_password",
+        ],
+    )
+    def test_missing_required_key(self, tmp_path, missing_key) -> None:
+        spec = _valid_spec()
+        del spec[missing_key]
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(spec))
+
+        with pytest.raises(click.UsageError, match=missing_key):
+            _load_realm_spec(str(path))
+
+    def test_unsupported_version(self, tmp_path) -> None:
+        spec = _valid_spec()
+        spec["version"] = 2
+        path = tmp_path / "realm_spec.json"
+        path.write_text(json.dumps(spec))
+
+        with pytest.raises(click.UsageError, match="version"):
+            _load_realm_spec(str(path))


### PR DESCRIPTION
…odes

--realm-spec consumes /etc/exordos/realm_spec.json delivered by the exordos ecosystem builder to managed realm nodes: the pre-assigned identity (realm_uuid/secret/tokens), ecosystem endpoint, admin password and telemetry flag are taken from the spec and self-registration is skipped. The booted child then flips its ecosystem realm record from PROVISIONING to ACTIVE by self-reporting with that identity.

--download-only resolves and caches the element inventories (core + ecosystem_realm) and exits; used to pre-warm the cache when baking the exordos-realm node image.