### PR TITLE
Add fast versioned macOS CLI installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,19 @@ name: build binary
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/build.yml'
+      - '.github/workflows/publish-to-pypi.yml'
+      - 'etc/install.sh'
+      - 'etc/package-macos.sh'
+      - 'exordos/**'
+      - 'pyproject.toml'
+      - 'tox.ini'
 
 jobs:
   build_binaries:
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include:
@@ -13,9 +23,6 @@ jobs:
             python-version: "3.14"
           - os: ubuntu-latest
             artifact-suffix: linux
-            python-version: "3.14"
-          - os: macos-latest
-            artifact-suffix: macos-arm
             python-version: "3.14"
           - os: windows-latest
             artifact-suffix: windows
@@ -52,3 +59,129 @@ jobs:
         with:
           name: exordos-${{ matrix.artifact-suffix }}
           path: dist/*
+
+  build_macos_binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            machine-arch: arm64
+            target-arch: arm64
+            artifact-suffix: macos-arm64
+            python-version: "3.14"
+          - os: macos-15-intel
+            machine-arch: x86_64
+            target-arch: x86_64
+            artifact-suffix: macos-x86_64
+            python-version: "3.14"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 30
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = "${{ matrix.machine-arch }}"
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install tox-uv
+        run: uv tool install tox --with tox-uv
+      - name: Build macOS onedir bundle
+        run: >-
+          tox -e bin --
+          --onedir
+          --target-arch "${{ matrix.target-arch }}"
+      - name: Verify bundle and signatures
+        run: |
+          set -euo pipefail
+          lipo dist/exordos/exordos -verify_arch "${{ matrix.target-arch }}"
+          dist/exordos/exordos --silent --no-check-updates version
+          while IFS= read -r -d '' candidate; do
+            if file "$candidate" | grep -q 'Mach-O'; then
+              case "$candidate" in
+                *.framework/*)
+                  codesign --verify --strict --ignore-resources --verbose=2 "$candidate"
+                  ;;
+                *)
+                  codesign --verify --strict --verbose=2 "$candidate"
+                  ;;
+              esac
+            fi
+          done < <(find dist/exordos -type f -print0)
+      - name: Archive bundle and create checksum
+        run: >-
+          sh etc/package-macos.sh
+          dist/exordos
+          dist/exordos-${{ matrix.artifact-suffix }}.zip
+      - name: Smoke-test installer
+        env:
+          ARTIFACT: exordos-${{ matrix.artifact-suffix }}.zip
+        run: |
+          set -euo pipefail
+          VERSION=$(dist/exordos/exordos --silent --no-check-updates version)
+          REPO_ROOT="$RUNNER_TEMP/exordos-repo"
+          INSTALL_PREFIX="$RUNNER_TEMP/exordos-install"
+          mkdir -p "$REPO_ROOT/latest" "$REPO_ROOT/$VERSION"
+          cp "dist/$ARTIFACT" "dist/$ARTIFACT.sha256" "$REPO_ROOT/$VERSION/"
+          printf '%s\n' "$VERSION" > "$REPO_ROOT/latest/VERSION"
+          EXORDOS_INSTALL_PREFIX="$INSTALL_PREFIX" \
+          EXORDOS_REPO_URL="file://$REPO_ROOT" \
+          EXORDOS_INSTALL_ALLOW_ADHOC=1 \
+            sh etc/install.sh
+          "$INSTALL_PREFIX/bin/exordos" --silent --no-check-updates version
+          "$INSTALL_PREFIX/bin/exordos" --help >/dev/null
+      - name: Check startup performance
+        env:
+          EXORDOS_BINARY: ${{ runner.temp }}/exordos-install/bin/exordos
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          import statistics
+          import subprocess
+          import tempfile
+          import time
+
+          binary = os.environ["EXORDOS_BINARY"]
+          with tempfile.TemporaryDirectory() as directory:
+              root = Path(directory)
+              environment = os.environ | {
+                  "HOME": str(root / "home"),
+                  "TMPDIR": str(root / "tmp"),
+              }
+              Path(environment["HOME"]).mkdir()
+              Path(environment["TMPDIR"]).mkdir()
+              command = [
+                  binary,
+                  "--config",
+                  str(root / "missing.yaml"),
+                  "--no-check-updates",
+                  "--silent",
+                  "version",
+              ]
+              subprocess.run(command, check=True, env=environment, capture_output=True)
+              durations = []
+              for _ in range(7):
+                  started = time.perf_counter()
+                  subprocess.run(command, check=True, env=environment, capture_output=True)
+                  durations.append(time.perf_counter() - started)
+              median = statistics.median(durations)
+              maximum = max(durations)
+              print(f"startup median={median:.3f}s max={maximum:.3f}s")
+              if median >= 2.0 or maximum >= 5.0:
+                  raise SystemExit("macOS startup performance regression")
+              if list(Path(environment["TMPDIR"]).glob("_MEI*")):
+                  raise SystemExit("onedir launch unexpectedly created a _MEI directory")
+          PY
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: exordos-${{ matrix.artifact-suffix }}
+          path: |
+            dist/exordos-${{ matrix.artifact-suffix }}.zip
+            dist/exordos-${{ matrix.artifact-suffix }}.zip.sha256

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build_python:
     name: Build distribution 📦
+    needs: validate_release_ref
     runs-on: ubuntu-latest
 
     steps:
@@ -41,6 +42,8 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to PyPI
     needs:
     - build_python
+    - build_binaries
+    - build_macos_binaries
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -58,6 +61,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
   build_binaries:
+    needs: validate_release_ref
     strategy:
       matrix:
         include:
@@ -67,27 +71,24 @@ jobs:
           - os: ubuntu-latest
             artifact-suffix: linux
             python-version: "3.14"
-          - os: macos-latest
-            artifact-suffix: macos-arm
-            python-version: "3.14"
           - os: windows-latest
             artifact-suffix: windows
             python-version: "3.14"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 30
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install --yes ca-certificates
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Install tox-uv
         run: uv tool install tox --with tox-uv
       - name: Build executable
@@ -101,20 +102,254 @@ jobs:
           fi
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: exordos-${{ matrix.artifact-suffix }}
           path: dist/*
+
+  build_macos_binaries:
+    name: Build signed macOS ${{ matrix.target-arch }} bundle
+    needs: validate_release_ref
+    environment: macos-release
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            machine-arch: arm64
+            target-arch: arm64
+            artifact-suffix: macos-arm64
+            python-version: "3.14"
+          - os: macos-15-intel
+            machine-arch: x86_64
+            target-arch: x86_64
+            artifact-suffix: macos-x86_64
+            python-version: "3.14"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 30
+          persist-credentials: false
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = "${{ matrix.machine-arch }}"
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Install tox-uv
+        run: uv tool install tox --with tox-uv
+      - name: Validate signing secrets
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$MACOS_CERTIFICATE_P12_BASE64"
+          test -n "$MACOS_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_API_PRIVATE_KEY_P8_BASE64"
+          test -n "$APPLE_API_KEY_ID"
+          test -n "$APPLE_API_ISSUER_ID"
+      - name: Import Developer ID certificate
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/exordos-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 32)
+          printf '%s' "$MACOS_CERTIFICATE_P12_BASE64" \
+            | /usr/bin/base64 -D > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          IDENTITY_COUNT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -c 'Developer ID Application')
+          test "$IDENTITY_COUNT" -eq 1
+          SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | awk '/Developer ID Application/ {print $2; exit}')
+          test -n "$SIGNING_IDENTITY"
+          printf 'MACOS_SIGNING_IDENTITY=%s\n' "$SIGNING_IDENTITY" >> "$GITHUB_ENV"
+      - name: Build signed macOS onedir bundle
+        run: >-
+          tox -e bin --
+          --onedir
+          --target-arch "${{ matrix.target-arch }}"
+          --codesign-identity "$MACOS_SIGNING_IDENTITY"
+      - name: Verify architecture and Developer ID signatures
+        run: |
+          set -euo pipefail
+          lipo dist/exordos/exordos -verify_arch "${{ matrix.target-arch }}"
+          VERSION=$(dist/exordos/exordos --silent --no-check-updates version)
+          test "$VERSION" = "$GITHUB_REF_NAME"
+
+          SIGNING_TEAM=''
+          verify_developer_id() {
+            local candidate=$1
+            shift
+            codesign --verify --strict --verbose=2 "$@" "$candidate"
+            local signature
+            signature=$(codesign -dvvv "$candidate" 2>&1)
+            ! grep -q '^Signature=adhoc$' <<< "$signature"
+            grep -q '^Authority=Developer ID Application:' <<< "$signature"
+            local team
+            team=$(awk -F= '/^TeamIdentifier=/ {print $2; exit}' <<< "$signature")
+            test -n "$team"
+            test "$team" != 'not set'
+            if [[ -z "$SIGNING_TEAM" ]]; then
+              SIGNING_TEAM=$team
+            else
+              test "$team" = "$SIGNING_TEAM"
+            fi
+            SIGNED_CODE_COUNT=$((SIGNED_CODE_COUNT + 1))
+          }
+
+          SIGNED_CODE_COUNT=0
+          while IFS= read -r -d '' candidate; do
+            if file "$candidate" | grep -q 'Mach-O'; then
+              case "$candidate" in
+                *.framework/*)
+                  verify_developer_id "$candidate" --ignore-resources
+                  ;;
+                *)
+                  verify_developer_id "$candidate"
+                  ;;
+              esac
+            fi
+          done < <(find dist/exordos -type f -print0)
+          test "$SIGNED_CODE_COUNT" -gt 0
+      - name: Archive bundle
+        run: >-
+          sh etc/package-macos.sh
+          dist/exordos
+          dist/exordos-${{ matrix.artifact-suffix }}.zip
+      - name: Notarize archive
+        env:
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY_P8_BASE64" \
+            | /usr/bin/base64 -D > "$API_KEY_PATH"
+          chmod 600 "$API_KEY_PATH"
+          xcrun notarytool submit \
+            "dist/exordos-${{ matrix.artifact-suffix }}.zip" \
+            --key "$API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          spctl --assess --type execute --verbose=4 dist/exordos/exordos
+      - name: Smoke-test installer
+        env:
+          ARTIFACT: exordos-${{ matrix.artifact-suffix }}.zip
+        run: |
+          set -euo pipefail
+          VERSION=$(dist/exordos/exordos --silent --no-check-updates version)
+          REPO_ROOT="$RUNNER_TEMP/exordos-repo"
+          INSTALL_PREFIX="$RUNNER_TEMP/exordos-install"
+          mkdir -p "$REPO_ROOT/latest" "$REPO_ROOT/$VERSION"
+          cp "dist/$ARTIFACT" "dist/$ARTIFACT.sha256" "$REPO_ROOT/$VERSION/"
+          printf '%s\n' "$VERSION" > "$REPO_ROOT/latest/VERSION"
+          EXORDOS_INSTALL_PREFIX="$INSTALL_PREFIX" \
+          EXORDOS_REPO_URL="file://$REPO_ROOT" \
+            sh etc/install.sh
+          "$INSTALL_PREFIX/bin/exordos" --silent --no-check-updates version
+          "$INSTALL_PREFIX/bin/exordos" --help >/dev/null
+      - name: Check startup performance
+        env:
+          EXORDOS_BINARY: ${{ runner.temp }}/exordos-install/bin/exordos
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          import statistics
+          import subprocess
+          import tempfile
+          import time
+
+          binary = os.environ["EXORDOS_BINARY"]
+          with tempfile.TemporaryDirectory() as directory:
+              root = Path(directory)
+              environment = os.environ | {
+                  "HOME": str(root / "home"),
+                  "TMPDIR": str(root / "tmp"),
+              }
+              Path(environment["HOME"]).mkdir()
+              Path(environment["TMPDIR"]).mkdir()
+              command = [
+                  binary,
+                  "--config",
+                  str(root / "missing.yaml"),
+                  "--no-check-updates",
+                  "--silent",
+                  "version",
+              ]
+              subprocess.run(command, check=True, env=environment, capture_output=True)
+              durations = []
+              for _ in range(7):
+                  started = time.perf_counter()
+                  subprocess.run(command, check=True, env=environment, capture_output=True)
+                  durations.append(time.perf_counter() - started)
+              median = statistics.median(durations)
+              maximum = max(durations)
+              print(f"startup median={median:.3f}s max={maximum:.3f}s")
+              if median >= 2.0 or maximum >= 5.0:
+                  raise SystemExit("macOS startup performance regression")
+              if list(Path(environment["TMPDIR"]).glob("_MEI*")):
+                  raise SystemExit("onedir launch unexpectedly created a _MEI directory")
+          PY
+      - name: Remove signing material before artifact upload
+        run: |
+          security delete-keychain "$RUNNER_TEMP/exordos-signing.keychain-db"
+          rm -f \
+            "$RUNNER_TEMP/developer-id.p12" \
+            "$RUNNER_TEMP"/AuthKey_*.p8
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: exordos-${{ matrix.artifact-suffix }}
+          path: |
+            dist/exordos-${{ matrix.artifact-suffix }}.zip
+            dist/exordos-${{ matrix.artifact-suffix }}.zip.sha256
+      - name: Remove signing material
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/exordos-signing.keychain-db" 2>/dev/null || true
+          rm -f \
+            "$RUNNER_TEMP/developer-id.p12" \
+            "$RUNNER_TEMP"/AuthKey_*.p8
 
   github-release:
     name: Create GitHub Release with artifacts
     needs:
     - publish-to-pypi
     - build_binaries
+    - build_macos_binaries
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
 
     steps:
     - name: Download Python distributions
@@ -132,10 +367,15 @@ jobs:
       with:
         name: exordos-linux-ubuntu-resolute
         path: dist/
-    - name: Download macOS arm binary
+    - name: Download macOS arm64 bundle
       uses: actions/download-artifact@v8
       with:
-        name: exordos-macos-arm
+        name: exordos-macos-arm64
+        path: dist/
+    - name: Download macOS x86_64 bundle
+      uses: actions/download-artifact@v8
+      with:
+        name: exordos-macos-x86_64
         path: dist/
     - name: Download Windows binary
       uses: actions/download-artifact@v8
@@ -149,7 +389,7 @@ jobs:
         gh release create
         "$GITHUB_REF_NAME"
         --repo "$GITHUB_REPOSITORY"
-        --notes ""
+        --generate-notes
     - name: Upload release artifacts
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -160,10 +400,13 @@ jobs:
 
   exordos-release:
     name: Create exordos Release with artifacts
-    needs:
-    - build_binaries
+    needs: github-release
     runs-on: self-hosted
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Download Linux binary
       uses: actions/download-artifact@v8
       with:
@@ -174,10 +417,15 @@ jobs:
       with:
         name: exordos-linux-ubuntu-resolute
         path: dist/
-    - name: Download macOS arm binary
+    - name: Download macOS arm64 bundle
       uses: actions/download-artifact@v8
       with:
-        name: exordos-macos-arm
+        name: exordos-macos-arm64
+        path: dist/
+    - name: Download macOS x86_64 bundle
+      uses: actions/download-artifact@v8
+      with:
+        name: exordos-macos-x86_64
         path: dist/
     - name: Download Windows binary
       uses: actions/download-artifact@v8
@@ -186,26 +434,69 @@ jobs:
         path: dist/
     - name: Push artifacts to repository
       run: |
-        set -eux
+        set -eu
+        : "${REPO_ENDPOINT_PUT:?REPO_ENDPOINT_PUT must be set}"
         chmod +x ./dist/exordos-linux
         VERSION=$(./dist/exordos-linux --silent version)
+        printf '%s\n' "$VERSION" > ./dist/VERSION
+
+        upload() {
+          curl --fail --show-error --silent \
+            -X PUT --upload-file "$1" "$REPO_ENDPOINT_PUT/$2"
+        }
 
         # Upload VERSION release
-        curl -X PUT --upload-file ./dist/exordos-linux \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/${VERSION}/exordos-linux
-        curl -X PUT --upload-file ./dist/exordos-linux-ubuntu-resolute \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/${VERSION}/exordos-linux-ubuntu-resolute
-        curl -X PUT --upload-file ./dist/exordos-macos-arm \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/${VERSION}/exordos-macos-arm
-        curl -X PUT --upload-file ./dist/exordos-windows.exe \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/${VERSION}/exordos-windows.exe
+        upload ./dist/exordos-linux \
+          "${PROJECT_NAME}/${VERSION}/exordos-linux"
+        upload ./dist/exordos-linux-ubuntu-resolute \
+          "${PROJECT_NAME}/${VERSION}/exordos-linux-ubuntu-resolute"
+        upload ./dist/exordos-macos-arm64.zip \
+          "${PROJECT_NAME}/${VERSION}/exordos-macos-arm64.zip"
+        upload ./dist/exordos-macos-arm64.zip.sha256 \
+          "${PROJECT_NAME}/${VERSION}/exordos-macos-arm64.zip.sha256"
+        upload ./dist/exordos-macos-x86_64.zip \
+          "${PROJECT_NAME}/${VERSION}/exordos-macos-x86_64.zip"
+        upload ./dist/exordos-macos-x86_64.zip.sha256 \
+          "${PROJECT_NAME}/${VERSION}/exordos-macos-x86_64.zip.sha256"
+        upload ./dist/exordos-windows.exe \
+          "${PROJECT_NAME}/${VERSION}/exordos-windows.exe"
 
         # Upload latest release
-        curl -X PUT --upload-file ./dist/exordos-linux \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/latest/exordos-linux
-        curl -X PUT --upload-file ./dist/exordos-linux \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/latest/exordos-linux-ubuntu-resolute
-        curl -X PUT --upload-file ./dist/exordos-macos-arm \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/latest/exordos-macos-arm
-        curl -X PUT --upload-file ./dist/exordos-windows.exe \
-          $REPO_ENDPOINT_PUT/${PROJECT_NAME}/latest/exordos-windows.exe
+        upload ./dist/exordos-linux \
+          "${PROJECT_NAME}/latest/exordos-linux"
+        upload ./dist/exordos-linux \
+          "${PROJECT_NAME}/latest/exordos-linux-ubuntu-resolute"
+        upload ./dist/exordos-macos-arm64.zip \
+          "${PROJECT_NAME}/latest/exordos-macos-arm64.zip"
+        upload ./dist/exordos-macos-arm64.zip.sha256 \
+          "${PROJECT_NAME}/latest/exordos-macos-arm64.zip.sha256"
+        upload ./dist/exordos-macos-x86_64.zip \
+          "${PROJECT_NAME}/latest/exordos-macos-x86_64.zip"
+        upload ./dist/exordos-macos-x86_64.zip.sha256 \
+          "${PROJECT_NAME}/latest/exordos-macos-x86_64.zip.sha256"
+        upload ./dist/exordos-windows.exe \
+          "${PROJECT_NAME}/latest/exordos-windows.exe"
+
+        # VERSION is the commit point for the new macOS installer contract.
+        upload ./dist/VERSION "${PROJECT_NAME}/latest/VERSION"
+
+        # Activate the installer only after all referenced artifacts exist.
+        upload ./etc/install.sh "install.sh"
+
+  validate_release_ref:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Validate tag and branch ancestry
+      run: |
+        set -euo pipefail
+        if [[ ! "$GITHUB_REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+[-+0-9A-Za-z.]*$ ]]; then
+          echo "Release tag is not a supported Exordos version: $GITHUB_REF_NAME" >&2
+          exit 1
+        fi
+        git fetch origin master
+        git merge-base --is-ancestor "$GITHUB_SHA" origin/master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
       - '.markdownlint.yaml'
       - '*.md'
   pull_request:
-    types: [opened]
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -35,6 +34,20 @@ jobs:
       - name: ruff
         run: |
           tox -e ruff-check
+  Installer:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install tox-uv
+        run: uv tool install tox --with tox-uv
+      - name: Shell lint and installer tests
+        run: tox -e installer
   Tests:
     runs-on: ubuntu-24.04
     strategy:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://repo.exordos.com/install.sh | sh
 
 ## What Exordos CLI does
 
-Exordos CLI bridges the gap between your local development environment and the Exordos Core platform. With a single binary you can:
+Exordos CLI bridges the gap between your local development environment and the Exordos Core platform. With a self-contained installation you can:
 
 - **Build projects** — compile Exordos project images and artifacts from a declarative `exordos.yaml` configuration.
 - **Bootstrap installations** — spin up local virtual machine environments from built images for development and testing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Exordos CLI is the official command-line interface for the [Exordos Core platfor
 
 **📚 Platform Documentation:** [exordos.github.io/exordos_core](https://exordos.github.io/exordos_core/)
 
-With a single binary you can:
+With a self-contained CLI installation you can:
 
 - **Build projects** — compile Exordos project images and artifacts from a declarative `exordos.yaml` configuration.
 - **Bootstrap installations** — spin up local virtual machine environments from built images for development and testing.
@@ -20,6 +20,16 @@ Install the CLI with a single command:
 
 ```bash
 curl -fsSL https://repo.exordos.com/install.sh | sh
+```
+
+On macOS, the installer selects the native Apple Silicon or Intel archive,
+verifies its SHA-256 checksum, and keeps versioned installations under
+`/usr/local/lib/exordos`. The active `/usr/local/bin/exordos` launcher is
+switched atomically. To reactivate an already installed version or install a
+specific published version, set `EXORDOS_VERSION`:
+
+```bash
+curl -fsSL https://repo.exordos.com/install.sh | EXORDOS_VERSION=3.1.15 sh
 ```
 
 ### Via uv

--- a/docs/index.ru.md
+++ b/docs/index.ru.md
@@ -4,7 +4,7 @@ Exordos CLI — это интерфейс командной строки для
 
 **📚 Документация платформы:** [exordos.github.io/exordos_core](https://exordos.github.io/exordos_core/)
 
-С помощью одного бинарного файла вы можете:
+С помощью автономной установки CLI вы можете:
 
 - **Собирать проекты** — компилировать образы и артефакты проектов Exordos из декларативной конфигурации `exordos.yaml`.
 - **Инициализировать установки** — запускать локальные виртуальные машины из собранных образов для разработки и тестирования.
@@ -19,7 +19,17 @@ Exordos CLI — это интерфейс командной строки для
 Установите CLI одной командой:
 
 ```bash
-curl -fsSL https://repo.exordos.com/install.sh | sudo sh
+curl -fsSL https://repo.exordos.com/install.sh | sh
+```
+
+В macOS установщик выбирает нативный архив для Apple Silicon или Intel,
+проверяет его контрольную сумму SHA-256 и хранит версии в
+`/usr/local/lib/exordos`. Активная ссылка `/usr/local/bin/exordos`
+переключается атомарно. Чтобы активировать уже установленную версию или
+установить конкретную опубликованную версию, задайте `EXORDOS_VERSION`:
+
+```bash
+curl -fsSL https://repo.exordos.com/install.sh | EXORDOS_VERSION=3.1.15 sh
 ```
 
 ### Через uv

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -15,20 +15,59 @@ status() { echo ">>> $*" >&2; }
 error() { echo "${red}ERROR:${plain} $*"; exit 1; }
 warning() { echo "${red}WARNING:${plain} $*"; }
 
-TEMP_DIR=$(mktemp -d)
-cleanup() { rm -rf $TEMP_DIR; }
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/exordos-install.XXXXXX")
+INSTALL_STAGE=''
+INSTALL_LOCK=''
+NEED_SUDO=0
+cleanup() {
+    if [ -n "$INSTALL_STAGE" ]; then
+        case "$INSTALL_STAGE" in
+            */.exordos-install.*)
+                if [ "$NEED_SUDO" -eq 1 ]; then
+                    sudo -n rm -rf "$INSTALL_STAGE" 2>/dev/null || :
+                else
+                    rm -rf "$INSTALL_STAGE" 2>/dev/null || :
+                fi
+                ;;
+        esac
+    fi
+    if [ -n "$INSTALL_LOCK" ]; then
+        case "$INSTALL_LOCK" in
+            */.exordos-install.*.lock)
+                if [ "$NEED_SUDO" -eq 1 ]; then
+                    sudo -n rmdir "$INSTALL_LOCK" 2>/dev/null || :
+                else
+                    rmdir "$INSTALL_LOCK" 2>/dev/null || :
+                fi
+                ;;
+        esac
+    fi
+    case "$TEMP_DIR" in
+        */exordos-install.*)
+            rm -rf "$TEMP_DIR"
+            ;;
+    esac
+}
 trap cleanup EXIT
 
