### PR TITLE
fix(common): pick highest semver tag when multiple tags share a commit

### DIFF
--- a/exordos/cmd/builds/commands.py
+++ b/exordos/cmd/builds/commands.py
@@ -25,6 +25,7 @@ import rich_click as click
 from exordos import utils
 from exordos.builder import builder as simple_builder
 from exordos.builder.packer import PackerBuilder
+from exordos.common.version import get_project_version
 import exordos.constants as c
 from exordos.logger import ClickLogger
 from exordos.spec import schema
@@ -149,7 +150,7 @@ def build_cmd(
         click.secho("No builds found in the configuration", fg="yellow")
         return
 
-    version = utils.get_project_version(project_dir)
+    version = get_project_version(project_dir)
 
     logger = ClickLogger()
     packer_image_builder = PackerBuilder(logger)

--- a/exordos/common/version.py
+++ b/exordos/common/version.py
@@ -26,6 +26,13 @@ import exordos.constants as c
 VERSION_REGEXP = r"(?:\d+\.\d+\.\d+(?:-(?:rc|dev)\+\d{14}\.[a-f0-9]{8})?|latest)"
 
 
+def _semver_sort_key(tag_name: str):
+    try:
+        return (0, packaging_version.parse(tag_name))
+    except packaging_version.InvalidVersion:
+        return (-1, tag_name)
+
+
 def get_project_version(
     path: str, rc_branches=c.RC_BRANCHES, start_version=(0, 0, 0)
 ) -> str:
@@ -38,10 +45,10 @@ def get_project_version(
     # Open the git repo
     repo = git.Repo(path)
 
-    # If a tag is set, return it as version
-    for tag in repo.tags:
-        if tag.commit == repo.head.commit:
-            return tag.name
+    # If a tag is set, return the highest semver tag on this commit
+    head_tags = [tag.name for tag in repo.tags if tag.commit == repo.head.commit]
+    if head_tags:
+        return max(head_tags, key=_semver_sort_key)
 
     # Find the nearest tag
     nearest_tag = None

--- a/exordos/tests/unit/test_get_project_version.py
+++ b/exordos/tests/unit/test_get_project_version.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 from git import Repo
 import pytest
 
-from exordos.utils import get_project_version
+from exordos.common.version import get_project_version
 
 
 def test_version_with_tag():

--- a/exordos/tests/unit/test_get_project_version.py
+++ b/exordos/tests/unit/test_get_project_version.py
@@ -40,6 +40,25 @@ def test_version_with_tag():
         assert version == "1.2.3"
 
 
+def test_version_multiple_tags_on_head_picks_highest_semver():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = Repo.init(tmpdir)
+        with open(os.path.join(tmpdir, "test.txt"), "w") as f:
+            f.write("test")
+        repo.index.add([os.path.join(tmpdir, "test.txt")])
+        commit = repo.index.commit("Initial commit")
+
+        # Tags added out of semver order; "0.0.3" sorts before "0.1.0"
+        # lexicographically, which previously caused the wrong tag to win.
+        repo.create_tag("0.0.3", commit)
+        repo.create_tag("0.1.0", commit)
+
+        repo.head.commit = commit
+
+        version = get_project_version(tmpdir)
+        assert version == "0.1.0"
+
+
 def test_version_without_tag():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo = Repo.init(tmpdir)

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -37,7 +37,7 @@ import git
 import rich_click as click
 import ruamel.yaml
 
-from exordos.common.version import _semver_sort_key
+from exordos.common.version import get_project_version
 import exordos.constants as c
 
 yaml = ruamel.yaml.YAML()
@@ -140,77 +140,6 @@ def installation_name_from_bootstrap(bootstrap_name: str) -> str:
 def get_repo(path: str) -> git.Repo:
     repo = git.Repo(path)
     return repo
-
-
-def get_project_version(
-    path: str, rc_branches=c.RC_BRANCHES, start_version=(0, 0, 0)
-) -> str:
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"File {path} not found")
-
-    if not os.path.isdir(path):
-        raise ValueError(f"Path {path} is not a directory")
-
-    # Open the git repo
-    repo = git.Repo(path)
-
-    # If a tag is set, return the highest semver tag on this commit
-    head_tags = [tag.name for tag in repo.tags if tag.commit == repo.head.commit]
-    if head_tags:
-        return max(head_tags, key=_semver_sort_key)
-
-    # Find the nearest tag
-    nearest_tag = None
-    for commit in repo.iter_commits(max_count=100):
-        for tag in repo.tags:
-            if tag.commit == commit:
-                nearest_tag = tag
-                break
-
-        if nearest_tag:
-            break
-
-    # Get the current version
-    if nearest_tag:
-        try:
-            major, minor, patch = (int(i) for i in nearest_tag.name.split("."))
-        except ValueError:
-            raise ValueError(
-                f"Invalid format for tag {nearest_tag.name}, "
-                "expected major.minor.patch version format"
-            )
-    # Empty repo, start from 0.0.0
-    else:
-        major, minor, patch = start_version
-
-    # Increment the version
-    patch += 1
-
-    hexsha = repo.head.commit.hexsha
-
-    try:
-        branch = repo.active_branch.name
-    except Exception:
-        # Detached head
-        branch = None
-
-    date = repo.head.commit.committed_date
-    date_repr = "{}{:02}{:02}{:02}{:02}{:02}".format(
-        time.gmtime(date).tm_year,
-        time.gmtime(date).tm_mon,
-        time.gmtime(date).tm_mday,
-        time.gmtime(date).tm_hour,
-        time.gmtime(date).tm_min,
-        time.gmtime(date).tm_sec,
-    )
-
-    # Determine the prefix
-    if branch in rc_branches:
-        prefix = "rc"
-    else:
-        prefix = "dev"
-
-    return f"{major}.{minor}.{patch}-{prefix}+{date_repr}.{hexsha[:8]}"
 
 
 def wait_for(

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -37,6 +37,7 @@ import git
 import rich_click as click
 import ruamel.yaml
 
+from exordos.common.version import _semver_sort_key
 import exordos.constants as c
 
 yaml = ruamel.yaml.YAML()
@@ -153,10 +154,10 @@ def get_project_version(
     # Open the git repo
     repo = git.Repo(path)
 
-    # If a tag is set, return it as version
-    for tag in repo.tags:
-        if tag.commit == repo.head.commit:
-            return tag.name
+    # If a tag is set, return the highest semver tag on this commit
+    head_tags = [tag.name for tag in repo.tags if tag.commit == repo.head.commit]
+    if head_tags:
+        return max(head_tags, key=_semver_sort_key)
 
     # Find the nearest tag
     nearest_tag = None


### PR DESCRIPTION
get_project_version returned the first matching tag from repo.tags, which GitPython orders lexicographically rather than by semver. When a commit had both "0.0.3" and "0.1.0" tags, "0.0.3" won the string comparison and was returned instead of "0.1.0", producing a stale version for exordos get-version and exordos build alike.