### PR TITLE
add_user

### DIFF
--- a/docs/cli/projects_add_user.md
+++ b/docs/cli/projects_add_user.md
@@ -1,0 +1,53 @@
+
+# projects_add_user
+
+Add a user to a project (by UUID, email, or name)
+
+## Usage
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos iam projects add_user [OPTIONS]                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                           
+```
+
+## Options
+
+* `project_id` (REQUIRED):
+    * Type: uuid
+    * Default: `sentinel.unset`
+    * Usage: `-p
+--project-id`
+
+  UUID of the project
+
+* `user` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `-u
+--user`
+
+  UUID, email, or name of the user to add
+
+* `role` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `-r
+--role`
+
+  Role to assign (e.g. 'owner')
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos iam projects add_user [OPTIONS]                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                           
+```

--- a/exordos/cmd/iam/project/commands.py
+++ b/exordos/cmd/iam/project/commands.py
@@ -86,3 +86,46 @@ def add_cmd(
 
     entity = base_client.add_entity(client, c.PROJECT_COLLECTION, data)
     show_data(entity)
+
+
+@projects_group.command(
+    "add_user", help=f"Add a user to a {ENTITY} (by UUID, email, or name)"
+)
+@click.pass_context
+@click.option(
+    "-p",
+    "--project-id",
+    type=click.UUID,
+    required=True,
+    help=f"UUID of the {ENTITY}",
+)
+@click.option(
+    "-u",
+    "--user",
+    type=str,
+    required=True,
+    help="UUID, email, or name of the user to add",
+)
+@click.option(
+    "-r",
+    "--role",
+    type=str,
+    required=True,
+    help="Role to assign (e.g. 'owner')",
+)
+def add_user_cmd(
+    ctx: click.Context,
+    project_id: sys_uuid.UUID,
+    user: str,
+    role: str,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    base_client.action_entity(
+        client,
+        c.PROJECT_COLLECTION,
+        "add_user",
+        project_id,
+        user=user,
+        role=role,
+    )
+    click.echo(f"User {user} added to {ENTITY} {project_id} as {role}")


### PR DESCRIPTION
## Summary by Sourcery

Enable assigning users to projects through the IAM CLI.

New Features:
- Add a CLI command to add a user to a project by UUID, email, or name with an assigned role.

Documentation:
- Add usage documentation for the project user-management command.