### PR TITLE
fix(cli): install the SPICE/QXL QEMU module on hypervisor hosts

### DIFF
--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -261,6 +261,12 @@ def _install_packages(add_sudo: bool = False) -> None:
     """Install required Debian packages."""
     packages = [
         "qemu-system-x86",
+        # qemu-system-x86 alone doesn't pull this in, but LibvirtPoolDriver's
+        # generated domain XML uses spice graphics + qxl video - without
+        # it libvirt rejects domain creation outright ("unsupported
+        # configuration: domain configuration does not support video
+        # model 'qxl'"), since QEMU itself doesn't report the device.
+        "qemu-system-modules-spice",
         "qemu-utils",
         "libvirt-daemon-system",
         "libvirt-dev",


### PR DESCRIPTION
qemu-system-x86 alone doesn't include it - Ubuntu splits SPICE/QXL display support into a separate qemu-system-modules-spice package. Without it, LibvirtPoolDriver's generated domain XML (spice graphics + qxl video) fails outright: libvirt rejects it since QEMU itself doesn't report the qxl device. A host that happened to already have it from unrelated prior setup worked fine; a freshly provisioned one (e.g. from the exordos-base image) didn't.

## Summary by Sourcery

Bug Fixes:
- Prevent libvirt domain creation failures on freshly provisioned hypervisor hosts by installing the qemu-system-modules-spice package.