-available() { command -v $1 >/dev/null; }
+available() { command -v "$1" >/dev/null; }
 require() {
     local MISSING=''
-    for TOOL in $*; do
-        if ! available $TOOL; then
+    for TOOL in "$@"; do
+        if ! available "$TOOL"; then
             MISSING="$MISSING $TOOL"
         fi
     done
 
-    echo $MISSING
+    echo "$MISSING"
+}
+
+privileged() {
+    if [ "$NEED_SUDO" -eq 1 ]; then
+        sudo "$@"
+    else
+        "$@"
+    fi
 }
 
 OS="$(uname -s)"
@@ -44,7 +83,7 @@ esac
 ###########################################
 
 if [ "$OS" = "Darwin" ]; then
-    NEEDS=$(require curl)
+    NEEDS=$(require awk codesign curl ditto file find grep shasum)
     if [ -n "$NEEDS" ]; then
         status "ERROR: The following tools are required but missing:"
         for NEED in $NEEDS; do
@@ -53,18 +92,210 @@ if [ "$OS" = "Darwin" ]; then
         exit 1
     fi
 
-    BINDIR="/usr/local/bin"
-    DOWNLOAD_URL="https://repo.exordos.com/exordos/latest/exordos-macos-arm"
+    INSTALL_PREFIX="${EXORDOS_INSTALL_PREFIX:-/usr/local}"
+    REPO_URL="${EXORDOS_REPO_URL:-https://repo.exordos.com/exordos}"
+    case "$INSTALL_PREFIX" in
+        /|//*|*//*|*/./*|*/.|*/../*|*/..)
+            error "EXORDOS_INSTALL_PREFIX must be a canonical path below /"
+            ;;
+        /*) ;;
+        *) error "EXORDOS_INSTALL_PREFIX must be an absolute directory" ;;
+    esac
+    INSTALL_ROOT="$INSTALL_PREFIX/lib/exordos"
+    VERSIONS_DIR="$INSTALL_ROOT/versions"
+    BINDIR="$INSTALL_PREFIX/bin"
 
-    status "Installing exordos to $BINDIR..."
-    mkdir -p "$BINDIR" 2>/dev/null || sudo mkdir -p "$BINDIR"
-    curl --fail --show-error --location --progress-bar \
-        "$DOWNLOAD_URL" --output "$TEMP_DIR/exordos"
-    chmod +x "$TEMP_DIR/exordos"
-    mv "$TEMP_DIR/exordos" "$BINDIR/exordos" 2>/dev/null || \
-        sudo mv "$TEMP_DIR/exordos" "$BINDIR/exordos"
+    MACHINE_ARCH=$(uname -m)
+    if [ "$MACHINE_ARCH" = "x86_64" ] && \
+        [ -x /usr/sbin/sysctl ] && \
+        [ "$(/usr/sbin/sysctl -in sysctl.proc_translated 2>/dev/null || :)" = "1" ]; then
+        MACHINE_ARCH="arm64"
+    fi
+    case "$MACHINE_ARCH" in
+        arm64) MACOS_ARCH="arm64" ;;
+        x86_64) MACOS_ARCH="x86_64" ;;
+        *) error "Unsupported macOS architecture: $MACHINE_ARCH" ;;
+    esac
 
-    status "Install complete. You can now run 'exordos'."
+    VERSION="${EXORDOS_VERSION:-}"
+    if [ -z "$VERSION" ]; then
+        status "Resolving the latest exordos version..."
+        curl --fail --show-error --location --silent \
+            "$REPO_URL/latest/VERSION" --output "$TEMP_DIR/VERSION"
+        VERSION=$(cat "$TEMP_DIR/VERSION")
+    fi
+    case "$VERSION" in
+        [0-9]*) ;;
+        *) error "Invalid exordos version: $VERSION" ;;
+    esac
+    case "$VERSION" in
+        *[!0-9A-Za-z.+-]*|*..*) error "Invalid exordos version: $VERSION" ;;
+    esac
+
+    if ! mkdir -p "$VERSIONS_DIR" "$BINDIR" 2>/dev/null || \
+        [ ! -w "$VERSIONS_DIR" ] || [ ! -w "$BINDIR" ]; then
+        [ "$INSTALL_PREFIX" = "/usr/local" ] || \
+            error "A custom EXORDOS_INSTALL_PREFIX must be writable without sudo"
+        available sudo || error "sudo is required to install exordos to $INSTALL_PREFIX"
+        status "Administrator access is required to install exordos to $INSTALL_PREFIX."
+        sudo -v
+        NEED_SUDO=1
+        privileged mkdir -p "$VERSIONS_DIR" "$BINDIR"
+    fi
+
+    TARGET_DIR="$VERSIONS_DIR/$VERSION"
+    TARGET_BINARY="$TARGET_DIR/exordos"
+    if [ -e "$TARGET_DIR" ] || [ -L "$TARGET_DIR" ]; then
+        [ -d "$TARGET_DIR" ] && [ ! -L "$TARGET_DIR" ] || \
+            error "Installed version path is not a directory: $TARGET_DIR"
+        [ -f "$TARGET_DIR/.complete" ] && [ -x "$TARGET_BINARY" ] || \
+            error "Installed version is incomplete: $TARGET_DIR"
+        INSTALLED_VERSION=$("$TARGET_BINARY" --silent --no-check-updates version)
+        [ "$INSTALLED_VERSION" = "$VERSION" ] || \
+            error "Installed version at $TARGET_DIR is corrupt"
+        status "Using the existing exordos $VERSION installation."
+    else
+        ARTIFACT="exordos-macos-$MACOS_ARCH.zip"
+        RELEASE_URL="$REPO_URL/$VERSION"
+        ARCHIVE="$TEMP_DIR/$ARTIFACT"
+        CHECKSUM_FILE="$ARCHIVE.sha256"
+
+        status "Downloading exordos $VERSION for macOS $MACOS_ARCH..."
+        curl --fail --show-error --location --progress-bar \
+            "$RELEASE_URL/$ARTIFACT" --output "$ARCHIVE"
+        curl --fail --show-error --location --silent \
+            "$RELEASE_URL/$ARTIFACT.sha256" --output "$CHECKSUM_FILE"
+
+        EXPECTED_HASH=$(tr 'A-F' 'a-f' < "$CHECKSUM_FILE")
+        case "$EXPECTED_HASH" in
+            *[!0-9a-f]*)
+                error "Invalid SHA-256 checksum for $ARTIFACT"
+                ;;
+        esac
+        [ "${#EXPECTED_HASH}" -eq 64 ] || \
+            error "Invalid SHA-256 checksum for $ARTIFACT"
+        ACTUAL_HASH=$(shasum -a 256 "$ARCHIVE")
+        ACTUAL_HASH=${ACTUAL_HASH%% *}
+        [ "$ACTUAL_HASH" = "$EXPECTED_HASH" ] || \
+            error "SHA-256 checksum mismatch for $ARTIFACT"
+
+        UNPACKED="$TEMP_DIR/unpacked"
+        mkdir -p "$UNPACKED"
+        ditto -x -k "$ARCHIVE" "$UNPACKED"
+        if find "$UNPACKED" -mindepth 1 -maxdepth 1 ! -name exordos | grep -q .; then
+            error "Unexpected top-level entry in $ARTIFACT"
+        fi
+        [ -d "$UNPACKED/exordos" ] && [ ! -L "$UNPACKED/exordos" ] || \
+            error "Invalid archive layout in $ARTIFACT"
+        [ -d "$UNPACKED/exordos/_internal" ] && \
+            [ ! -L "$UNPACKED/exordos/_internal" ] || \
+            error "Missing runtime directory in $ARTIFACT"
+        [ -f "$UNPACKED/exordos/exordos" ] && \
+            [ ! -L "$UNPACKED/exordos/exordos" ] || \
+            error "Missing launcher in $ARTIFACT"
+        chmod +x "$UNPACKED/exordos/exordos"
+        verify_macos_code() {
+            CANDIDATE=$1
+            shift
+            codesign --verify --strict "$@" "$CANDIDATE"
+            SIGNATURE=$(codesign -dvvv "$CANDIDATE" 2>&1)
+            if printf '%s\n' "$SIGNATURE" | grep -q '^Signature=adhoc$'; then
+                [ "${EXORDOS_INSTALL_ALLOW_ADHOC:-0}" = "1" ] || \
+                    error "Ad-hoc signature found in $ARTIFACT"
+            else
+                printf '%s\n' "$SIGNATURE" | \
+                    grep -q '^Authority=Developer ID Application:' || \
+                    error "Unexpected signing authority in $ARTIFACT"
+                CANDIDATE_TEAM=$(printf '%s\n' "$SIGNATURE" | \
+                    awk -F= '/^TeamIdentifier=/ {print $2; exit}')
+                [ -n "$CANDIDATE_TEAM" ] && \
+                    [ "$CANDIDATE_TEAM" != "not set" ] || \
+                    error "Missing TeamIdentifier in $ARTIFACT"
+                if [ -z "$SIGNING_TEAM" ]; then
+                    SIGNING_TEAM=$CANDIDATE_TEAM
+                else
+                    [ "$CANDIDATE_TEAM" = "$SIGNING_TEAM" ] || \
+                        error "Mixed signing teams in $ARTIFACT"
+                fi
+            fi
+            SIGNED_CODE_COUNT=$((SIGNED_CODE_COUNT + 1))
+        }
+
+        SIGNED_CODE_COUNT=0
+        SIGNING_TEAM=''
+        MACHO_LIST="$TEMP_DIR/macho-files"
+        find "$UNPACKED/exordos" -type f > "$MACHO_LIST"
+        while IFS= read -r CANDIDATE; do
+            if file "$CANDIDATE" | grep -q 'Mach-O'; then
+                case "$CANDIDATE" in
+                    *.framework/*)
+                        verify_macos_code "$CANDIDATE" --ignore-resources
+                        ;;
+                    *) verify_macos_code "$CANDIDATE" ;;
+                esac
+            fi
+        done < "$MACHO_LIST"
+        [ "$SIGNED_CODE_COUNT" -gt 0 ] || \
+            error "No signed code found in $ARTIFACT"
+        ARCHIVE_VERSION=$(
+            "$UNPACKED/exordos/exordos" --silent --no-check-updates version
+        )
+        [ "$ARCHIVE_VERSION" = "$VERSION" ] || \
+            error "Archive contains exordos $ARCHIVE_VERSION, expected $VERSION"
+        printf '%s\n' "$ACTUAL_HASH" > "$UNPACKED/exordos/.archive-sha256"
+        : > "$UNPACKED/exordos/.complete"
+
+        INSTALL_LOCK="$VERSIONS_DIR/.exordos-install.$VERSION.lock"
+        privileged mkdir "$INSTALL_LOCK" 2>/dev/null || \
+            error "Another exordos $VERSION installation is in progress"
+        [ ! -e "$TARGET_DIR" ] && [ ! -L "$TARGET_DIR" ] || \
+            error "Another installer created $TARGET_DIR"
+
+        INSTALL_STAGE="$VERSIONS_DIR/.exordos-install.$VERSION.$$"
+        [ ! -e "$INSTALL_STAGE" ] && [ ! -L "$INSTALL_STAGE" ] || \
+            error "Installation staging path already exists: $INSTALL_STAGE"
+        privileged ditto "$UNPACKED/exordos" "$INSTALL_STAGE"
+        STAGED_VERSION=$(
+            "$INSTALL_STAGE/exordos" --silent --no-check-updates version
+        )
+        [ "$STAGED_VERSION" = "$VERSION" ] || \
+            error "Staged exordos version validation failed"
+        privileged mv -n "$INSTALL_STAGE" "$TARGET_DIR"
+        [ ! -e "$INSTALL_STAGE" ] || \
+            error "Another installer created $TARGET_DIR"
+        INSTALL_STAGE=''
+        privileged rmdir "$INSTALL_LOCK"
+        INSTALL_LOCK=''
+    fi
+
+    if [ -e "$BINDIR/exordos" ] && [ ! -L "$BINDIR/exordos" ]; then
+        [ -f "$BINDIR/exordos" ] || \
+            error "$BINDIR/exordos is not a regular file or symlink"
+        LEGACY_HASH=$(shasum -a 256 "$BINDIR/exordos")
+        LEGACY_HASH=${LEGACY_HASH%% *}
+        LEGACY_DIR="$INSTALL_ROOT/legacy"
+        LEGACY_BINARY="$LEGACY_DIR/exordos-onefile-$LEGACY_HASH"
+        privileged mkdir -p "$LEGACY_DIR"
+        if [ ! -f "$LEGACY_BINARY" ]; then
+            privileged cp -p "$BINDIR/exordos" "$LEGACY_BINARY"
+        fi
+        BACKUP_HASH=$(shasum -a 256 "$LEGACY_BINARY")
+        BACKUP_HASH=${BACKUP_HASH%% *}
+        [ "$BACKUP_HASH" = "$LEGACY_HASH" ] || \
+            error "Failed to verify the legacy exordos backup"
+        status "Preserved the previous one-file binary at $LEGACY_BINARY."
+    fi
+
+    LINK_STAGE="$BINDIR/.exordos-install.$$"
+    [ ! -e "$LINK_STAGE" ] && [ ! -L "$LINK_STAGE" ] || \
+        error "Launcher staging path already exists: $LINK_STAGE"
+    privileged ln -s "$TARGET_BINARY" "$LINK_STAGE"
+    privileged mv -f "$LINK_STAGE" "$BINDIR/exordos"
+
+    ACTIVE_VERSION=$("$BINDIR/exordos" --silent --no-check-updates version)
+    [ "$ACTIVE_VERSION" = "$VERSION" ] || \
+        error "Installed exordos version validation failed"
+    status "exordos $VERSION was successfully installed."
     exit 0
 fi
 

--- a/etc/package-macos.sh
+++ b/etc/package-macos.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#    Copyright 2026 Genesis Corporation.
+#    Licensed under the Apache License, Version 2.0 (the "License")
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 BUNDLE_DIR ARCHIVE_PATH" >&2
+    exit 2
+fi
+
+BUNDLE_DIR=$1
+ARCHIVE_PATH=$2
+
+[ -d "$BUNDLE_DIR/_internal" ] || {
+    echo "Missing runtime directory: $BUNDLE_DIR/_internal" >&2
+    exit 1
+}
+[ -x "$BUNDLE_DIR/exordos" ] || {
+    echo "Missing executable launcher: $BUNDLE_DIR/exordos" >&2
+    exit 1
+}
+[ ! -e "$ARCHIVE_PATH" ] || {
+    echo "Archive already exists: $ARCHIVE_PATH" >&2
+    exit 1
+}
+
+/usr/bin/ditto -c -k --keepParent --norsrc --noextattr --noqtn --noacl \
+    "$BUNDLE_DIR" "$ARCHIVE_PATH"
+
+ARCHIVE_HASH=$(shasum -a 256 "$ARCHIVE_PATH")
+ARCHIVE_HASH=${ARCHIVE_HASH%% *}
+printf '%s\n' "$ARCHIVE_HASH" > "$ARCHIVE_PATH.sha256"

--- a/etc/tests/test-install-macos.sh
+++ b/etc/tests/test-install-macos.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+#    Copyright 2026 Genesis Corporation.
+#    Licensed under the Apache License, Version 2.0 (the "License")
+
+set -eu
+
+REPOSITORY_ROOT=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/exordos-installer-test.XXXXXX")
+
+cleanup() {
+    case "$TEST_ROOT" in
+        */exordos-installer-test.*) rm -rf "$TEST_ROOT" ;;
+    esac
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+FAKE_BIN="$TEST_ROOT/bin"
+FAKE_REPO="$TEST_ROOT/repo"
+PREFIX="$TEST_ROOT/prefix"
+mkdir -p "$FAKE_BIN" "$FAKE_REPO/latest" "$TEST_ROOT/home"
+
+cat > "$FAKE_BIN/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+    -s) printf '%s\n' Darwin ;;
+    -m) printf '%s\n' "${FAKE_ARCH:-arm64}" ;;
+    *) exit 2 ;;
+esac
+EOF
+
+cat > "$FAKE_BIN/ditto" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-x" ] && [ "$2" = "-k" ]; then
+    SOURCE=$3
+    DESTINATION=$4
+elif [ "$#" -eq 2 ]; then
+    SOURCE=$1
+    DESTINATION=$2
+else
+    exit 2
+fi
+python3 - "$SOURCE" "$DESTINATION" <<'PY'
+import pathlib
+import shutil
+import sys
+import zipfile
+
+source = pathlib.Path(sys.argv[1])
+destination = pathlib.Path(sys.argv[2])
+if source.is_dir():
+    shutil.copytree(source, destination, symlinks=True)
+else:
+    with zipfile.ZipFile(source) as zip_file:
+        zip_file.extractall(destination)
+PY
+EOF
+
+cat > "$FAKE_BIN/codesign" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *' -dvvv '*)
+        if [ "${FAKE_SIGNATURE_MODE:-developer}" = "adhoc" ]; then
+            echo 'Signature=adhoc' >&2
+            echo 'TeamIdentifier=not set' >&2
+        else
+            echo 'Authority=Developer ID Application: Exordos Test (TESTTEAM)' >&2
+            echo 'TeamIdentifier=TESTTEAM' >&2
+        fi
+        ;;
+esac
+exit 0
+EOF
+
+cat > "$FAKE_BIN/file" <<'EOF'
+#!/bin/sh
+case "$1" in
+    */exordos) echo "$1: Mach-O 64-bit executable" ;;
+    *) /usr/bin/file "$@" ;;
+esac
+EOF
+
+chmod +x \
+    "$FAKE_BIN/uname" \
+    "$FAKE_BIN/ditto" \
+    "$FAKE_BIN/codesign" \
+    "$FAKE_BIN/file"
+
+create_release() {
+    VERSION=$1
+    ARCH=$2
+    RELEASE_DIR="$FAKE_REPO/$VERSION"
+    FIXTURE_DIR="$TEST_ROOT/fixture-$VERSION-$ARCH"
+    ARCHIVE="$RELEASE_DIR/exordos-macos-$ARCH.zip"
+    mkdir -p "$RELEASE_DIR" "$FIXTURE_DIR/exordos/_internal"
+    printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$VERSION" \
+        > "$FIXTURE_DIR/exordos/exordos"
+    printf '%s\n' runtime > "$FIXTURE_DIR/exordos/_internal/marker"
+    chmod +x "$FIXTURE_DIR/exordos/exordos"
+    python3 - "$FIXTURE_DIR" "$ARCHIVE" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+source = pathlib.Path(sys.argv[1])
+archive = pathlib.Path(sys.argv[2])
+with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zip_file:
+    for path in source.rglob("*"):
+        if path.is_file():
+            zip_file.write(path, path.relative_to(source))
+PY
+    HASH=$(shasum -a 256 "$ARCHIVE")
+    HASH=${HASH%% *}
+    printf '%s\n' "$HASH" > "$ARCHIVE.sha256"
+}
+
+install_version() {
+    env \
+        PATH="$FAKE_BIN:$PATH" \
+        HOME="$TEST_ROOT/home" \
+        EXORDOS_INSTALL_PREFIX="$PREFIX" \
+        EXORDOS_REPO_URL="file://$FAKE_REPO" \
+        FAKE_ARCH="${FAKE_ARCH:-arm64}" \
+        FAKE_SIGNATURE_MODE="${FAKE_SIGNATURE_MODE:-developer}" \
+        ${EXORDOS_VERSION_OVERRIDE:+EXORDOS_VERSION=$EXORDOS_VERSION_OVERRIDE} \
+        sh "$REPOSITORY_ROOT/etc/install.sh"
+}
+
+assert_active_version() {
+    EXPECTED=$1
+    [ -L "$PREFIX/bin/exordos" ] || fail "launcher is not a symlink"
+    ACTUAL=$("$PREFIX/bin/exordos" --silent --no-check-updates version)
+    [ "$ACTUAL" = "$EXPECTED" ] || \
+        fail "active version is $ACTUAL, expected $EXPECTED"
+}
+
+create_release 3.1.14 arm64
+printf '%s\n' 3.1.14 > "$FAKE_REPO/latest/VERSION"
+
+# Preserve an existing one-file installation before activating the bundle.
+mkdir -p "$PREFIX/bin"
+printf '#!/bin/sh\nprintf "%%s\\n" "legacy"\n' > "$PREFIX/bin/exordos"
+chmod +x "$PREFIX/bin/exordos"
+LEGACY_HASH=$(shasum -a 256 "$PREFIX/bin/exordos")
+LEGACY_HASH=${LEGACY_HASH%% *}
+install_version
+assert_active_version 3.1.14
+[ -f "$PREFIX/lib/exordos/versions/3.1.14/.complete" ] || \
+    fail "completion marker is missing"
+[ -x "$PREFIX/lib/exordos/legacy/exordos-onefile-$LEGACY_HASH" ] || \
+    fail "legacy one-file binary was not preserved"
+
+# Reinstalling an immutable version must reuse the existing directory.
+FIRST_MARKER=$(stat -c %i "$PREFIX/lib/exordos/versions/3.1.14/.complete")
+install_version
+SECOND_MARKER=$(stat -c %i "$PREFIX/lib/exordos/versions/3.1.14/.complete")
+[ "$FIRST_MARKER" = "$SECOND_MARKER" ] || fail "reinstall replaced the version"
+
+create_release 3.1.15 arm64
+printf '%s\n' 3.1.15 > "$FAKE_REPO/latest/VERSION"
+install_version
+assert_active_version 3.1.15
+[ -x "$PREFIX/lib/exordos/versions/3.1.14/exordos" ] || \
+    fail "previous version was removed"
+
+# Explicit rollback reuses an installed version without downloading it again.
+EXORDOS_VERSION_OVERRIDE=3.1.14 install_version
+assert_active_version 3.1.14
+unset EXORDOS_VERSION_OVERRIDE
+
+# A checksum failure must not switch the active launcher.
+create_release 3.1.16 arm64
+printf '%064d\n' 0 > "$FAKE_REPO/3.1.16/exordos-macos-arm64.zip.sha256"
+printf '%s\n' 3.1.16 > "$FAKE_REPO/latest/VERSION"
+if install_version; then
+    fail "checksum mismatch unexpectedly succeeded"
+fi
+assert_active_version 3.1.14
+
+# Ad-hoc signatures are rejected before the downloaded launcher is executed.
+create_release 3.1.17 arm64
+printf '%s\n' 3.1.17 > "$FAKE_REPO/latest/VERSION"
+if FAKE_SIGNATURE_MODE=adhoc install_version; then
+    fail "ad-hoc signature unexpectedly succeeded"
+fi
+assert_active_version 3.1.14
+
+# Intel uses its own artifact.
+create_release 3.1.14 x86_64
+INTEL_PREFIX="$TEST_ROOT/intel-prefix"
+PREFIX="$INTEL_PREFIX" FAKE_ARCH=x86_64 EXORDOS_VERSION_OVERRIDE=3.1.14 \
+    install_version
+PREFIX="$INTEL_PREFIX" assert_active_version 3.1.14
+
+# Unsupported architectures fail before mutating the prefix.
+UNKNOWN_PREFIX="$TEST_ROOT/unknown-prefix"
+if PREFIX="$UNKNOWN_PREFIX" FAKE_ARCH=ppc64 install_version; then
+    fail "unsupported architecture unexpectedly succeeded"
+fi
+[ ! -e "$UNKNOWN_PREFIX/bin/exordos" ] || \
+    fail "unsupported architecture mutated the install prefix"
+
+echo "macOS installer tests passed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
+    "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = begin,py3{10,11,12,13,14},end
           py3{10,11,12,13,14}-functional
