### PR TITLE
feat(clients): register a node's universal agent and write its key

### DIFF
--- a/exordos/clients/base_client.py
+++ b/exordos/clients/base_client.py
@@ -23,8 +23,10 @@ from bazooka import exceptions as bazooka_exc
 import certifi
 import rich_click as click
 
+from exordos import constants as c
 from exordos import utils
 from exordos.clients import base as http_client
+from exordos.common.crypto import write_agent_private_key
 
 os.environ["SSL_CERT_FILE"] = certifi.where()
 CONNECT_TIMEOUT = 5
@@ -153,6 +155,39 @@ def action_entity(
         client.do_action(collection, uuid=uuid, name=action, invoke=invoke, **kwargs)
     except bazooka_exc.NotFoundError:
         raise click.ClickException(f"UUID {uuid} not found")
+
+
+def register_agent_and_write_key(
+    client: http_client.CollectionBaseClient,
+    node_uuid: str,
+    key_path: str,
+) -> None:
+    """Register this node's universal agent with Core (if not already)
+    and write its node encryption key to disk.
+
+    Registering ahead of the agent's own first run lets this fetch the
+    key via the `issue_key` action right after - the agent daemon's own
+    self-registration later just updates this same record instead of
+    conflicting with it.
+    """
+    try:
+        client.create(
+            c.AGENT_COLLECTION,
+            data={
+                "uuid": node_uuid,
+                "name": f"universal_agent_{node_uuid[:8]}",
+                "node": node_uuid,
+                "capabilities": {"capabilities": []},
+                "facts": {"facts": []},
+            },
+        )
+    except bazooka_exc.ConflictError:
+        pass
+
+    private_key_base64 = client.do_action(
+        c.AGENT_COLLECTION, "issue_key", node_uuid, invoke=True
+    )["key"]
+    write_agent_private_key(private_key_base64, key_path)
 
 
 def add_fields_to_url(

--- a/exordos/clients/base_client.py
+++ b/exordos/clients/base_client.py
@@ -161,6 +161,8 @@ def register_agent_and_write_key(
     client: http_client.CollectionBaseClient,
     node_uuid: str,
     key_path: str,
+    agent_uuid: str | None = None,
+    capabilities: list[str] | None = None,
 ) -> None:
     """Register this node's universal agent with Core (if not already)
     and write its node encryption key to disk.
@@ -169,15 +171,22 @@ def register_agent_and_write_key(
     key via the `issue_key` action right after - the agent daemon's own
     self-registration later just updates this same record instead of
     conflicting with it.
+
+    `agent_uuid` defaults to `node_uuid`, matching the standard universal
+    agent's own default (`UniversalAgent.from_system_uuid()`), which is
+    also a node itself. A custom agent_uuid is only needed for an agent
+    that isn't the node's own standard agent.
     """
+    agent_uuid = agent_uuid or node_uuid
+
     try:
         client.create(
             c.AGENT_COLLECTION,
             data={
-                "uuid": node_uuid,
-                "name": f"universal_agent_{node_uuid[:8]}",
+                "uuid": agent_uuid,
+                "name": f"universal_agent_{agent_uuid[:8]}",
                 "node": node_uuid,
-                "capabilities": {"capabilities": []},
+                "capabilities": {"capabilities": capabilities or []},
                 "facts": {"facts": []},
             },
         )
@@ -185,7 +194,7 @@ def register_agent_and_write_key(
         pass
 
     private_key_base64 = client.do_action(
-        c.AGENT_COLLECTION, "issue_key", node_uuid, invoke=True
+        c.AGENT_COLLECTION, "issue_key", agent_uuid, invoke=True
     )["key"]
     write_agent_private_key(private_key_base64, key_path)
 

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -17,9 +17,13 @@
 from __future__ import annotations
 
 import base64
+import os
 import secrets
+import tempfile
 
 from cryptography.hazmat.primitives.ciphers import aead
+
+from exordos.common.run import run_command
 
 KEY_SIZE = 32
 NONCE_SIZE = 12
@@ -73,3 +77,31 @@ def decrypt_chacha20_poly1305(
 
     cipher = aead.ChaCha20Poly1305(key)
     return cipher.decrypt(nonce, ciphertext, associated_data)
+
+
+def write_root_owned_file(content: str, dest_path: str, mode: str | None = None) -> None:
+    """Write `content` to `dest_path`, a system path this (non-root, but
+    sudo-capable) process can't write to directly.
+
+    The file itself is written as the current user to a private temp file
+    (matching how infra/libvirt writes domain XML: only the final `virsh
+    define <path>` needs elevation, not the write itself), then moved into
+    place with `sudo`.
+    """
+    run_command(["sudo", "mkdir", "-p", os.path.dirname(dest_path)])
+    fd, tmp_path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        run_command(["sudo", "install", "-m", mode or "600", tmp_path, dest_path])
+    finally:
+        os.remove(tmp_path)
+
+
+def write_agent_private_key(private_key_base64: str, key_path: str) -> None:
+    """Write a universal agent's node encryption key.
+
+    Must match the key the core stored for this node, so restrict it
+    to the owner.
+    """
+    write_root_owned_file(private_key_base64, key_path, mode="600")

--- a/exordos/tests/unit/test_base_client.py
+++ b/exordos/tests/unit/test_base_client.py
@@ -62,3 +62,36 @@ class TestRegisterAgentAndWriteKey:
             )
 
         write_key_mock.assert_called_once_with("s3cr3t-key==", key_path)
+
+    def test_uses_a_distinct_agent_uuid_and_capabilities_when_given(
+        self, tmp_path
+    ) -> None:
+        key_path = str(tmp_path / "private_key")
+        fake_client = MagicMock()
+        fake_client.do_action.return_value = {"key": "s3cr3t-key=="}
+
+        with patch.object(base_client, "write_agent_private_key"):
+            base_client.register_agent_and_write_key(
+                fake_client,
+                "node-uuid",
+                key_path,
+                agent_uuid="8d10a674-agent-uuid",
+                capabilities=["pool"],
+            )
+
+        fake_client.create.assert_called_once_with(
+            base_client.c.AGENT_COLLECTION,
+            data={
+                "uuid": "8d10a674-agent-uuid",
+                "name": "universal_agent_8d10a674",
+                "node": "node-uuid",
+                "capabilities": {"capabilities": ["pool"]},
+                "facts": {"facts": []},
+            },
+        )
+        fake_client.do_action.assert_called_once_with(
+            base_client.c.AGENT_COLLECTION,
+            "issue_key",
+            "8d10a674-agent-uuid",
+            invoke=True,
+        )

--- a/exordos/tests/unit/test_base_client.py
+++ b/exordos/tests/unit/test_base_client.py
@@ -1,0 +1,64 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from bazooka import exceptions as bazooka_exc
+
+from exordos.clients import base_client
+
+
+class TestRegisterAgentAndWriteKey:
+    def test_registers_the_agent_and_writes_its_key(self, tmp_path) -> None:
+        key_path = str(tmp_path / "private_key")
+        fake_client = MagicMock()
+        fake_client.do_action.return_value = {"key": "s3cr3t-key=="}
+
+        with patch.object(base_client, "write_agent_private_key") as write_key_mock:
+            base_client.register_agent_and_write_key(
+                fake_client, "8d10a674-node-uuid", key_path
+            )
+
+        fake_client.create.assert_called_once_with(
+            base_client.c.AGENT_COLLECTION,
+            data={
+                "uuid": "8d10a674-node-uuid",
+                "name": "universal_agent_8d10a674",
+                "node": "8d10a674-node-uuid",
+                "capabilities": {"capabilities": []},
+                "facts": {"facts": []},
+            },
+        )
+        fake_client.do_action.assert_called_once_with(
+            base_client.c.AGENT_COLLECTION,
+            "issue_key",
+            "8d10a674-node-uuid",
+            invoke=True,
+        )
+        write_key_mock.assert_called_once_with("s3cr3t-key==", key_path)
+
+    def test_tolerates_an_already_registered_agent(self, tmp_path) -> None:
+        key_path = str(tmp_path / "private_key")
+        fake_client = MagicMock()
+        fake_client.create.side_effect = bazooka_exc.ConflictError(cause=MagicMock())
+        fake_client.do_action.return_value = {"key": "s3cr3t-key=="}
+
+        with patch.object(base_client, "write_agent_private_key") as write_key_mock:
+            base_client.register_agent_and_write_key(
+                fake_client, "node-uuid", key_path
+            )
+
+        write_key_mock.assert_called_once_with("s3cr3t-key==", key_path)

--- a/exordos/tests/unit/test_crypto.py
+++ b/exordos/tests/unit/test_crypto.py
@@ -1,0 +1,82 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest.mock import call as mock_call
+from unittest.mock import patch
+
+from exordos.common import crypto
+
+
+class TestWriteRootOwnedFile:
+    """All privileged filesystem operations must go through sudo:
+    callers run as a regular, sudo-capable user, not root.
+    """
+
+    def test_installs_content_via_sudo(self, tmp_path) -> None:
+        dest_path = str(tmp_path / "etc" / "exordos_universal_agent" / "some.conf")
+        written = {}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["sudo", "install"]:
+                written["content"] = open(cmd[4]).read()
+                written["dest"] = cmd[5]
+
+        with patch.object(crypto, "run_command", side_effect=fake_run) as run_mock:
+            crypto.write_root_owned_file("hello world\n", dest_path, mode="644")
+
+        assert run_mock.call_args_list[0] == mock_call(
+            ["sudo", "mkdir", "-p", str(tmp_path / "etc" / "exordos_universal_agent")]
+        )
+        assert written["content"] == "hello world\n"
+        assert written["dest"] == dest_path
+
+    def test_installs_with_given_mode(self, tmp_path) -> None:
+        dest_path = str(tmp_path / "node_private_key")
+
+        with patch.object(crypto, "run_command") as run_mock:
+            crypto.write_root_owned_file("secret\n", dest_path, mode="600")
+
+        install_call = run_mock.call_args_list[-1][0][0]
+        assert install_call[:4] == ["sudo", "install", "-m", "600"]
+        assert install_call[5] == dest_path
+
+    def test_defaults_to_a_restrictive_mode(self, tmp_path) -> None:
+        # install (not cp+chmod) sets the mode atomically as it creates
+        # the file - default to 600 rather than leaving it to whatever
+        # cp/root's umask would otherwise produce.
+        dest_path = str(tmp_path / "some_file")
+
+        with patch.object(crypto, "run_command") as run_mock:
+            crypto.write_root_owned_file("content\n", dest_path)
+
+        install_call = run_mock.call_args_list[-1][0][0]
+        assert install_call[:4] == ["sudo", "install", "-m", "600"]
+
+
+class TestWriteAgentPrivateKey:
+    def test_writes_with_restricted_mode(self, tmp_path) -> None:
+        key_path = str(tmp_path / "node_private_key")
+        written = {}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["sudo", "install"]:
+                written["content"] = open(cmd[4]).read()
+                written["mode"] = cmd[3]
+
+        with patch.object(crypto, "run_command", side_effect=fake_run):
+            crypto.write_agent_private_key("s3cr3t==", key_path)
+
+        assert written["content"] == "s3cr3t=="
+        assert written["mode"] == "600"


### PR DESCRIPTION
Add register_agent_and_write_key(), a generic, hypervisor-agnostic helper for pre-registering a node's UniversalAgent with Core and persisting the node encryption key it issues to disk. Any command that provisions a local universal agent (not just hypervisor add) can call this instead of duplicating the register+issue_key+write flow.