### PR TITLE
Secure bootstrap password file permissions

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -458,6 +458,34 @@ def _iam_default_client_settings() -> dict:
     }
 
 
+def _save_admin_password_file(
+    path: str, admin_password: str, logger: ClickLogger
+) -> None:
+    password_path = pathlib.Path(path)
+    if ".." in password_path.parts:
+        logger.error("Invalid password file path (contains '..'). Skipping save.")
+        return
+
+    try:
+        password_path.parent.mkdir(parents=True, exist_ok=True)
+
+        def secure_opener(file_path: str, flags: int) -> int:
+            return os.open(file_path, flags, 0o600)
+
+        with open(
+            password_path, "x", encoding="utf-8", opener=secure_opener
+        ) as password_file:
+            password_file.write(admin_password)
+        logger.info(f"Admin password saved to {password_path}")
+    except FileExistsError:
+        logger.warning(
+            f"Admin password file {password_path} already exists. "
+            "Skipping saving the password."
+        )
+    except OSError as e:
+        logger.error(f"Failed to save admin password to {password_path}: {e}")
+
+
 def _bootstrap_core(
     image_path: str | None,
     image_uri: str | None,
@@ -568,32 +596,7 @@ def _bootstrap_core(
         logger.info(f"Launched Exordos installation in `{profile.value}` profile")
 
         if save_admin_password_file:
-            # Basic security check to prevent path traversal.
-            if ".." in pathlib.Path(save_admin_password_file).parts:
-                logger.error(
-                    "Invalid password file path (contains '..'). Skipping save."
-                )
-            else:
-                try:
-                    # Ensure parent directory exists.
-                    pathlib.Path(save_admin_password_file).parent.mkdir(
-                        parents=True, exist_ok=True
-                    )
-                    # Use exclusive creation ('x' mode) to prevent race conditions
-                    # and accidental overwrites.
-                    with open(save_admin_password_file, "x") as f:
-                        f.write(admin_password)
-                    logger.info(f"Admin password saved to {save_admin_password_file}")
-                except FileExistsError:
-                    logger.warning(
-                        f"Admin password file {save_admin_password_file} "
-                        "already exists. Skipping saving the password."
-                    )
-                except OSError as e:
-                    logger.error(
-                        "Failed to save admin password to "
-                        f"{save_admin_password_file}: {e}"
-                    )
+            _save_admin_password_file(save_admin_password_file, admin_password, logger)
     except Exception:
         infra.delete_stand(dev_stand)
         logger.error(f"Failed to launch Exordos installation {dev_stand.name}")

--- a/exordos/tests/unit/test_cmd_stand.py
+++ b/exordos/tests/unit/test_cmd_stand.py
@@ -1,0 +1,38 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+import pathlib
+import stat
+from unittest import mock
+
+from exordos.cmd.stand import commands
+
+
+def test_save_admin_password_file_uses_owner_only_permissions(
+    tmp_path: pathlib.Path,
+) -> None:
+    password_path = tmp_path / "secrets" / "admin-password"
+    previous_umask = os.umask(0o002)
+    try:
+        commands._save_admin_password_file(
+            str(password_path), "test-password", mock.Mock()
+        )
+    finally:
+        os.umask(previous_umask)
+
+    assert password_path.read_text(encoding="utf-8") == "test-password"
+    assert stat.S_IMODE(password_path.stat().st_mode) == 0o600


### PR DESCRIPTION
## Summary

- create `--save-admin-password-file` targets atomically with owner-only `0600` permissions
- preserve exclusive creation and existing-file protection
- add a regression test that reproduces a permissive `umask 0002`

## Root cause

The CLI used Python `open(..., "x")`, so the resulting file mode was derived from the process umask. On a real local Exordos Core bootstrap this produced `0664`, exposing the generated admin password to group readers.

## Impact

Generated admin password files are now readable and writable only by their owner, independent of a permissive umask.

## Validation

- `tox -e develop -x testenv:develop.basepython=/usr/bin/python3.12` — 233 passed
- `tox -e ruff -x testenv:ruff.basepython=/usr/bin/python3.12` — passed