### PR TITLE
feat(cli): support deleting multiple resources

### DIFF
--- a/docs/cli/backend_pools_delete.md
+++ b/docs/cli/backend_pools_delete.md
@@ -7,7 +7,7 @@ Delete backend_pool
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network backend_pools delete [OPTIONS] UUID                                                                                                                                                                                                                                                
+ Usage: exordos network backend_pools delete [OPTIONS] UUID...                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -42,7 +42,7 @@ Delete backend_pool
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network backend_pools delete [OPTIONS] UUID                                                                                                                                                                                                                                                
+ Usage: exordos network backend_pools delete [OPTIONS] UUID...                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            
  Delete backend_pool                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/borders_delete.md
+++ b/docs/cli/borders_delete.md
@@ -7,7 +7,7 @@ Delete border
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network borders delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos network borders delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete border
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network borders delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos network borders delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
  Delete border                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/certificates_delete.md
+++ b/docs/cli/certificates_delete.md
@@ -7,7 +7,7 @@ Delete certificate
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret certificates delete [OPTIONS] UUID                                                                                                                                                                                                                                                  
+ Usage: exordos secret certificates delete [OPTIONS] UUID...                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete certificate
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret certificates delete [OPTIONS] UUID                                                                                                                                                                                                                                                  
+ Usage: exordos secret certificates delete [OPTIONS] UUID...                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            
  Delete certificate                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/clients_delete.md
+++ b/docs/cli/clients_delete.md
@@ -7,7 +7,7 @@ Delete client
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam clients delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos iam clients delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete client
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam clients delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos iam clients delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
  Delete client                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/cn_delete.md
+++ b/docs/cli/cn_delete.md
@@ -7,7 +7,7 @@ Delete node
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos cn delete [OPTIONS] UUID                                                                                                                                                                                                                                                                   
+ Usage: exordos cn delete [OPTIONS] UUID...                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete node
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos cn delete [OPTIONS] UUID                                                                                                                                                                                                                                                                   
+ Usage: exordos cn delete [OPTIONS] UUID...                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            
  Delete node                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/domains_delete.md
+++ b/docs/cli/domains_delete.md
@@ -7,7 +7,7 @@ Delete domain
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos dns domains delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos dns domains delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete domain
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos dns domains delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos dns domains delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
  Delete domain                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/exordos.md
+++ b/docs/cli/exordos.md
@@ -43,6 +43,14 @@ Provides all the necessary tools for work with Exordos Platform
 
   Client user name
 
+* `login`:
+    * Type: text
+    * Default: `none`
+    * Usage: `-l
+--login`
+
+  Client login
+
 * `password`:
     * Type: text
     * Default: `none`

--- a/docs/cli/hypervisors_delete.md
+++ b/docs/cli/hypervisors_delete.md
@@ -7,7 +7,7 @@ Delete hypervisor
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos compute hypervisors delete [OPTIONS] UUID                                                                                                                                                                                                                                                  
+ Usage: exordos compute hypervisors delete [OPTIONS] UUID...                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete hypervisor
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos compute hypervisors delete [OPTIONS] UUID                                                                                                                                                                                                                                                  
+ Usage: exordos compute hypervisors delete [OPTIONS] UUID...                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            
  Delete hypervisor                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/idps_delete.md
+++ b/docs/cli/idps_delete.md
@@ -7,7 +7,7 @@ Delete idp
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam idps delete [OPTIONS] UUID                                                                                                                                                                                                                                                             
+ Usage: exordos iam idps delete [OPTIONS] UUID...                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete idp
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam idps delete [OPTIONS] UUID                                                                                                                                                                                                                                                             
+ Usage: exordos iam idps delete [OPTIONS] UUID...                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                            
  Delete idp                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/load_balancers_delete.md
+++ b/docs/cli/load_balancers_delete.md
@@ -7,7 +7,7 @@ Delete load_balancer
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network load_balancers delete [OPTIONS] UUID                                                                                                                                                                                                                                               
+ Usage: exordos network load_balancers delete [OPTIONS] UUID...                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete load_balancer
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network load_balancers delete [OPTIONS] UUID                                                                                                                                                                                                                                               
+ Usage: exordos network load_balancers delete [OPTIONS] UUID...                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            
  Delete load_balancer                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/manifests_delete.md
+++ b/docs/cli/manifests_delete.md
@@ -7,7 +7,7 @@ Delete manifest
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos em manifests delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos em manifests delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete manifest
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos em manifests delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos em manifests delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
  Delete manifest                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/organization_members_delete.md
