### PR TITLE
fix(compute): rename hypervisor driver_spec key from `driver` to `kind`

### DIFF
--- a/exordos/stand/models.py
+++ b/exordos/stand/models.py
@@ -132,7 +132,7 @@ class Hypervisor:
     network: str
     connection_uri: str
     storage_pool: str = "default"
-    driver: str = "libvirt"
+    kind: str = "libvirt"
     machine_prefix: str = "vm-"
     iface_rom_file: str = "/usr/share/qemu/1af41041.rom"
 


### PR DESCRIPTION
exordos_core's MachinePool.driver_spec moved from a free-form dict to a KindModelSelectorType discriminated union keyed by "kind" (see exordos_core#3e59512). The CLI still sent "driver", so `exordos bootstrap` failed with `UnknownType: Unknown kind for value: {...}` on the core side.