### PR TITLE
Migrate GitHub organization references

### DIFF
--- a/exordos/constants.py
+++ b/exordos/constants.py
@@ -19,7 +19,7 @@ import os
 import typing as tp
 
 PKG_NAME = "exordos"
-GITHUB_RELEASES_URL = f"https://api.github.com/repos/infraguys/{PKG_NAME}/releases"
+GITHUB_RELEASES_URL = f"https://api.github.com/repos/exordos/{PKG_NAME}/releases"
 EXORDOS_REPO_URL = "https://repo.exordos.com"
 ELEMENT_REPO_PATH = "exordos-elements"
 ELEMENT_REPO_URL = f"{EXORDOS_REPO_URL}/{ELEMENT_REPO_PATH}"

--- a/exordos/infra/libvirt/libvirt.py
+++ b/exordos/infra/libvirt/libvirt.py
@@ -37,7 +37,7 @@ domain_template = """
   <name>{name}</name>
   <uuid>{uuid}</uuid>
   <metadata>
-    <genesis:genesis xmlns:genesis="https://github.com/infraguys">
+    <genesis:genesis xmlns:genesis="https://github.com/exordos">
       {meta_tags}
     </genesis:genesis>
   </metadata>

--- a/exordos/tests/unit/test_github_organization.py
+++ b/exordos/tests/unit/test_github_organization.py
@@ -1,0 +1,29 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from exordos import constants
+from exordos.infra.libvirt import libvirt
+
+
+def test_github_release_url_uses_exordos_organization() -> None:
+    assert (
+        constants.GITHUB_RELEASES_URL
+        == "https://api.github.com/repos/exordos/exordos/releases"
+    )
+
+
+def test_libvirt_metadata_namespace_uses_exordos_organization() -> None:
+    assert 'xmlns:genesis="https://github.com/exordos"' in libvirt.domain_template


### PR DESCRIPTION
## Summary

- use `exordos/exordos` for CLI release checks
- use `https://github.com/exordos` as the metadata namespace for newly created libvirt domains
- add regression coverage for both public organization references

## Why

The CLI still referenced the previous GitHub organization in its release API URL and generated libvirt XML. Public repositories now live under the `exordos` organization.

Existing libvirt domains remain compatible because metadata readers do not match the namespace URI; the change only affects XML generated for new domains.

## Validation

- `tox -e develop` — 234 passed
- `tox -e ruff` — passed