### PR TITLE
feat(deploy): add --realm option to deploy command

### DIFF
--- a/exordos/cmd/deploy/commands.py
+++ b/exordos/cmd/deploy/commands.py
@@ -71,19 +71,19 @@ def _find_local_ip_in_network(
     return None
 
 
-def _is_local_realm(config: dict[str, tp.Any]) -> bool:
-    """Check whether the current realm is local.
+def _is_local_realm(config: dict[str, tp.Any], realm: str | None = None) -> bool:
+    """Check whether the given (or current) realm is local.
 
     A realm is considered local when:
       1. ``local: true`` is set in the realm configuration.
       2. If ``meta.cidr`` is present, a local interface has an IP in that
          network.
     """
-    current_realm = config.get("current-realm")
-    if not current_realm:
+    realm_name = realm or config.get("current-realm")
+    if not realm_name:
         return False
 
-    realm_config = config.get("realms", {}).get(current_realm)
+    realm_config = (config.get("realms") or {}).get(realm_name)
     if not realm_config:
         return False
 
@@ -102,15 +102,15 @@ def _is_local_realm(config: dict[str, tp.Any]) -> bool:
     return True
 
 
-def _get_local_host_bind(config: dict[str, tp.Any]) -> str:
+def _get_local_host_bind(config: dict[str, tp.Any], realm: str | None = None) -> str:
     """Return the bind address for the local HTTP server.
 
-    Uses the host IP from the current realm's ``meta.cidr`` network.
+    Uses the host IP from the given (or current) realm's ``meta.cidr`` network.
     Raises an error if no local IP matching the realm CIDR is found.
     """
-    current_realm = config.get("current-realm")
-    if current_realm:
-        realm_config = config.get("realms", {}).get(current_realm, {})
+    realm_name = realm or config.get("current-realm")
+    if realm_name:
+        realm_config = (config.get("realms") or {}).get(realm_name, {})
         cidr_str = realm_config.get("meta", {}).get("cidr")
         if cidr_str:
             try:
@@ -338,6 +338,15 @@ def _deploy_element(
     ),
 )
 @click.option(
+    "-r",
+    "--realm",
+    default=None,
+    help=(
+        "Name of the realm to deploy to. If omitted, the current realm "
+        "from the configuration is used."
+    ),
+)
+@click.option(
     "-c",
     "--exordosctl-cfg-file",
     default=c.CONFIG_FILE,
@@ -355,8 +364,16 @@ def deploy_cmd(
     timeout: float,
     element: str | None,
     exordosctl_cfg_file: str,
+    realm: str | None,
 ) -> None:
     inventory_elements = _load_build_inventory(element_dir)
+    if realm:
+        if realm not in (obj.cfg.get("realms") or {}):
+            raise click.ClickException(
+                f"Realm '{realm}' not found in configuration. "
+                f"Available: {', '.join(sorted((obj.cfg.get('realms') or {}).keys()))}"
+            )
+        obj.auth_data["realm"] = realm
     client = base_client.get_user_api_client(obj.auth_data)
 
     available = sorted(inventory_elements.keys())
@@ -385,8 +402,8 @@ def deploy_cmd(
     # and install the element directly from it. This only works with a
     # local realm where there is direct network connectivity between the
     # host and the realm's Core VM.
-    if not repository and _is_local_realm(obj.cfg):
-        bind_host = _get_local_host_bind(obj.cfg)
+    if not repository and _is_local_realm(obj.cfg, realm):
+        bind_host = _get_local_host_bind(obj.cfg, realm)
 
         with local_server.serve_directory(element_dir, bind_host) as base_url:
             url = f"{base_url}{c.ELEMENT_REPO_PATH}/"

--- a/exordos/tests/unit/test_deploy_cli.py
+++ b/exordos/tests/unit/test_deploy_cli.py
@@ -379,6 +379,21 @@ class TestDeployCmdPushMode:
         deploy_elements_mock.assert_called_once()
 
 
+class TestDeployCmdRealmValidation:
+    def test_invalid_realm_raises(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_commands.deploy_cmd,
+            ["-e", str(output_dir), "--realm", "nonexistent"],
+            obj=_obj(),
+        )
+
+        assert result.exit_code != 0
+        assert "Realm 'nonexistent' not found" in result.output
+
+
 class TestDeployCmdLocalMode:
     def test_errors_without_local_realm(self, tmp_path: pathlib.Path) -> None:
         output_dir = _make_build_output(tmp_path)


### PR DESCRIPTION
Allow specifying a target realm for the deploy command via `-r/--realm`.

When omitted, the current realm from the configuration is used (existing behavior). When provided, the realm is used for both API authentication and local realm detection (local mode / bind address selection).

Changes:
- Add `realm` parameter to `_is_local_realm` and `_get_local_host_bind`
- Add `-r/--realm` CLI option to `deploy_cmd`
- Override `auth_data["realm"]` when `--realm` is specified