-          ruff,ruff-check,mypy
+          installer,ruff,ruff-check,mypy
 minversion = 2.0
 skipsdist = false
 skip_missing_interpreters = true
@@ -80,7 +80,17 @@ basepython = python3.14
 extras =
   bin
 runner = uv-venv-lock-runner
-commands = pyinstaller --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator --onefile ./exordos/cmd/cli.py
+commands = pyinstaller {posargs:--onefile} --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator ./exordos/cmd/cli.py
+
+[testenv:installer]
+extras =
+  shellcheck
+runner = uv-venv-lock-runner
+allowlist_externals =
+  sh
+commands =
+  shellcheck -s sh -e SC1091,SC2016,SC2034,SC2086,SC2251,SC3043 etc/install.sh etc/package-macos.sh etc/tests/test-install-macos.sh
+  sh etc/tests/test-install-macos.sh
 
 [testenv:cli_docs]
 runner = uv-venv-lock-runner


### PR DESCRIPTION
## Summary

- ship native Apple Silicon and Intel macOS onedir ZIP bundles while keeping Linux and Windows onefile artifacts unchanged
- keep the existing curl-to-shell install command, but install macOS releases into versioned directories and atomically switch the launcher
- verify SHA-256, Developer ID signatures, signing-team consistency, bundle layout, and embedded CLI version before activation
- preserve the previous onefile binary, retain installed versions for rollback, and serialize concurrent installs
- sign and notarize tagged macOS releases in a protected environment, with installer smoke and startup-performance gates on both architectures
- run real ad-hoc macOS packaging, installation, and performance checks on pull requests