+++ b/docs/cli/organization_members_delete.md
@@ -7,7 +7,7 @@ Delete organization_member
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam organization_members delete [OPTIONS] UUID                                                                                                                                                                                                                                             
+ Usage: exordos iam organization_members delete [OPTIONS] UUID...                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -42,7 +42,7 @@ Delete organization_member
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam organization_members delete [OPTIONS] UUID                                                                                                                                                                                                                                             
+ Usage: exordos iam organization_members delete [OPTIONS] UUID...                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                            
  Delete organization_member                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/organizations_delete.md
+++ b/docs/cli/organizations_delete.md
@@ -7,7 +7,7 @@ Delete organization
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam organizations delete [OPTIONS] UUID                                                                                                                                                                                                                                                    
+ Usage: exordos iam organizations delete [OPTIONS] UUID...                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete organization
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam organizations delete [OPTIONS] UUID                                                                                                                                                                                                                                                    
+ Usage: exordos iam organizations delete [OPTIONS] UUID...                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                            
  Delete organization                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/passwords_delete.md
+++ b/docs/cli/passwords_delete.md
@@ -7,7 +7,7 @@ Delete password
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret passwords delete [OPTIONS] UUID                                                                                                                                                                                                                                                     
+ Usage: exordos secret passwords delete [OPTIONS] UUID...                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete password
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret passwords delete [OPTIONS] UUID                                                                                                                                                                                                                                                     
+ Usage: exordos secret passwords delete [OPTIONS] UUID...                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                            
  Delete password                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/permission_bindings_delete.md
+++ b/docs/cli/permission_bindings_delete.md
@@ -7,7 +7,7 @@ Delete permission_binding
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam permission_bindings delete [OPTIONS] UUID                                                                                                                                                                                                                                              
+ Usage: exordos iam permission_bindings delete [OPTIONS] UUID...                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete permission_binding
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam permission_bindings delete [OPTIONS] UUID                                                                                                                                                                                                                                              
+ Usage: exordos iam permission_bindings delete [OPTIONS] UUID...                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                            
  Delete permission_binding                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/permissions_delete.md
+++ b/docs/cli/permissions_delete.md
@@ -7,7 +7,7 @@ Delete permission
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam permissions delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos iam permissions delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete permission
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam permissions delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos iam permissions delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
  Delete permission                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/profiles_delete.md
+++ b/docs/cli/profiles_delete.md
@@ -7,7 +7,7 @@ Delete profile
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vs profiles delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos vs profiles delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete profile
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vs profiles delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos vs profiles delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
  Delete profile                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/projects_delete.md
+++ b/docs/cli/projects_delete.md
@@ -7,7 +7,7 @@ Delete project
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam projects delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos iam projects delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete project
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam projects delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos iam projects delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
  Delete project                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/realms_add.md
+++ b/docs/cli/realms_add.md
@@ -63,6 +63,13 @@ Add a new ecosystem realm
     * Default: `sentinel.unset`
     * Usage: `--core-version`
 
+* `ssh_public_key`:
+    * Type: file
+    * Default: `sentinel.unset`
+    * Usage: `--ssh-public-key`
+
+  Path to the ssh public key
+
 * `help`:
     * Type: boolean
     * Default: `false`
@@ -87,6 +94,7 @@ Add a new ecosystem realm
 │ --node-root-disk-size      INTEGER                                                                                                                                                                                                                                                                      │
 │ --node-image               TEXT     Url of the realm image                                                                                                                                                                                                                                              │
 │ --core-version             TEXT                                                                                                                                                                                                                                                                         │
+│ --ssh-public-key           FILE     Path to the ssh public key                                                                                                                                                                                                                                          │
 │ --help                              Show this message and exit.                                                                                                                                                                                                                                         │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/docs/cli/records_delete.md
+++ b/docs/cli/records_delete.md
@@ -7,7 +7,7 @@ Delete record
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos dns records delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos dns records delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -42,7 +42,7 @@ Delete record
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos dns records delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos dns records delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
  Delete record                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/repo_delete.md
+++ b/docs/cli/repo_delete.md
@@ -7,7 +7,7 @@ Delete repository
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos repo delete [OPTIONS] UUID                                                                                                                                                                                                                                                                 
+ Usage: exordos repo delete [OPTIONS] UUID...                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete repository
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos repo delete [OPTIONS] UUID                                                                                                                                                                                                                                                                 
+ Usage: exordos repo delete [OPTIONS] UUID...                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                            
  Delete repository                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/role_bindings_delete.md
