### PR TITLE
fix(packer): stop apt update services before poweroff in shutdown_com…

### DIFF
--- a/exordos/packer/debian_12/debian-12.pkr.hcl
+++ b/exordos/packer/debian_12/debian-12.pkr.hcl
@@ -118,7 +118,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
-# shutdown machine
-sudo poweroff
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
+# Shutdown machine
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/exordos_base/exordos-base.pkr.hcl
+++ b/exordos/packer/exordos_base/exordos-base.pkr.hcl
@@ -114,7 +114,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
 # Shutdown machine
-sudo poweroff
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/exordos_base_minimal/exordos-base-minimal.pkr.hcl
+++ b/exordos/packer/exordos_base_minimal/exordos-base-minimal.pkr.hcl
@@ -114,7 +114,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
 # Shutdown machine
-sudo poweroff
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/exordos_custom/exordos-custom.pkr.hcl
+++ b/exordos/packer/exordos_custom/exordos-custom.pkr.hcl
@@ -116,7 +116,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
-# shutdown machine
-sudo poweroff
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
+# Shutdown machine
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/ubuntu_24/ubuntu-24.pkr.hcl
+++ b/exordos/packer/ubuntu_24/ubuntu-24.pkr.hcl
@@ -118,7 +118,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
-# shutdown machine
-sudo poweroff
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
+# Shutdown machine
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/ubuntu_26/ubuntu-26.pkr.hcl
+++ b/exordos/packer/ubuntu_26/ubuntu-26.pkr.hcl
@@ -118,7 +118,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
-# shutdown machine
-sudo poweroff
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
+# Shutdown machine
+sudo systemctl poweroff
 EOF
 }

--- a/exordos/packer/ubuntu_26_minimal/ubuntu-26-minimal.pkr.hcl
+++ b/exordos/packer/ubuntu_26_minimal/ubuntu-26-minimal.pkr.hcl
@@ -118,7 +118,11 @@ sudo sync
 # Minify orphan space
 sudo fstrim -a
 
-# shutdown machine
-sudo poweroff
+# Stop update services; `systemctl stop` waits for an in-flight
+# apt transaction to finish instead of killing it.
+sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+
+# Shutdown machine
+sudo systemctl poweroff
 EOF
 }


### PR DESCRIPTION
…mand

Plain `poweroff` is sometimes refused with "Operation denied due to active block inhibitor" when unattended-upgrades holds a shutdown inhibitor mid apt transaction, failing the build. Stop the update services first (systemctl stop waits for an in-flight transaction to finish), then power off normally.