### PR TITLE
fix(cli): cached tokens by requested scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ list_ecosystem_realms:
 	./dist/exordos -u jdoe@corp.com -p 12345678 realms l
 
 delete_ecosystem_realm:
-	./dist/exordos -u jdoe@corp.com -p 12345678 realms d example --ecosystem
+	./dist/exordos -u jdoe@corp.com -p 12345678 realms d example

--- a/exordos/clients/base.py
+++ b/exordos/clients/base.py
@@ -143,11 +143,12 @@ class CoreIamAuthenticator(AbstractAuthenticator):
         realm: str | None = None,
     ):
         cache_identity = username or login
+        cache_scope = scope or self.empty_scope()
 
-        # Try to load from cache if username or login and realm are provided.
+        # Try to load from cache if identity and realm are provided.
         if cache_identity and realm and not access_token and not refresh_token:
             cache = TokenCache()
-            cached_tokens = cache.load_tokens(cache_identity, realm)
+            cached_tokens = cache.load_tokens(cache_identity, realm, cache_scope)
             if cached_tokens:
                 access_token = cached_tokens["access_token"]
                 refresh_token = cached_tokens["refresh_token"]
@@ -172,7 +173,7 @@ class CoreIamAuthenticator(AbstractAuthenticator):
 
         self._data = {
             "password": password,
-            "scope": scope or self.empty_scope(),
+            "scope": cache_scope,
             "ttl": str(self._ttl),
             "refresh_ttl": str(self._refresh_ttl),
         }
@@ -229,7 +230,9 @@ class CoreIamAuthenticator(AbstractAuthenticator):
                 ):
                     if self._realm:
                         cache = TokenCache()
-                        cache.clear_tokens(cache_identity, self._realm)
+                        cache.clear_tokens(
+                            cache_identity, self._realm, self._data["scope"]
+                        )
                 raise
         except bazooka_exc.BadRequestError as e:
             error_data = e.cause.response.json()
@@ -241,7 +244,9 @@ class CoreIamAuthenticator(AbstractAuthenticator):
             ):
                 cache = TokenCache()
                 cache.clear_tokens(
-                    self._data.get("username") or self._data["login"], self._realm
+                    self._data.get("username") or self._data["login"],
+                    self._realm,
+                    self._data["scope"],
                 )
                 self._refresh_token = None
                 data = self._do_authenticate()
@@ -258,6 +263,7 @@ class CoreIamAuthenticator(AbstractAuthenticator):
                 cache.save_tokens(
                     cache_identity,
                     self._realm,
+                    self._data["scope"],
                     self._access_token,
                     self._refresh_token,
                 )

--- a/exordos/tests/unit/test_authenticator.py
+++ b/exordos/tests/unit/test_authenticator.py
@@ -343,6 +343,7 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
             mock_cache.save_tokens.assert_called_once_with(
                 "testuser",
                 realm,
+                "",
                 "cached_access_token",
                 "cached_refresh_token",
             )
@@ -385,8 +386,8 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
                 realm=realm,
             )
 
-            # Verify load_tokens uses the configured username and realm
-            mock_cache.load_tokens.assert_called_once_with("testuser", realm)
+            # Verify load_tokens uses the configured username, realm, and scope
+            mock_cache.load_tokens.assert_called_once_with("testuser", realm, "")
 
             # After all initialization, the final values should be from cache
             self.assertEqual(auth._access_token, cached_access)
@@ -419,10 +420,11 @@ class TestCoreIamAuthenticatorTokenCache(unittest.TestCase):
 
             auth.authenticate()
 
-        mock_cache.load_tokens.assert_called_once_with("test-login", "test-realm")
+        mock_cache.load_tokens.assert_called_once_with("test-login", "test-realm", "")
         mock_cache.save_tokens.assert_called_once_with(
             "test-login",
             "test-realm",
+            "",
             "cached_access_token",
             "cached_refresh_token",
         )

--- a/exordos/tests/unit/test_token_cache.py
+++ b/exordos/tests/unit/test_token_cache.py
@@ -42,13 +42,14 @@ class TestTokenCache(unittest.TestCase):
         """Test saving and loading tokens for a username and realm."""
         username = "testuser"
         realm = "test-realm"
+        scope = "test-scope"
         access_token = "test_access_token_123"
         refresh_token = "test_refresh_token_456"
 
-        self.cache.save_tokens(username, realm, access_token, refresh_token)
+        self.cache.save_tokens(username, realm, scope, access_token, refresh_token)
 
         self.assertTrue(os.path.exists(self.cache.cache_file))
-        loaded_tokens = self.cache.load_tokens(username, realm)
+        loaded_tokens = self.cache.load_tokens(username, realm, scope)
 
         self.assertIsNotNone(loaded_tokens)
         self.assertEqual(loaded_tokens["access_token"], access_token)