+++ b/docs/cli/role_bindings_delete.md
@@ -7,7 +7,7 @@ Delete role_binding
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam role_bindings delete [OPTIONS] UUID                                                                                                                                                                                                                                                    
+ Usage: exordos iam role_bindings delete [OPTIONS] UUID...                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete role_binding
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam role_bindings delete [OPTIONS] UUID                                                                                                                                                                                                                                                    
+ Usage: exordos iam role_bindings delete [OPTIONS] UUID...                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                            
  Delete role_binding                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/roles_delete.md
+++ b/docs/cli/roles_delete.md
@@ -7,7 +7,7 @@ Delete role
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam roles delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos iam roles delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete role
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam roles delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos iam roles delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
  Delete role                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/routes_delete.md
+++ b/docs/cli/routes_delete.md
@@ -7,7 +7,7 @@ Delete route
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network routes delete [OPTIONS] UUID                                                                                                                                                                                                                                                       
+ Usage: exordos network routes delete [OPTIONS] UUID...                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -47,7 +47,7 @@ Delete route
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network routes delete [OPTIONS] UUID                                                                                                                                                                                                                                                       
+ Usage: exordos network routes delete [OPTIONS] UUID...                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                            
  Delete route                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/rsa_keys_delete.md
+++ b/docs/cli/rsa_keys_delete.md
@@ -7,7 +7,7 @@ Delete rsa_key
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret rsa_keys delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos secret rsa_keys delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete rsa_key
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret rsa_keys delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos secret rsa_keys delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
  Delete rsa_key                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/rules_delete.md
+++ b/docs/cli/rules_delete.md
@@ -7,7 +7,7 @@ Delete rule
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos rules delete [OPTIONS] UUID                                                                                                                                                                                                                                                                
+ Usage: exordos rules delete [OPTIONS] UUID...                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete rule
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos rules delete [OPTIONS] UUID                                                                                                                                                                                                                                                                
+ Usage: exordos rules delete [OPTIONS] UUID...                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                            
  Delete rule                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/services_delete.md
+++ b/docs/cli/services_delete.md
@@ -7,7 +7,7 @@ Delete service
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos em services delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos em services delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete service
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos em services delete [OPTIONS] UUID                                                                                                                                                                                                                                                          
+ Usage: exordos em services delete [OPTIONS] UUID...                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                            
  Delete service                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/sets_delete.md
+++ b/docs/cli/sets_delete.md
@@ -7,7 +7,7 @@ Delete set
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos compute sets delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos compute sets delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete set
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos compute sets delete [OPTIONS] UUID                                                                                                                                                                                                                                                         
+ Usage: exordos compute sets delete [OPTIONS] UUID...                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                            
  Delete set                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/ssh_keys_delete.md
+++ b/docs/cli/ssh_keys_delete.md
@@ -7,7 +7,7 @@ Delete ssh_key
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret ssh_keys delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos secret ssh_keys delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete ssh_key
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos secret ssh_keys delete [OPTIONS] UUID                                                                                                                                                                                                                                                      
+ Usage: exordos secret ssh_keys delete [OPTIONS] UUID...                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                            
  Delete ssh_key                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/users_delete.md
+++ b/docs/cli/users_delete.md
@@ -7,7 +7,7 @@ Delete user
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam users delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos iam users delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete user
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos iam users delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos iam users delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
  Delete user                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/users_info.md
+++ b/docs/cli/users_info.md
@@ -6,9 +6,9 @@ Show detailed information about the user
 ## Usage
 
 ```console
-                                                                                
- Usage: exordos iam users info [OPTIONS] USER                                   
-                                                                                
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos iam users info [OPTIONS] USER                                                                                                                                                                                                                                                              
+                                                                                                                                                                                                                                                                                                           
 ```
 
 ## Options
@@ -38,7 +38,7 @@ Show detailed information about the user
 ## CLI Help
 
 ```console
-                                                                                
- Usage: exordos iam users info [OPTIONS] USER                                   
-                                                                                
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos iam users info [OPTIONS] USER                                                                                                                                                                                                                                                              
+                                                                                                                                                                                                                                                                                                           
 ```

--- a/docs/cli/values_delete.md
+++ b/docs/cli/values_delete.md
@@ -7,7 +7,7 @@ Delete value
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vs values delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos vs values delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete value
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vs values delete [OPTIONS] UUID                                                                                                                                                                                                                                                            
+ Usage: exordos vs values delete [OPTIONS] UUID...                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                            
  Delete value                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/vhosts_delete.md
+++ b/docs/cli/vhosts_delete.md
@@ -7,7 +7,7 @@ Delete vhost
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network vhosts delete [OPTIONS] UUID                                                                                                                                                                                                                                                       
+ Usage: exordos network vhosts delete [OPTIONS] UUID...                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -42,7 +42,7 @@ Delete vhost
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos network vhosts delete [OPTIONS] UUID                                                                                                                                                                                                                                                       
+ Usage: exordos network vhosts delete [OPTIONS] UUID...                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                            
  Delete vhost                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                            

