### PR TITLE
fix show not existing in response domains for vhosts

### DIFF
--- a/exordos/cmd/network/vhosts/commands.py
+++ b/exordos/cmd/network/vhosts/commands.py
@@ -26,7 +26,7 @@ FIELDS_MAP = {
     "Name": "name",
     "Protocol": "protocol",
     "Port": "port",
-    "Domains": "domains",
+    "Domains": lambda x: str(x.get("domains", "")),
     "Enabled": "enabled",
     "External Sources": "external_sources",
     "Status": "status",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure vhost domain information is correctly rendered as a string in the command output instead of relying on direct mapping.