### PR TITLE
fix(cli): add SSH public key environment variable

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -900,6 +900,7 @@ def _update_realm_config(
 )
 @click.option(
     "--ssh-public-key",
+    envvar="SSH_PUBLIC_KEY",
     multiple=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help=(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Enable configuring SSH public key paths via environment variable to fix missing env support for the SSH option.