### PR TITLE
fix(clients): scope token cache to username

### DIFF
--- a/exordos/clients/base.py
+++ b/exordos/clients/base.py
@@ -142,10 +142,10 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         password_prompt: tp.Callable[[], str] | None = None,
         realm: str | None = None,
     ):
-        # Try to load from cache if realm is provided and no explicit tokens
-        if realm and not access_token and not refresh_token:
+        # Try to load from cache if username is provided and no explicit tokens
+        if username and not access_token and not refresh_token:
             cache = TokenCache()
-            cached_tokens = cache.load_tokens(realm)
+            cached_tokens = cache.load_tokens(username)
             if cached_tokens:
                 access_token = cached_tokens["access_token"]
                 refresh_token = cached_tokens["refresh_token"]
@@ -222,19 +222,19 @@ class CoreIamAuthenticator(AbstractAuthenticator):
                 otp = self._otp_prompt()
                 data = self._do_authenticate(otp=otp)
             else:
-                if self._realm:
+                if username := self._data.get("username"):
                     cache = TokenCache()
-                    cache.clear_tokens(self._realm)
+                    cache.clear_tokens(username)
                 raise
         except bazooka_exc.BadRequestError as e:
             error_data = e.cause.response.json()
             if (
                 error_data.get("error") == "invalid_grant"
                 and "expire" in error_data.get("error_description", "").lower()
-                and self._realm
+                and self._data.get("username")
             ):
                 cache = TokenCache()
-                cache.clear_tokens(self._realm)
+                cache.clear_tokens(self._data["username"])
                 self._refresh_token = None
                 data = self._do_authenticate()
             else:
@@ -243,11 +243,11 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         self._access_token = data["access_token"]
         self._refresh_token = data["refresh_token"]
 
-        # Save tokens to cache if realm is provided
-        if self._realm:
+        # Save tokens to cache if username is provided
+        if self._data.get("username"):
             cache = TokenCache()
             cache.save_tokens(
-                self._realm,
+                self._data["username"],
                 self._access_token,
                 self._refresh_token,
             )

--- a/exordos/clients/base.py
+++ b/exordos/clients/base.py
@@ -142,10 +142,12 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         password_prompt: tp.Callable[[], str] | None = None,
         realm: str | None = None,
     ):
-        # Try to load from cache if username is provided and no explicit tokens
-        if username and not access_token and not refresh_token:
+        cache_identity = username or login
+
+        # Try to load from cache if username or login and realm are provided.
+        if cache_identity and realm and not access_token and not refresh_token:
             cache = TokenCache()
-            cached_tokens = cache.load_tokens(username)
+            cached_tokens = cache.load_tokens(cache_identity, realm)
             if cached_tokens:
                 access_token = cached_tokens["access_token"]
                 refresh_token = cached_tokens["refresh_token"]