@@ -56,9 +57,13 @@ class TestTokenCache(unittest.TestCase):
 
     def test_load_for_changed_username_returns_no_tokens(self):
         """Test that a username has no tokens for another username's key."""
-        self.cache.save_tokens("first-user", "test-realm", "access", "refresh")
+        self.cache.save_tokens(
+            "first-user", "test-realm", "test-scope", "access", "refresh"
+        )
 
-        loaded_tokens = self.cache.load_tokens("second-user", "test-realm")
+        loaded_tokens = self.cache.load_tokens(
+            "second-user", "test-realm", "test-scope"
+        )
 
         self.assertIsNone(loaded_tokens)
         self.assertTrue(os.path.exists(self.cache.cache_file))
@@ -68,16 +73,16 @@ class TestTokenCache(unittest.TestCase):
         with open(self.cache.cache_file, "w") as f:
             json.dump({}, f)
 
-        loaded_tokens = self.cache.load_tokens("testuser", "test-realm")
+        loaded_tokens = self.cache.load_tokens("testuser", "test-realm", "test-scope")
         self.assertIsNone(loaded_tokens)
 
     def test_save_for_changed_username_replaces_cached_tokens(self):
         """Test that saving tokens for another username replaces the cache."""
         self.cache.save_tokens(
-            "first-user", "test-realm", "first-access", "first-refresh"
+            "first-user", "test-realm", "test-scope", "first-access", "first-refresh"
         )
         self.cache.save_tokens(
-            "second-user", "test-realm", "second-access", "second-refresh"
+            "second-user", "test-realm", "test-scope", "second-access", "second-refresh"
         )
 
         with open(self.cache.cache_file, "r") as f:
@@ -86,49 +91,55 @@ class TestTokenCache(unittest.TestCase):
         self.assertEqual(
             data,
             {
-                "test-realm_first-user": {
+                "test-realm_first-user_test-scope": {
                     "access_token": "first-access",
                     "refresh_token": "first-refresh",
                 },
-                "test-realm_second-user": {
+                "test-realm_second-user_test-scope": {
                     "access_token": "second-access",
                     "refresh_token": "second-refresh",
                 },
             },
         )
 
-    def test_save_multiple_realm_username_keys(self):
-        """Test saving tokens for multiple realm and username keys."""
+    def test_save_multiple_realm_username_scope_keys(self):
+        """Test saving tokens for multiple realm, username, and scope keys."""
         self.cache.save_tokens(
-            "testuser", "first-realm", "first-access", "first-refresh"
+            "testuser", "first-realm", "first-scope", "first-access", "first-refresh"
         )
         self.cache.save_tokens(
-            "testuser", "second-realm", "second-access", "second-refresh"
+            "testuser",
+            "second-realm",
+            "second-scope",
+            "second-access",
+            "second-refresh",
         )
 
         self.assertEqual(
-            self.cache.load_tokens("testuser", "first-realm"),
+            self.cache.load_tokens("testuser", "first-realm", "first-scope"),
             {"access_token": "first-access", "refresh_token": "first-refresh"},
         )
         self.assertEqual(
-            self.cache.load_tokens("testuser", "second-realm"),
+            self.cache.load_tokens("testuser", "second-realm", "second-scope"),
             {"access_token": "second-access", "refresh_token": "second-refresh"},
         )
 
-    def test_clear_tokens_removes_only_realm_tokens(self):
-        """Test clearing tokens for one realm preserves the other realm."""
+    def test_clear_tokens_removes_only_scope_tokens(self):
+        """Test clearing tokens for one scope preserves the other scope."""
         self.cache.save_tokens(
-            "testuser", "first-realm", "first-access", "first-refresh"
+            "testuser", "test-realm", "first-scope", "first-access", "first-refresh"
         )
         self.cache.save_tokens(
-            "testuser", "second-realm", "second-access", "second-refresh"
+            "testuser", "test-realm", "second-scope", "second-access", "second-refresh"
         )
 
-        self.cache.clear_tokens("testuser", "first-realm")
+        self.cache.clear_tokens("testuser", "test-realm", "first-scope")
 
-        self.assertIsNone(self.cache.load_tokens("testuser", "first-realm"))
+        self.assertIsNone(
+            self.cache.load_tokens("testuser", "test-realm", "first-scope")
+        )
         self.assertEqual(
-            self.cache.load_tokens("testuser", "second-realm"),
+            self.cache.load_tokens("testuser", "test-realm", "second-scope"),
             {"access_token": "second-access", "refresh_token": "second-refresh"},
         )
 
@@ -139,7 +150,9 @@ class TestTokenCache(unittest.TestCase):
         refresh_token = "test_refresh"
 
         # Save tokens
-        self.cache.save_tokens(username, "test-realm", access_token, refresh_token)
+        self.cache.save_tokens(
+            username, "test-realm", "test-scope", access_token, refresh_token
+        )
 
         # Verify file permissions (should be 0o600)
         file_mode = os.stat(self.cache.cache_file).st_mode & 0o777

--- a/exordos/token_cache.py
+++ b/exordos/token_cache.py
@@ -29,12 +29,12 @@ import exordos.constants as c
 
 
 class TokenCache:
-    """Manages token cache for a username and realm.
+    """Manages token cache for a username, realm, and scope.
 
     Tokens are stored in a JSON file at ~/.exordos/tokens.json with the
     following structure:
     {
-        "<realm>_<username>": {
+        "<realm>_<username>_<scope>": {
             "access_token": "<token>",
             "refresh_token": "<token>",
         }
@@ -55,20 +55,23 @@ class TokenCache:
         os.makedirs(self.cache_dir, exist_ok=True)
 
     @staticmethod
-    def _cache_key(username: str, realm: str) -> str:
-        """Build the cache key for a username and realm."""
-        return f"{realm}_{username}"
+    def _cache_key(username: str, realm: str, scope: str) -> str:
+        """Build the cache key for a username, realm, and scope."""
+        return f"{realm}_{username}_{scope}"
 
-    def load_tokens(self, username: str, realm: str) -> dict[str, tp.Any] | None:
-        """Load cached tokens for a username and realm.
+    def load_tokens(
+        self, username: str, realm: str, scope: str
+    ) -> dict[str, tp.Any] | None:
+        """Load cached tokens for a username, realm, and scope.
 
         Args:
             username: Username to load tokens for.
             realm: Realm to load tokens for.
+            scope: Scope to load tokens for.
 
         Returns:
             Dictionary with access_token and refresh_token if available,
-            None if no cached tokens exist for the username and realm.
+            None if no cached tokens exist for the username, realm, and scope.
         """
         if not os.path.exists(self.cache_file):
             return None
@@ -80,7 +83,7 @@ class TokenCache:
             if not isinstance(data, dict):
                 return None
 
-            tokens = data.get(self._cache_key(username, realm))
+            tokens = data.get(self._cache_key(username, realm, scope))
             if not isinstance(tokens, dict):
                 return None
 
@@ -92,13 +95,19 @@ class TokenCache:
             return None
 
     def save_tokens(
-        self, username: str, realm: str, access_token: str, refresh_token: str
+        self,
+        username: str,
+        realm: str,
+        scope: str,
+        access_token: str,
+        refresh_token: str,
     ) -> None:
-        """Save tokens to cache for a username and realm.
+        """Save tokens to cache for a username, realm, and scope.
 
         Args:
             username: Username to save tokens for.
             realm: Realm to save tokens for.
+            scope: Scope to save tokens for.
             access_token: Access token to cache.
             refresh_token: Refresh token to cache.
         """
@@ -115,8 +124,8 @@ class TokenCache:
             else:
                 data = {}
 
-            # Update tokens for the username and realm.
-            data[self._cache_key(username, realm)] = {
+            # Update tokens for the username, realm, and scope.
+            data[self._cache_key(username, realm, scope)] = {
                 "access_token": access_token,
                 "refresh_token": refresh_token,
             }
@@ -134,12 +143,13 @@ class TokenCache:
             # Token caching is best-effort; do not crash the application if it fails
             pass
 
-    def clear_tokens(self, username: str, realm: str) -> None:
-        """Clear cached tokens for a username and realm.
+    def clear_tokens(self, username: str, realm: str, scope: str) -> None:
+        """Clear cached tokens for a username, realm, and scope.
 
         Args:
             username: Username whose cached tokens should be cleared.
             realm: Realm whose cached tokens should be cleared.
+            scope: Scope whose cached tokens should be cleared.
         """
         if not os.path.exists(self.cache_file):
             return
@@ -147,7 +157,7 @@ class TokenCache:
         try:
             with open(self.cache_file, "r") as f:
                 data = json.load(f)
-            cache_key = self._cache_key(username, realm)
+            cache_key = self._cache_key(username, realm, scope)
             if cache_key in data:
                 del data[cache_key]
                 if not data:


### PR DESCRIPTION
## Summary by Sourcery

Cache authentication tokens by username, realm, and scope instead of just username and realm, and update clients and tests to use the new cache key format.

Bug Fixes:
- Ensure cached tokens are segregated by scope so different permission scopes do not share or overwrite each other.

Enhancements:
- Extend token cache API and authenticator client to include scope in cache keys and cache clearing logic.
- Improve token cache tests to cover scope-aware caching and clearing behaviors.