### PR TITLE
feat(cli): add user info command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ tox -e docs
 tox -e bin
 ```
 
+Exordos core openapi specification: `https://github.com/exordos/exordos_core/blob/master/docs/openapi/openapi_user.yaml`
+
 ## Code Style and Naming Conventions
 
 ### Style Guidelines
@@ -176,6 +178,7 @@ When verifying changes, follow these rules:
 - **Linting**: Run `tox -e ruff`. Do not invoke `ruff` directly — always go through tox.
 - **Type checking**: Do NOT run `tox -e mypy` (or mypy in any form). Skip type checking entirely.
 - **Tests**: Prefer `tox -e py312` or `pytest exordos/tests/unit/` for the relevant test scope.
+- **Make Binary**: Run `tox -e bin`. Do not invoke `pyinstaller` directly — always go through tox.
 
 ## Additional Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ tox -e docs
 tox -e bin
 ```
 
-Exordos core openapi specification: `https://github.com/exordos/exordos_core/blob/master/docs/openapi/openapi_user.yaml`
+Exordos core OpenAPI specification: `https://github.com/exordos/exordos_core/blob/master/docs/openapi/openapi_user.yaml`
 
 ## Code Style and Naming Conventions
 

--- a/docs/cli/users_info.md
+++ b/docs/cli/users_info.md
@@ -1,0 +1,48 @@
+
+# users_info
+
+Show detailed information about the user
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos iam users info [OPTIONS] USER                                   
+                                                                                
+```
+
+## Options
+* `user` (REQUIRED): 
+  * Type: text 
+  * Default: `sentinel.unset`
+  * Usage: `user`
+
+  user UUID or username
+
+
+* `output`: 
+  * Type: choice 
+  * Default: `table`
+  * Usage: `--output
+-o`
+
+  the output format, defaults to table
+
+
+* `help`: 
+  * Type: boolean 
+  * Default: `false`
+  * Usage: `--help`
+
+  Show this message and exit.
+
+
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos iam users info [OPTIONS] USER                                   
+                                                                                
+```
+

--- a/docs/cli/users_info.md
+++ b/docs/cli/users_info.md
@@ -12,31 +12,28 @@ Show detailed information about the user
 ```
 
 ## Options
-* `user` (REQUIRED): 
-  * Type: text 
-  * Default: `sentinel.unset`
-  * Usage: `user`
+
+* `user` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `user`
 
   user UUID or username
 
-
-* `output`: 
-  * Type: choice 
-  * Default: `table`
-  * Usage: `--output
+* `output`:
+    * Type: choice
+    * Default: `table`
+    * Usage: `--output
 -o`
 
   the output format, defaults to table
 
-
-* `help`: 
-  * Type: boolean 
-  * Default: `false`
-  * Usage: `--help`
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
 
   Show this message and exit.
-
-
 
 ## CLI Help
 
@@ -45,4 +42,3 @@ Show detailed information about the user
  Usage: exordos iam users info [OPTIONS] USER                                   
                                                                                 
 ```
-

--- a/exordos/cmd/iam/user/commands.py
+++ b/exordos/cmd/iam/user/commands.py
@@ -215,6 +215,89 @@ def change_password_cmd(
     click.echo(f"Password changed for {ENTITY} {uuid}")
 
 
+@users_group.command("info", help=f"Show detailed information about the {ENTITY}")
+@click.pass_context
+@click.argument(
+    "user",
+    type=str,
+    required=True,
+    help=f"{ENTITY} UUID or username",
+)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+def info_cmd(ctx: click.Context, user: str, output: str) -> None:
+    user_fields = ["uuid", "username", "email", "first_name", "last_name", "status"]
+    project_fields = ["uuid", "name", "organization"]
+    role_binding_fields = ["uuid", "role", "project", "user"]
+    organization_fields = ["uuid", "name"]
+    org_member_fields = ["uuid", "user", "organization", "role"]
+
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    user_data = base_client.get_entity(client, ENTITY_COLLECTION, user)
+    user_uuid = user_data["uuid"]
+    role_bindings = base_client.list_entities(
+        client, c.ROLE_BINDING_COLLECTION, user=user_uuid
+    )
+
+    organizations = base_client.list_entities(client, c.ORGANIZATION_COLLECTION)
+    org_members = []
+    user_organizations = []
+
+    for organization in organizations:
+        members = base_client.list_entities(
+            client,
+            c.ORGANIZATION_MEMBER_COLLECTION.format(
+                organization_uuid=organization["uuid"]
+            ),
+            user=user_uuid,
+        )
+        if members:
+            user_organizations.append(organization)
+            org_members.extend(members)
+
+    projects = []
+    for organization in user_organizations:
+        projects.extend(
+            base_client.list_entities(
+                client,
+                c.PROJECT_COLLECTION,
+                organization=organization["uuid"],
+            )
+        )
+    projects = [
+        {k: v for k, v in project.items() if k in project_fields}
+        for project in projects
+    ]
+    role_bindings = [
+        {k: v for k, v in role_binding.items() if k in role_binding_fields}
+        for role_binding in role_bindings
+    ]
+    org_members = [
+        {k: v for k, v in org_member.items() if k in org_member_fields}
+        for org_member in org_members
+    ]
+    user_organizations = [
+        {k: v for k, v in organization.items() if k in organization_fields}
+        for organization in user_organizations
+    ]
+
+    show_data(
+        {
+            "user": {k: v for k, v in user_data.items() if k in user_fields},
+            "orgs": user_organizations,
+            "projects": projects,
+            "role_bindings": role_bindings,
+            "org_members": org_members,
+        },
+        output,
+    )
+
+
 @users_group.command("confirm_email", help=f"Confirm email of the {ENTITY}")
 @click.pass_context
 @click.argument(


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI command to display detailed information about a user and document its usage, along with minor updates to development guidelines and references.

New Features:
- Introduce `exordos iam users info` CLI command to show detailed user information including organizations, projects, role bindings, and organization memberships.

Enhancements:
- Clarify developer workflow by emphasizing use of `tox -e bin` instead of invoking pyinstaller directly.

Documentation:
- Add user-facing documentation page for the `users info` CLI command, including usage, options, and help output.
- Document the location of the Exordos core OpenAPI user specification and extend AGENTS guidelines with instructions for building the binary via tox.