### PR TITLE
feat(builder): add flatten option for script-generated directory arti…

### DIFF
--- a/docs/exordos-yaml.md
+++ b/docs/exordos-yaml.md
@@ -76,6 +76,27 @@ resolved relative to the `exordos.yaml` file.
             - dist/
 ```
 
+#### Flatten option
+
+When a matched pattern is a directory, the archive preserves the top-level
+directory name as a wrapper inside the archive by default. Set `flatten: true`
+to place the directory contents at the root of the archive without the wrapper
+directory. This is useful when the archive is extracted into a directory served
+directly by nginx (e.g. via `alias`), where an extra wrapper directory would
+cause files to be one level too deep.
+
+```yaml
+      artifacts:
+        - script: images/docs_build.sh
+          work_dir: ../
+          flatten: true
+          artifacts:
+            - dist/
+```
+
+The example above produces `dist.tar.zst` containing the contents of `dist/`
+(e.g. `index.html`, `assets/`, ...) without a `dist/` wrapper.
+
 ## Push configuration file
 
 The push configuration is kept in a separate file — `exordos.push.yaml` — placed alongside `exordos.yaml` in the `exordos` directory. It defines one or more named push targets, each specifying a driver and a destination path.

--- a/exordos/builder/base.py
+++ b/exordos/builder/base.py
@@ -157,6 +157,7 @@ class GeneratedArtifact:
     script: str
     work_dir: str
     patterns: list[str]
+    flatten: bool = False
 
     @classmethod
     def from_config(
@@ -167,6 +168,8 @@ class GeneratedArtifact:
             raise ValueError(
                 "Artifact configuration cannot have both 'path' and 'script'"
             )
+
+        flatten = config.get("flatten", False)
 
         script = config["script"]
         if not os.path.isabs(script):
@@ -182,7 +185,12 @@ class GeneratedArtifact:
         if not patterns:
             raise ValueError("'artifacts' patterns are required for a script artifact")
 
-        return cls(script=script, work_dir=artifact_work_dir, patterns=patterns)
+        return cls(
+            script=script,
+            work_dir=artifact_work_dir,
+            patterns=patterns,
+            flatten=flatten,
+        )
 
 
 @dataclasses.dataclass
@@ -223,12 +231,14 @@ class Element:
         configs = [Config.from_config(config, work_dir) for config in config_configs]
 
         artifacts_configs = element_config.pop("artifacts", [])
-        artifacts = [
-            GeneratedArtifact.from_config(artifact, work_dir)
-            if "script" in artifact
-            else Artifact.from_config(artifact, work_dir)
-            for artifact in artifacts_configs
-        ]
+        artifacts = []
+        for artifact in artifacts_configs:
+            if isinstance(artifact, str):
+                artifact = {"path": artifact}
+            if "script" in artifact:
+                artifacts.append(GeneratedArtifact.from_config(artifact, work_dir))
+            else:
+                artifacts.append(Artifact.from_config(artifact, work_dir))
 
         # Convert manifest to Path if present
         manifest = element_config.pop("manifest", None)

--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -85,12 +85,25 @@ class SimpleBuilder:
 
         return pathlib.Path(dst_path.name)
 
-    def _archive_dir_zst(self, src_dir: pathlib.Path, dst_path: pathlib.Path) -> None:
-        """Archive a directory with tar and compress it with zstd."""
+    def _archive_dir_zst(
+        self,
+        src_dir: pathlib.Path,
+        dst_path: pathlib.Path,
+        flatten: bool = False,
+    ) -> None:
+        """Archive a directory with tar and compress it with zstd.
+
+        When ``flatten`` is True, the directory contents are placed at the
+        root of the archive without the wrapper directory.
+        """
         with tempfile.TemporaryDirectory() as tmp_dir:
             tar_path = pathlib.Path(tmp_dir) / f"{src_dir.name}.tar"
             with tarfile.open(tar_path, "w") as tar:
-                tar.add(src_dir, arcname=src_dir.name)
+                if flatten:
+                    for child in sorted(src_dir.iterdir()):
+                        tar.add(child, arcname=child.name)
+                else:
+                    tar.add(src_dir, arcname=src_dir.name)
 
             subprocess.run(
                 ["zstd", "-9", "-T0", "-f", "-o", dst_path, tar_path],
@@ -126,7 +139,9 @@ class SimpleBuilder:
                 src = pathlib.Path(generated.work_dir) / match
                 if src.is_dir():
                     dst_name = f"{src.name}.tar.zst"
-                    self._archive_dir_zst(src, output_dir / dst_name)
+                    self._archive_dir_zst(
+                        src, output_dir / dst_name, flatten=generated.flatten
+                    )
                     result_paths.append(pathlib.Path(dst_name))
                 else:
                     shutil.copy(src, output_dir / src.name)

--- a/exordos/spec/exordos_spec.yaml
+++ b/exordos/spec/exordos_spec.yaml
@@ -104,6 +104,13 @@ properties:
                   work_dir:
                     type: string
                     description: Directory to run the script in
+                  flatten:
+                    type: boolean
+                    description: >
+                      When true and a matched pattern is a directory, place
+                      the directory contents at the root of the archive
+                      without the wrapper directory. Only supported for
+                      script-generated artifacts.
                   artifacts:
                     type: array
                     description: Glob patterns matching the script's output artifacts

--- a/exordos/tests/unit/test_builder.py
+++ b/exordos/tests/unit/test_builder.py
@@ -760,3 +760,106 @@ class TestBuildElementArtifacts:
 
         with pytest.raises(ValueError):
             builder.build_element(element, out_dir)
+
+
+class TestGeneratedArtifactFlatten:
+    """Tests for the flatten option on GeneratedArtifact."""
+
+    def test_from_config_defaults_flatten_false(self, tmp_path) -> None:
+        artifact = base.GeneratedArtifact.from_config(
+            {"script": "build.sh", "artifacts": ["dist/"]}, tmp_path
+        )
+        assert artifact.flatten is False
+
+    def test_from_config_flatten_true(self, tmp_path) -> None:
+        artifact = base.GeneratedArtifact.from_config(
+            {"script": "build.sh", "artifacts": ["dist/"], "flatten": True},
+            tmp_path,
+        )
+        assert artifact.flatten is True
+
+    def test_directory_artifact_archived_without_flatten(self, tmp_path) -> None:
+        """Directory matched by generated artifact is archived with wrapper."""
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        _make_script(
+            work_dir / "build.sh",
+            "mkdir -p dist && echo hi > dist/index.html "
+            "&& mkdir -p dist/assets && echo css > dist/assets/style.css",
+        )
+
+        generated = base.GeneratedArtifact(
+            script=str(work_dir / "build.sh"),
+            work_dir=str(work_dir),
+            patterns=["dist/"],
+            flatten=False,
+        )
+        builder = SimpleBuilder(
+            exordos_dir=tmp_path,
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=tmp_path / "out",
+        )
+        output_dir = tmp_path / "artifacts"
+        result = builder._build_generated_artifact(generated, output_dir)
+
+        assert result == [pathlib.Path("dist.tar.zst")]
+        archive = output_dir / "dist.tar.zst"
+        assert archive.exists()
+
+        extracted_tar = tmp_path / "extracted.tar"
+        subprocess.run(
+            ["zstd", "-d", "-f", "-o", str(extracted_tar), str(archive)],
+            check=True,
+        )
+        with tarfile.open(extracted_tar) as tar:
+            names = tar.getnames()
+        assert "dist" in names
+        assert "dist/index.html" in names
+        assert "dist/assets" in names
+        assert "dist/assets/style.css" in names
+
+    def test_directory_artifact_archived_with_flatten(self, tmp_path) -> None:
+        """Directory matched by generated artifact with flatten has no wrapper."""
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        _make_script(
+            work_dir / "build.sh",
+            "mkdir -p dist && echo hi > dist/index.html "
+            "&& mkdir -p dist/assets && echo css > dist/assets/style.css",
+        )
+
+        generated = base.GeneratedArtifact(
+            script=str(work_dir / "build.sh"),
+            work_dir=str(work_dir),
+            patterns=["dist/"],
+            flatten=True,
+        )
+        builder = SimpleBuilder(
+            exordos_dir=tmp_path,
+            deps=[],
+            elements=[],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=tmp_path / "out",
+        )
+        output_dir = tmp_path / "artifacts"
+        result = builder._build_generated_artifact(generated, output_dir)
+
+        assert result == [pathlib.Path("dist.tar.zst")]
+        archive = output_dir / "dist.tar.zst"
+        assert archive.exists()
+
+        extracted_tar = tmp_path / "extracted.tar"
+        subprocess.run(
+            ["zstd", "-d", "-f", "-o", str(extracted_tar), str(archive)],
+            check=True,
+        )
+        with tarfile.open(extracted_tar) as tar:
+            names = tar.getnames()
+        assert "dist" not in names
+        assert "index.html" in names
+        assert "assets" in names
+        assert "assets/style.css" in names


### PR DESCRIPTION
- Add `flatten` field to `GeneratedArtifact` to strip the wrapper directory when archiving matched directories
- Support string shorthand for static artifacts in element config
- Update OpenAPI spec and docs with flatten option description
- Add unit tests for flatten behavior with and without the option

## Summary by Sourcery

Add support for flattening script-generated directory artifacts so their contents are archived without the wrapper directory, and wire this option through the builder configuration and pipeline.

New Features:
- Introduce a flatten flag on GeneratedArtifact to control whether matched directories are archived with or without their top-level wrapper.
- Allow string shorthand for static artifacts in element configuration to simplify artifact declarations.

Enhancements:
- Propagate the flatten option through directory archiving logic in the builder to support wrapper-less archives for script outputs.

Documentation:
- Document the flatten option for script-generated artifacts in the exordos YAML configuration guide, including usage examples.

Tests:
- Add unit tests covering default and explicit flatten behavior in GeneratedArtifact configuration and the resulting archive layout for directory artifacts.

Chores:
- Update the OpenAPI/JSON schema specification to describe the new flatten option for script-generated artifacts.