### PR TITLE
feat(cli): add user update command

### DIFF
--- a/docs/cli/users_update.md
+++ b/docs/cli/users_update.md
@@ -1,0 +1,87 @@
+
+# users_update
+
+Update user
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos iam users update [OPTIONS] UUID                                 
+                                                                                
+```
+
+## Options
+
+* `uuid` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `uuid`
+
+* `name`:
+    * Type: text
+    * Default: `none`
+    * Usage: `-n
+--name`
+
+  Username of the user
+
+* `description`:
+    * Type: text
+    * Default: `none`
+    * Usage: `-D
+--description`
+
+  Description of the user
+
+* `first_name`:
+    * Type: text
+    * Default: `none`
+    * Usage: `--first-name`
+
+* `last_name`:
+    * Type: text
+    * Default: `none`
+    * Usage: `--last-name`
+
+* `surname`:
+    * Type: text
+    * Default: `none`
+    * Usage: `--surname`
+
+* `phone`:
+    * Type: text
+    * Default: `none`
+    * Usage: `--phone`
+
+* `email`:
+    * Type: text
+    * Default: `none`
+    * Usage: `--email`
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos iam users update [OPTIONS] UUID                                 
+                                                                                
+ Update user                                                                    
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name            -n  TEXT  Username of the user                             │
+│ --description     -D  TEXT  Description of the user                          │
+│ --first-name          TEXT                                                   │
+│ --last-name           TEXT                                                   │
+│ --surname             TEXT                                                   │
+│ --phone               TEXT                                                   │
+│ --email               TEXT                                                   │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```

--- a/exordos/cmd/iam/user/commands.py
+++ b/exordos/cmd/iam/user/commands.py
@@ -304,6 +304,88 @@ def info_cmd(ctx: click.Context, user: str, output: str) -> None:
     )
 
 
+@click.command("update", help=f"Update {ENTITY}")
+@click.pass_context
+@click.argument(
+    "uuid",
+    type=str,
+    required=True,
+)
+@click.option(
+    "-n",
+    "--name",
+    type=str,
+    default=None,
+    help=f"Username of the {ENTITY}",
+)
+@click.option(
+    "-D",
+    "--description",
+    type=str,
+    default=None,
+    help=f"Description of the {ENTITY}",
+)
+@click.option(
+    "--first-name",
+    type=str,
+    default=None,
+)
+@click.option(
+    "--last-name",
+    type=str,
+    default=None,
+)
+@click.option(
+    "--surname",
+    type=str,
+    default=None,
+)
+@click.option(
+    "--phone",
+    type=str,
+    default=None,
+)
+@click.option(
+    "--email",
+    type=str,
+    default=None,
+)
+def update_cmd(
+    ctx: click.Context,
+    uuid: str,
+    name: str | None,
+    description: str | None,
+    first_name: str | None,
+    last_name: str | None,
+    surname: str | None,
+    phone: str | None,
+    email: str | None,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    data = {}
+    if name is not None:
+        data["username"] = name
+    if description is not None:
+        data["description"] = description
+    if first_name is not None:
+        data["first_name"] = first_name
+    if last_name is not None:
+        data["last_name"] = last_name
+    if surname is not None:
+        data["surname"] = surname
+    if phone is not None:
+        data["phone"] = phone
+    if email is not None:
+        data["email"] = email
+
+    if not data:
+        click.echo("No data to update")
+        return
+
+    entity = base_client.update_entity(client, ENTITY_COLLECTION, uuid, data)
+    show_data(entity)
+
+
 @users_group.command("confirm_email", help=f"Confirm email of the {ENTITY}")
 @click.pass_context
 @click.argument(
@@ -338,3 +420,4 @@ def confirm_email(
 
 
 users_group.add_command(add_cmd, aliases=["a"])
+users_group.add_command(update_cmd, aliases=["u"])


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI command to update IAM users and document its usage.

New Features:
- Introduce an `exordos iam users update` CLI command to modify existing user attributes.

Documentation:
- Add user-facing documentation for the new `users update` CLI command, including options and example help output.