### PR TITLE
fix(cli): bootstrap inventory envvar and options to create realm

### DIFF
--- a/exordos/cmd/realms/commands.py
+++ b/exordos/cmd/realms/commands.py
@@ -256,6 +256,13 @@ def list_cmd(ctx: click.Context) -> None:
     type=str,
     required=False,
 )
+@click.option(
+    "--ssh-public-key",
+    envvar="SSH_PUBLIC_KEY",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    required=False,
+    help="Path to the ssh public key",
+)
 def add_cmd(
     ctx: click.Context,
     uuid: sys_uuid.UUID | None,
@@ -266,6 +273,7 @@ def add_cmd(
     node_root_disk_size: int | None,
     node_image: str | None,
     core_version: str | None,
+    ssh_public_key: str | None,
 ) -> None:
     ecosystem_client = get_ecosystem_client(ctx)
     if uuid is None:
@@ -287,6 +295,10 @@ def add_cmd(
         data["node_image"] = node_image
     if core_version is not None:
         data["core_version"] = core_version
+    if ssh_public_key is not None:
+        with open(ssh_public_key, "r") as f:
+            ssh_public_key = f.read()
+        data["ssh_public_key"] = ssh_public_key
     data = base_client.add_entity(ecosystem_client, ENTITY_COLLECTION, data)
     show_data(data)
 

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -667,6 +667,7 @@ def _update_realm_config(
 @click.option(
     "-i",
     "--inventory",
+    envvar="INVENTORY",
     help=(
         "Path to the inventory directory containing inventory.json, "
         "or an HTTP(S) URL pointing to an Nginx-served directory. "
@@ -1138,6 +1139,9 @@ def bootstrap_cmd(
                 key_content = f.read().strip()
                 key_parts.append(key_content + "\n")
         ssh_public_key_content = "".join(key_parts)
+    elif realm_spec_data is not None and realm_spec_data.get("ssh_public_key"):
+        ssh_public_key_content = ssh_public_key_path = realm_spec_data["ssh_public_key"]
+        ssh_private_key_path = None
     else:
         with ssh.generate_keys(name.replace("-", "_"), permanent=True) as (
             private_key_path,


### PR DESCRIPTION
## Summary by Sourcery

Add CLI support for configuring SSH public keys and inventory paths when creating or bootstrapping realms and stands.

New Features:
- Allow specifying an SSH public key for realm creation via a new --ssh-public-key option or SSH_PUBLIC_KEY environment variable.
- Allow stand bootstrap commands to pick up the inventory path from an INVENTORY environment variable.

Enhancements:
- Use an existing ssh_public_key from realm specifications during stand bootstrap instead of always generating new keys.