## Why

The current macOS onefile executable starts in roughly 12 seconds because every launch extracts a fresh PyInstaller tree and triggers repeated Library Validation checks. The onedir prototype starts in about 0.24 seconds. Linux onefile startup remains below one second, so this change is scoped to macOS packaging and installation.

## Compatibility and rollout

The public installation command remains unchanged:

```sh
curl -fsSL https://repo.exordos.com/install.sh | sh
```

Tagged releases require a protected `macos-release` GitHub environment with these secrets:

- `MACOS_CERTIFICATE_P12_BASE64`
- `MACOS_CERTIFICATE_PASSWORD`
- `APPLE_API_PRIVATE_KEY_P8_BASE64`
- `APPLE_API_KEY_ID`
- `APPLE_API_ISSUER_ID`

The release graph blocks publication until signed/notarized ARM64 and x86_64 artifacts succeed, publishes versioned artifacts before `latest/VERSION`, and activates the matching installer last.

## Verification

Local checks:

- `tox -e installer`
- `tox -e ruff-check`
- `tox -e py314` (259 tests)
- `tox -e bin -- --onedir`
- `actionlint` for all changed workflows
- `markdownlint-cli2` for changed documentation
- `git diff --check`

GitHub-hosted macOS checks on commit `0ac11f4c`:

- Apple Silicon ARM64: build, code-signature verification, ZIP/checksum, real installer smoke, help/version smoke, and performance gate passed; startup median `0.527s`, max `0.652s`
- Intel x86_64: the same checks passed; startup median `1.212s`, max `1.520s`
- all unit, coverage, installer, lint, and documentation checks passed

The protected Developer ID signing and Apple notarization path is tag-only and therefore is not executed with release credentials on pull requests.
