### PR TITLE
feat(cli): add user password reset command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,6 @@ introspect:
 
 role_permissions:
 	./dist/exordos iam permissions role newcomer
+
+reset_password:
+	./dist/exordos iam u reset_password dae92b97-ee63-4376-9743-f735120ea7db --new-password 123456789

--- a/docs/cli/users_reset_password.md
+++ b/docs/cli/users_reset_password.md
@@ -1,0 +1,52 @@
+
+# users_reset_password
+
+Reset password of the user
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos iam users reset_password [OPTIONS] USER                         
+                                                                                
+```
+
+## Options
+
+* `user` (REQUIRED):
+    * Type: uuid
+    * Default: `sentinel.unset`
+    * Usage: `user`
+
+  user UUID
+
+* `code`:
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `-c
+--code`
+
+  Verification code for the user
+
+* `new_password`:
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `-n
+--new-password`
+
+  New password of the user. If not provided, will be asked interactively
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos iam users reset_password [OPTIONS] USER                         
+                                                                                
+```

--- a/exordos/cmd/iam/user/commands.py
+++ b/exordos/cmd/iam/user/commands.py
@@ -173,6 +173,55 @@ def add_cmd(
     show_data(entity)
 
 
+@users_group.command("reset_password", help=f"Reset password of the {ENTITY}")
+@click.pass_context
+@click.argument(
+    "user",
+    type=click.UUID,
+    required=True,
+    help=f"{ENTITY} UUID",
+)
+@click.option(
+    "-c",
+    "--code",
+    type=str,
+    required=False,
+    help=f"Verification code for the {ENTITY}",
+)
+@click.option(
+    "-n",
+    "--new-password",
+    type=str,
+    required=False,
+    help=f"New password of the {ENTITY}. If not provided, will be asked interactively",
+    hide_input=True,
+)
+def reset_password_cmd(
+    ctx: click.Context,
+    user: sys_uuid.UUID,
+    code: str | None,
+    new_password: str | None,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+
+    new_password = (
+        new_password
+        or questionary.password(f"Enter new password for {ENTITY} {user}:").ask()
+    )
+    if new_password is None:
+        click.echo("Password not provided")
+        return
+    data = {
+        "new_password": new_password,
+    }
+
+    if code is not None:
+        data["code"] = code
+
+    base_client.action_entity(client, ENTITY_COLLECTION, "reset_password", user, **data)
+    click.echo(f"Password reset for {ENTITY} {user}")
+
+
 @users_group.command("change_password", help=f"Change password of the {ENTITY}")
 @click.pass_context
 @click.argument(


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI command to reset a user's password and document its usage.

New Features:
- Introduce `users reset_password` CLI command to reset a user's password with optional verification code and interactive password input.

Build:
- Add a Makefile target to exercise the new user password reset CLI command.

Documentation:
- Add user-facing CLI documentation for the `users reset_password` command, including usage, options, and help output.