--- a/docs/cli/vv_delete.md
+++ b/docs/cli/vv_delete.md
@@ -7,7 +7,7 @@ Delete variable
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vv delete [OPTIONS] UUID                                                                                                                                                                                                                                                                   
+ Usage: exordos vv delete [OPTIONS] UUID...                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            
 ```
 
@@ -37,7 +37,7 @@ Delete variable
 
 ```console
                                                                                                                                                                                                                                                                                                            
- Usage: exordos vv delete [OPTIONS] UUID                                                                                                                                                                                                                                                                   
+ Usage: exordos vv delete [OPTIONS] UUID...                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                            
  Delete variable                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                            

--- a/exordos/cmd/base.py
+++ b/exordos/cmd/base.py
@@ -207,6 +207,7 @@ def create_entity_group(
         @click.command("delete", help=f"Delete {entity_name}")
         @click.argument(
             "uuid",
+            nargs=-1,
             type=str,
             required=True,
         )
@@ -221,16 +222,20 @@ def create_entity_group(
         @click.pass_context
         def delete_cmd(
             ctx: click.Context,
-            uuid: str,
+            uuid: tuple[str, ...],
             y: bool,
             **kwargs,
         ) -> None:
-            if y or questionary.confirm(f"Delete {entity_name} {uuid}?").ask():
-                client = base_client.get_user_api_client(ctx.obj.auth_data)
-                base_client.delete_entity(
-                    client, entity_collection.format(**kwargs), uuid
-                )
-                click.echo(f"{entity_name} {uuid} deleted")
+            client = base_client.get_user_api_client(ctx.obj.auth_data)
+            for entity_uuid in uuid:
+                if (
+                    y
+                    or questionary.confirm(f"Delete {entity_name} {entity_uuid}?").ask()
+                ):
+                    base_client.delete_entity(
+                        client, entity_collection.format(**kwargs), entity_uuid
+                    )
+                    click.echo(f"{entity_name} {entity_uuid} deleted")
 
         entity_group.add_command(delete_cmd, aliases=["d"])
 

--- a/exordos/cmd/cli.py
+++ b/exordos/cmd/cli.py
@@ -109,6 +109,12 @@ def _get_otp_prompt(otp_code: str | None) -> str:
     help="Client user name",
 )
 @click.option(
+    "-l",
+    "--login",
+    default=None,
+    help="Client login",
+)
+@click.option(
     "-p",
     "--password",
     default=None,
@@ -193,6 +199,7 @@ def exordos(
     endpoint: str,
     ecosystem_endpoint: str | None,
     user: str | None,
+    login: str | None,
     password: str | None,
     access_token: str | None,
     refresh_token: str | None,
@@ -246,6 +253,7 @@ def exordos(
         "check_updates", check_updates, cfg, realm_conf
     )
     final_user = _get_final_value("user", user, cfg, context_conf)
+    final_login = _get_final_value("login", login, cfg, context_conf)
     final_password = _get_final_value("password", password, cfg, context_conf)
     final_access_token = _get_final_value(
         "access_token", access_token, cfg, context_conf
@@ -280,6 +288,7 @@ def exordos(
         endpoint=final_endpoint,
         ecosystem_endpoint=final_ecosystem_endpoint,
         username=final_user,
+        login=final_login,
         password=final_password,
         access_token=final_access_token,
         refresh_token=final_refresh_token,

--- a/exordos/cmd/secret/ssh_keys/commands.py
+++ b/exordos/cmd/secret/ssh_keys/commands.py
@@ -189,6 +189,9 @@ def add_cmd(
                 }
         targets = list(targets_dict.values())
 
+    if not targets:
+        raise click.ClickException("No nodes and node_sets found")
+
     if project_id is None:
         project_id = targets[0]["project_id"]
     data["project_id"] = str(project_id)


### PR DESCRIPTION
## Summary by Sourcery

Allow CLI delete commands to operate on multiple resources at once and extend authentication options.

New Features:
- Support passing multiple UUIDs to delete commands across CLI resources with per-resource confirmation.
- Add a new global CLI option to authenticate using a client login separate from username.
- Introduce an ssh_public_key option for realm creation to specify an SSH public key file.

Bug Fixes:
- Fail fast with a clear error when attempting to add SSH keys without any matching nodes or node sets.

Documentation:
- Update CLI documentation to reflect multi-UUID delete support, the new login option, and the ssh_public_key parameter for realms.