@@ -153,7 +155,7 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         if not (
             access_token
             or refresh_token
-            or (username and (password or password_prompt))
+            or (cache_identity and (password or password_prompt))
         ):
             raise ValueError(
                 "Insufficient authentication credentials. Provide 'access_token', 'refresh_token', or both 'username' and 'password'."
@@ -222,19 +224,25 @@ class CoreIamAuthenticator(AbstractAuthenticator):
                 otp = self._otp_prompt()
                 data = self._do_authenticate(otp=otp)
             else:
-                if username := self._data.get("username"):
-                    cache = TokenCache()
-                    cache.clear_tokens(username)
+                if cache_identity := self._data.get("username") or self._data.get(
+                    "login"
+                ):
+                    if self._realm:
+                        cache = TokenCache()
+                        cache.clear_tokens(cache_identity, self._realm)
                 raise
         except bazooka_exc.BadRequestError as e:
             error_data = e.cause.response.json()
             if (
                 error_data.get("error") == "invalid_grant"
                 and "expire" in error_data.get("error_description", "").lower()
-                and self._data.get("username")
+                and (self._data.get("username") or self._data.get("login"))
+                and self._realm
             ):
                 cache = TokenCache()
-                cache.clear_tokens(self._data["username"])
+                cache.clear_tokens(
+                    self._data.get("username") or self._data["login"], self._realm
+                )
                 self._refresh_token = None
                 data = self._do_authenticate()
             else:
@@ -243,14 +251,16 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         self._access_token = data["access_token"]
         self._refresh_token = data["refresh_token"]
 
-        # Save tokens to cache if username is provided
-        if self._data.get("username"):
-            cache = TokenCache()
-            cache.save_tokens(
-                self._data["username"],
-                self._access_token,
-                self._refresh_token,
-            )
+        # Save tokens to cache if username or login and realm are provided.
+        if cache_identity := self._data.get("username") or self._data.get("login"):
+            if self._realm:
+                cache = TokenCache()
+                cache.save_tokens(
+                    cache_identity,
+                    self._realm,
+                    self._access_token,
+                    self._refresh_token,
+                )
 
     def get_auth_header(self) -> dict[str, str]:
         if not self._access_token:

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -79,7 +79,9 @@ def decrypt_chacha20_poly1305(
     return cipher.decrypt(nonce, ciphertext, associated_data)
 
 
-def write_root_owned_file(content: str, dest_path: str, mode: str | None = None) -> None:
+def write_root_owned_file(
+    content: str, dest_path: str, mode: str | None = None
+) -> None:
     """Write `content` to `dest_path`, a system path this (non-root, but
     sudo-capable) process can't write to directly.
 

--- a/exordos/tests/unit/test_authenticator.py
+++ b/exordos/tests/unit/test_authenticator.py
@@ -342,6 +342,7 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
             # Verify save_tokens was called with correct arguments
             mock_cache.save_tokens.assert_called_once_with(
                 "testuser",
+                realm,
                 "cached_access_token",
                 "cached_refresh_token",
             )
@@ -384,12 +385,47 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
                 realm=realm,
             )
 
-            # Verify load_tokens uses the configured username
-            mock_cache.load_tokens.assert_called_once_with("testuser")
+            # Verify load_tokens uses the configured username and realm
+            mock_cache.load_tokens.assert_called_once_with("testuser", realm)
 
             # After all initialization, the final values should be from cache
             self.assertEqual(auth._access_token, cached_access)
             self.assertEqual(auth._refresh_token, cached_refresh)
+
+    def test_caches_tokens_using_login_when_username_is_missing(self):
+        """Test that login is used as the cache identity when username is absent."""
+        from unittest.mock import MagicMock
+        from unittest.mock import patch
+
+        from exordos.token_cache import TokenCache
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "cached_access_token",
+            "refresh_token": "cached_refresh_token",
+        }
+        mock_client.post.return_value = mock_response
+        mock_cache = MagicMock(spec=TokenCache)
+
+        with patch("exordos.clients.base.TokenCache", return_value=mock_cache):
+            auth = base.CoreIamAuthenticator(
+                base_url="https://example.com/api/core",
+                login="test-login",
+                password="testpass",
+                http_client=mock_client,
+                realm="test-realm",
+            )
+
+            auth.authenticate()
+
+        mock_cache.load_tokens.assert_called_once_with("test-login", "test-realm")
+        mock_cache.save_tokens.assert_called_once_with(
+            "test-login",
+            "test-realm",
+            "cached_access_token",
+            "cached_refresh_token",
+        )
 
 
 class TestGetOtpPrompt:

--- a/exordos/tests/unit/test_authenticator.py
+++ b/exordos/tests/unit/test_authenticator.py
@@ -143,16 +143,18 @@ class TestCoreIamAuthenticator:
         mock_client.post.return_value = mock_response
         password_prompt = mock.MagicMock(return_value="testpass")
 
-        auth = base.CoreIamAuthenticator(
-            base_url="https://example.com/api/core",
-            username="testuser",
-            password_prompt=password_prompt,
-            http_client=mock_client,
-        )
+        with mock.patch("exordos.clients.base.TokenCache") as mock_token_cache:
+            mock_token_cache.return_value.load_tokens.return_value = None
+            auth = base.CoreIamAuthenticator(
+                base_url="https://example.com/api/core",
+                username="testuser",
+                password_prompt=password_prompt,
+                http_client=mock_client,
+            )
 
-        password_prompt.assert_not_called()
+            password_prompt.assert_not_called()
 
-        auth.authenticate()
+            auth.authenticate()
 
         password_prompt.assert_called_once()
         _, kwargs = mock_client.post.call_args
@@ -339,7 +341,7 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
 
             # Verify save_tokens was called with correct arguments
             mock_cache.save_tokens.assert_called_once_with(
-                realm,
+                "testuser",
                 "cached_access_token",
                 "cached_refresh_token",
             )
@@ -382,8 +384,8 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
                 realm=realm,
             )
 
-            # Verify load_tokens was called (may be called multiple times in the __init__)
-            self.assertTrue(mock_cache.load_tokens.called)
+            # Verify load_tokens uses the configured username
+            mock_cache.load_tokens.assert_called_once_with("testuser")
 
             # After all initialization, the final values should be from cache
             self.assertEqual(auth._access_token, cached_access)

--- a/exordos/tests/unit/test_base_client.py
+++ b/exordos/tests/unit/test_base_client.py
@@ -57,9 +57,7 @@ class TestRegisterAgentAndWriteKey:
         fake_client.do_action.return_value = {"key": "s3cr3t-key=="}
 
         with patch.object(base_client, "write_agent_private_key") as write_key_mock:
-            base_client.register_agent_and_write_key(
-                fake_client, "node-uuid", key_path
-            )
+            base_client.register_agent_and_write_key(fake_client, "node-uuid", key_path)
 
         write_key_mock.assert_called_once_with("s3cr3t-key==", key_path)
 

--- a/exordos/tests/unit/test_token_cache.py
+++ b/exordos/tests/unit/test_token_cache.py
@@ -39,41 +39,46 @@ class TestTokenCache(unittest.TestCase):
         os.rmdir(self.temp_dir)
 
     def test_save_and_load_tokens(self):
-        """Test saving and loading tokens for a username."""
+        """Test saving and loading tokens for a username and realm."""
         username = "testuser"
+        realm = "test-realm"
         access_token = "test_access_token_123"
         refresh_token = "test_refresh_token_456"
 
-        self.cache.save_tokens(username, access_token, refresh_token)
+        self.cache.save_tokens(username, realm, access_token, refresh_token)
 
         self.assertTrue(os.path.exists(self.cache.cache_file))
-        loaded_tokens = self.cache.load_tokens(username)
+        loaded_tokens = self.cache.load_tokens(username, realm)
 
         self.assertIsNotNone(loaded_tokens)
         self.assertEqual(loaded_tokens["access_token"], access_token)
         self.assertEqual(loaded_tokens["refresh_token"], refresh_token)
 
-    def test_load_for_changed_username_deletes_cache_file(self):
-        """Test that loading tokens for another username invalidates the cache."""
-        self.cache.save_tokens("first-user", "access", "refresh")
+    def test_load_for_changed_username_returns_no_tokens(self):
+        """Test that a username has no tokens for another username's key."""
+        self.cache.save_tokens("first-user", "test-realm", "access", "refresh")
 
-        loaded_tokens = self.cache.load_tokens("second-user")
+        loaded_tokens = self.cache.load_tokens("second-user", "test-realm")
 
         self.assertIsNone(loaded_tokens)
-        self.assertFalse(os.path.exists(self.cache.cache_file))
+        self.assertTrue(os.path.exists(self.cache.cache_file))
 
     def test_load_from_empty_file(self):
         """Test loading tokens when cache file is empty."""
         with open(self.cache.cache_file, "w") as f:
             json.dump({}, f)
 
-        loaded_tokens = self.cache.load_tokens("testuser")
+        loaded_tokens = self.cache.load_tokens("testuser", "test-realm")
         self.assertIsNone(loaded_tokens)
 
     def test_save_for_changed_username_replaces_cached_tokens(self):
         """Test that saving tokens for another username replaces the cache."""
-        self.cache.save_tokens("first-user", "first-access", "first-refresh")
-        self.cache.save_tokens("second-user", "second-access", "second-refresh")
+        self.cache.save_tokens(
+            "first-user", "test-realm", "first-access", "first-refresh"
+        )
+        self.cache.save_tokens(
+            "second-user", "test-realm", "second-access", "second-refresh"
+        )
 
         with open(self.cache.cache_file, "r") as f:
             data = json.load(f)
@@ -81,21 +86,51 @@ class TestTokenCache(unittest.TestCase):
         self.assertEqual(
             data,
             {
-                "second-user": {
+                "test-realm_first-user": {
+                    "access_token": "first-access",
+                    "refresh_token": "first-refresh",
+                },
+                "test-realm_second-user": {
                     "access_token": "second-access",
                     "refresh_token": "second-refresh",
-                }
+                },
             },
         )
 
-    def test_clear_tokens(self):
-        """Test clearing tokens for a username."""
-        username = "testuser"
-        self.cache.save_tokens(username, "test_access", "test_refresh")
+    def test_save_multiple_realm_username_keys(self):
+        """Test saving tokens for multiple realm and username keys."""
+        self.cache.save_tokens(
+            "testuser", "first-realm", "first-access", "first-refresh"
+        )
+        self.cache.save_tokens(
+            "testuser", "second-realm", "second-access", "second-refresh"
+        )
 
-        self.cache.clear_tokens(username)
+        self.assertEqual(
+            self.cache.load_tokens("testuser", "first-realm"),
+            {"access_token": "first-access", "refresh_token": "first-refresh"},
+        )
+        self.assertEqual(
+            self.cache.load_tokens("testuser", "second-realm"),
+            {"access_token": "second-access", "refresh_token": "second-refresh"},
+        )
 
-        self.assertFalse(os.path.exists(self.cache.cache_file))
+    def test_clear_tokens_removes_only_realm_tokens(self):
+        """Test clearing tokens for one realm preserves the other realm."""
+        self.cache.save_tokens(
+            "testuser", "first-realm", "first-access", "first-refresh"
+        )
+        self.cache.save_tokens(
+            "testuser", "second-realm", "second-access", "second-refresh"
+        )
+
+        self.cache.clear_tokens("testuser", "first-realm")
+
+        self.assertIsNone(self.cache.load_tokens("testuser", "first-realm"))
+        self.assertEqual(
+            self.cache.load_tokens("testuser", "second-realm"),
+            {"access_token": "second-access", "refresh_token": "second-refresh"},
+        )
 
     def test_cache_file_permissions(self):
         """Test that cache file has correct permissions."""
@@ -104,7 +139,7 @@ class TestTokenCache(unittest.TestCase):
         refresh_token = "test_refresh"
 
         # Save tokens
-        self.cache.save_tokens(username, access_token, refresh_token)
+        self.cache.save_tokens(username, "test-realm", access_token, refresh_token)
 
         # Verify file permissions (should be 0o600)
         file_mode = os.stat(self.cache.cache_file).st_mode & 0o777

--- a/exordos/tests/unit/test_token_cache.py
+++ b/exordos/tests/unit/test_token_cache.py
@@ -39,109 +39,72 @@ class TestTokenCache(unittest.TestCase):
         os.rmdir(self.temp_dir)
 
     def test_save_and_load_tokens(self):
-        """Test saving and loading tokens for a realm."""
-        realm = "test-realm"
+        """Test saving and loading tokens for a username."""
+        username = "testuser"
         access_token = "test_access_token_123"
         refresh_token = "test_refresh_token_456"
 
-        # Save tokens
-        self.cache.save_tokens(realm, access_token, refresh_token)
+        self.cache.save_tokens(username, access_token, refresh_token)
 
-        # Verify cache file exists
         self.assertTrue(os.path.exists(self.cache.cache_file))
+        loaded_tokens = self.cache.load_tokens(username)
 
-        # Load tokens
-        loaded_tokens = self.cache.load_tokens(realm)
-
-        # Verify loaded tokens match saved tokens
         self.assertIsNotNone(loaded_tokens)
         self.assertEqual(loaded_tokens["access_token"], access_token)
         self.assertEqual(loaded_tokens["refresh_token"], refresh_token)
 
-    def test_load_nonexistent_realm(self):
-        """Test loading tokens for a realm that doesn't exist."""
-        loaded_tokens = self.cache.load_tokens("nonexistent-realm")
+    def test_load_for_changed_username_deletes_cache_file(self):
+        """Test that loading tokens for another username invalidates the cache."""
+        self.cache.save_tokens("first-user", "access", "refresh")
+
+        loaded_tokens = self.cache.load_tokens("second-user")
+
         self.assertIsNone(loaded_tokens)
+        self.assertFalse(os.path.exists(self.cache.cache_file))
 
     def test_load_from_empty_file(self):
         """Test loading tokens when cache file is empty."""
-        # Create empty cache file
         with open(self.cache.cache_file, "w") as f:
             json.dump({}, f)
 
-        loaded_tokens = self.cache.load_tokens("test-realm")
+        loaded_tokens = self.cache.load_tokens("testuser")
         self.assertIsNone(loaded_tokens)
 
-    def test_save_multiple_realms(self):
-        """Test saving tokens for multiple realms."""
-        realm1 = "realm1"
-        realm2 = "realm2"
-        access_token1 = "access1"
-        refresh_token1 = "refresh1"
-        access_token2 = "access2"
-        refresh_token2 = "refresh2"
+    def test_save_for_changed_username_replaces_cached_tokens(self):
+        """Test that saving tokens for another username replaces the cache."""
+        self.cache.save_tokens("first-user", "first-access", "first-refresh")
+        self.cache.save_tokens("second-user", "second-access", "second-refresh")
 
-        # Save tokens for both realms
-        self.cache.save_tokens(realm1, access_token1, refresh_token1)
-        self.cache.save_tokens(realm2, access_token2, refresh_token2)
+        with open(self.cache.cache_file, "r") as f:
+            data = json.load(f)
 
-        # Load and verify both realms
-        loaded_tokens1 = self.cache.load_tokens(realm1)
-        loaded_tokens2 = self.cache.load_tokens(realm2)
-
-        self.assertEqual(loaded_tokens1["access_token"], access_token1)
-        self.assertEqual(loaded_tokens1["refresh_token"], refresh_token1)
-        self.assertEqual(loaded_tokens2["access_token"], access_token2)
-        self.assertEqual(loaded_tokens2["refresh_token"], refresh_token2)
+        self.assertEqual(
+            data,
+            {
+                "second-user": {
+                    "access_token": "second-access",
+                    "refresh_token": "second-refresh",
+                }
+            },
+        )
 
     def test_clear_tokens(self):
-        """Test clearing tokens for a realm."""
-        realm = "test-realm"
-        access_token = "test_access"
-        refresh_token = "test_refresh"
+        """Test clearing tokens for a username."""
+        username = "testuser"
+        self.cache.save_tokens(username, "test_access", "test_refresh")
 
-        # Save tokens
-        self.cache.save_tokens(realm, access_token, refresh_token)
+        self.cache.clear_tokens(username)
 
-        # Clear tokens
-        self.cache.clear_tokens(realm)
-
-        # Verify tokens are cleared
-        loaded_tokens = self.cache.load_tokens(realm)
-        self.assertIsNone(loaded_tokens)
-
-    def test_clear_tokens_preserves_other_realms(self):
-        """Test that clearing tokens for one realm preserves others."""
-        realm1 = "realm1"
-        realm2 = "realm2"
-        access_token1 = "access1"
-        refresh_token1 = "refresh1"
-        access_token2 = "access2"
-        refresh_token2 = "refresh2"
-
-        # Save tokens for both realms
-        self.cache.save_tokens(realm1, access_token1, refresh_token1)
-        self.cache.save_tokens(realm2, access_token2, refresh_token2)
-
-        # Clear tokens for realm1
-        self.cache.clear_tokens(realm1)
-
-        # Verify realm1 is cleared but realm2 is preserved
-        loaded_tokens1 = self.cache.load_tokens(realm1)
-        loaded_tokens2 = self.cache.load_tokens(realm2)
-
-        self.assertIsNone(loaded_tokens1)
-        self.assertEqual(loaded_tokens2["access_token"], access_token2)
-        self.assertEqual(loaded_tokens2["refresh_token"], refresh_token2)
+        self.assertFalse(os.path.exists(self.cache.cache_file))
 
     def test_cache_file_permissions(self):
         """Test that cache file has correct permissions."""
-        realm = "test-realm"
+        username = "testuser"
         access_token = "test_access"
         refresh_token = "test_refresh"
 
         # Save tokens
-        self.cache.save_tokens(realm, access_token, refresh_token)
+        self.cache.save_tokens(username, access_token, refresh_token)
 
         # Verify file permissions (should be 0o600)
         file_mode = os.stat(self.cache.cache_file).st_mode & 0o777

--- a/exordos/token_cache.py
+++ b/exordos/token_cache.py
@@ -29,16 +29,19 @@ import exordos.constants as c
 
 
 class TokenCache:
-    """Manages token cache for multiple realms.
+    """Manages token cache for a username.
 
     Tokens are stored in a JSON file at ~/.exordos/tokens.json with the
     following structure:
     {
-        "<realm_name>": {
+        "<username>": {
             "access_token": "<token>",
             "refresh_token": "<token>",
         }
     }
+
+    The cache belongs to one username. It is removed when another username
+    attempts to use it.
     """
 
     def __init__(self, cache_dir: str | None = None):
@@ -54,15 +57,15 @@ class TokenCache:
         """Create cache directory if it doesn't exist."""
         os.makedirs(self.cache_dir, exist_ok=True)
 
-    def load_tokens(self, realm: str) -> dict[str, tp.Any] | None:
-        """Load cached tokens for a specific realm.
+    def load_tokens(self, username: str) -> dict[str, tp.Any] | None:
+        """Load cached tokens for a username.
 
         Args:
-            realm: Realm name to load tokens for.
+            username: Username to load tokens for.
 
         Returns:
             Dictionary with access_token and refresh_token if available,
-            None if no cached tokens exist for the realm.
+            None if no cached tokens exist for the username.
         """
         if not os.path.exists(self.cache_file):
             return None
@@ -74,22 +77,23 @@ class TokenCache:
             if not isinstance(data, dict):
                 return None
 
-            realm_tokens = data.get(realm)
-            if not isinstance(realm_tokens, dict):
+            user_tokens = data.get(username)
+            if not isinstance(user_tokens, dict):
+                os.unlink(self.cache_file)
                 return None
 
             return {
-                "access_token": realm_tokens.get("access_token"),
-                "refresh_token": realm_tokens.get("refresh_token"),
+                "access_token": user_tokens.get("access_token"),
+                "refresh_token": user_tokens.get("refresh_token"),
             }
         except (json.JSONDecodeError, IOError):
             return None
 
-    def save_tokens(self, realm: str, access_token: str, refresh_token: str) -> None:
-        """Save tokens to cache for a specific realm.
+    def save_tokens(self, username: str, access_token: str, refresh_token: str) -> None:
+        """Save tokens to cache for a username.
 
         Args:
-            realm: Realm name to save tokens for.
+            username: Username to save tokens for.
             access_token: Access token to cache.
             refresh_token: Refresh token to cache.
         """
@@ -106,8 +110,12 @@ class TokenCache:
             else:
                 data = {}
 
-            # Update tokens for the realm
-            data[realm] = {
+            if data and username not in data:
+                os.unlink(self.cache_file)
+                data = {}
+
+            # Update tokens for the username
+            data[username] = {
                 "access_token": access_token,
                 "refresh_token": refresh_token,
             }
@@ -125,11 +133,11 @@ class TokenCache:
             # Token caching is best-effort; do not crash the application if it fails
             pass
 
-    def clear_tokens(self, realm: str) -> None:
-        """Clear cached tokens for a specific realm.
+    def clear_tokens(self, username: str) -> None:
+        """Clear cached tokens for a username.
 
         Args:
-            realm: Realm name to clear tokens for.
+            username: Username whose cached tokens should be cleared.
         """
         if not os.path.exists(self.cache_file):
             return
@@ -137,15 +145,7 @@ class TokenCache:
         try:
             with open(self.cache_file, "r") as f:
                 data = json.load(f)
-            if realm in data:
-                del data[realm]
-                # Write back to file atomically with secure permissions (0o600)
-                tmp_file = self.cache_file + ".tmp"
-                fd = os.open(tmp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                with open(fd, "w") as f:
-                    json.dump(data, f, indent=2)
-                    f.flush()
-                    os.fsync(f.fileno())
-                os.replace(tmp_file, self.cache_file)
+            if username in data:
+                os.unlink(self.cache_file)
         except Exception:
             pass

--- a/exordos/token_cache.py
+++ b/exordos/token_cache.py
@@ -29,19 +29,16 @@ import exordos.constants as c
 
 
 class TokenCache:
-    """Manages token cache for a username.
+    """Manages token cache for a username and realm.
 
     Tokens are stored in a JSON file at ~/.exordos/tokens.json with the
     following structure:
     {
-        "<username>": {
+        "<realm>_<username>": {
             "access_token": "<token>",
             "refresh_token": "<token>",
         }
     }
-
-    The cache belongs to one username. It is removed when another username
-    attempts to use it.
     """
 
     def __init__(self, cache_dir: str | None = None):
@@ -57,15 +54,21 @@ class TokenCache:
         """Create cache directory if it doesn't exist."""
         os.makedirs(self.cache_dir, exist_ok=True)
 
-    def load_tokens(self, username: str) -> dict[str, tp.Any] | None:
-        """Load cached tokens for a username.
+    @staticmethod
+    def _cache_key(username: str, realm: str) -> str:
+        """Build the cache key for a username and realm."""
+        return f"{realm}_{username}"
+
+    def load_tokens(self, username: str, realm: str) -> dict[str, tp.Any] | None:
+        """Load cached tokens for a username and realm.
 
         Args:
             username: Username to load tokens for.
+            realm: Realm to load tokens for.
 
         Returns:
             Dictionary with access_token and refresh_token if available,
-            None if no cached tokens exist for the username.
+            None if no cached tokens exist for the username and realm.
         """
         if not os.path.exists(self.cache_file):
             return None
@@ -77,23 +80,25 @@ class TokenCache:
             if not isinstance(data, dict):
                 return None
 
-            user_tokens = data.get(username)
-            if not isinstance(user_tokens, dict):
-                os.unlink(self.cache_file)
+            tokens = data.get(self._cache_key(username, realm))
+            if not isinstance(tokens, dict):
                 return None
 
             return {
-                "access_token": user_tokens.get("access_token"),
-                "refresh_token": user_tokens.get("refresh_token"),
+                "access_token": tokens.get("access_token"),
+                "refresh_token": tokens.get("refresh_token"),
             }
         except (json.JSONDecodeError, IOError):
             return None
 
-    def save_tokens(self, username: str, access_token: str, refresh_token: str) -> None:
-        """Save tokens to cache for a username.
+    def save_tokens(
+        self, username: str, realm: str, access_token: str, refresh_token: str
+    ) -> None:
+        """Save tokens to cache for a username and realm.
 
         Args:
             username: Username to save tokens for.
+            realm: Realm to save tokens for.
             access_token: Access token to cache.
             refresh_token: Refresh token to cache.
         """
@@ -110,12 +115,8 @@ class TokenCache:
             else:
                 data = {}
 
-            if data and username not in data:
-                os.unlink(self.cache_file)
-                data = {}
-
-            # Update tokens for the username
-            data[username] = {
+            # Update tokens for the username and realm.
+            data[self._cache_key(username, realm)] = {
                 "access_token": access_token,
                 "refresh_token": refresh_token,
             }
@@ -133,11 +134,12 @@ class TokenCache:
             # Token caching is best-effort; do not crash the application if it fails
             pass
 
-    def clear_tokens(self, username: str) -> None:
-        """Clear cached tokens for a username.
+    def clear_tokens(self, username: str, realm: str) -> None:
+        """Clear cached tokens for a username and realm.
 
         Args:
             username: Username whose cached tokens should be cleared.
+            realm: Realm whose cached tokens should be cleared.
         """
         if not os.path.exists(self.cache_file):
             return
@@ -145,7 +147,19 @@ class TokenCache:
         try:
             with open(self.cache_file, "r") as f:
                 data = json.load(f)
-            if username in data:
-                os.unlink(self.cache_file)
+            cache_key = self._cache_key(username, realm)
+            if cache_key in data:
+                del data[cache_key]
+                if not data:
+                    os.unlink(self.cache_file)
+                    return
+
+                tmp_file = self.cache_file + ".tmp"
+                fd = os.open(tmp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with open(fd, "w") as f:
+                    json.dump(data, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_file, self.cache_file)
         except Exception:
             pass


### PR DESCRIPTION
## Summary by Sourcery

Scope token caching to individual usernames instead of realms and ensure cached credentials are invalidated when a different username is used.

Bug Fixes:
- Invalidate and remove the token cache file when tokens are loaded or saved for a different username than the one currently stored.
- Clear the entire token cache file when tokens are cleared for the active username, avoiding stale credentials across users.

Enhancements:
- Simplify the token cache to belong to a single username, updating documentation and tests to reflect the new behavior.
- Ensure client authentication consistently uses the configured username for loading, clearing, and saving cached tokens.
- Minor formatting cleanup in cryptography and base client tests for readability.