### PR TITLE
feat(cli): add realm show and SSH commands

### DIFF
--- a/docs/cli/realms_show.md
+++ b/docs/cli/realms_show.md
@@ -1,0 +1,48 @@
+
+# realms_show
+
+Show realm details
+
+## Usage
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos realms show [OPTIONS] NAME_UUID                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                           
+```
+
+## Options
+
+* `name_uuid` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `name_uuid`
+
+* `output`:
+    * Type: choice
+    * Default: `table`
+    * Usage: `--output
+-o`
+
+  the output format, defaults to table
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos realms show [OPTIONS] NAME_UUID                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                           
+ Show realm details                                                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                           
+╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --output  -o  [json|html|table|yaml]  the output format, defaults to table                                                                                                                                                                                                                              │
+│ --help                                Show this message and exit.                                                                                                                                                                                                                                       │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/docs/cli/realms_ssh_connection.md
+++ b/docs/cli/realms_ssh_connection.md
@@ -1,0 +1,48 @@
+
+# realms_ssh_connection
+
+Show realm ssh connection info
+
+## Usage
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos realms ssh_connection [OPTIONS] NAME_UUID                                                                                                                                                                                                                                                  
+                                                                                                                                                                                                                                                                                                           
+```
+
+## Options
+
+* `name_uuid` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `name_uuid`
+
+* `output`:
+    * Type: choice
+    * Default: `table`
+    * Usage: `--output
+-o`
+
+  the output format, defaults to table
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                                                                                                                                                                                                                                           
+ Usage: exordos realms ssh_connection [OPTIONS] NAME_UUID                                                                                                                                                                                                                                                  
+                                                                                                                                                                                                                                                                                                           
+ Show realm ssh connection info                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                           
+╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --output  -o  [json|html|table|yaml]  the output format, defaults to table                                                                                                                                                                                                                              │
+│ --help                                Show this message and exit.                                                                                                                                                                                                                                       │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/exordos/clients/base_client.py
+++ b/exordos/clients/base_client.py
@@ -153,9 +153,11 @@ def action_entity(
     uuid: sys_uuid.UUID | str,
     invoke: bool = True,
     **kwargs,
-) -> None:
+) -> dict[str, tp.Any] | None:
     try:
-        client.do_action(collection, uuid=uuid, name=action, invoke=invoke, **kwargs)
+        return client.do_action(
+            collection, uuid=uuid, name=action, invoke=invoke, **kwargs
+        )
     except bazooka_exc.NotFoundError:
         raise click.ClickException(f"UUID {uuid} not found")
 

--- a/exordos/cmd/realms/commands.py
+++ b/exordos/cmd/realms/commands.py
@@ -27,6 +27,7 @@ import questionary
 import requests
 import rich_click as click
 
+from exordos import constants as c
 from exordos import utils as exordos_utils
 from exordos.clients import base_client
 from exordos.cmd.aliases import ClickAliasedGroup
@@ -140,8 +141,15 @@ def check_api(url: str) -> bool:
 
 
 @click.command("list", help="List of realms")
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
 @click.pass_context
-def list_cmd(ctx: click.Context) -> None:
+def list_cmd(ctx: click.Context, output: str) -> None:
     def get_ecosystem_realms() -> dict[str, Realm]:
         # Get the list of realms from the ecosystem
         from yretry import defaults
@@ -208,7 +216,7 @@ def list_cmd(ctx: click.Context) -> None:
     for realm in realms.values():
         table.add_row(realm.name, realm.ip, realm.provider, realm.status)
 
-    print_table(table)
+    print_table(table, output)
 
 
 @click.command("add", help=f"Add a new ecosystem {ENTITY}")
@@ -385,6 +393,58 @@ def delete_cmd(ctx: click.Context, name_uuid: str) -> None:
     raise click.ClickException(f"Local realm {name_uuid} not found")
 
 
+@click.command("show", help="Show realm details")
+@click.argument("name_uuid", type=str)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+@click.pass_context
+def show_cmd(ctx: click.Context, name_uuid: str, output: str) -> None:
+    from yretry import defaults
+
+    defaults.HTTP_RETRY_ATTEMPTS = 1
+    ecosystem_client = get_ecosystem_client(ctx)
+    try:
+        data = base_client.get_entity(ecosystem_client, ENTITY_COLLECTION, name_uuid)
+        show_data(data, output)
+    except Exception:
+        raise click.ClickException(f"{ENTITY} {name_uuid} not found")
+
+
+@click.command("ssh_connection", help="Show realm ssh connection info")
+@click.argument("name_uuid", type=str)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+@click.pass_context
+def ssh_connection_cmd(ctx: click.Context, name_uuid: str, output: str) -> None:
+    from yretry import defaults
+
+    defaults.HTTP_RETRY_ATTEMPTS = 1
+    ecosystem_client = get_ecosystem_client(ctx)
+    try:
+        data = base_client.action_entity(
+            ecosystem_client,
+            ENTITY_COLLECTION,
+            "ssh_connection",
+            name_uuid,
+            False,
+        )
+        show_data(data, output)
+    except Exception:
+        raise click.ClickException(f"{ENTITY} {name_uuid} not found")
+
+
 realms_group.add_command(list_cmd, aliases=["l"])
 realms_group.add_command(delete_cmd, aliases=["d"])
 realms_group.add_command(add_cmd, aliases=["a"])
+realms_group.add_command(show_cmd, aliases=["get", "g"])
+realms_group.add_command(ssh_connection_cmd)


### PR DESCRIPTION
## Summary by Sourcery

Add CLI support to inspect realms and retrieve their SSH connection details while wiring through returned action data.

New Features:
- Introduce `exordos realms show` command to display realm details in various output formats.
- Introduce `exordos realms ssh_connection` command to retrieve and display SSH connection information for a realm.

Enhancements:
- Update `action_entity` to return action response data from the client for downstream use by callers.

Documentation:
- Add CLI documentation pages for `realms show` and `realms ssh_connection` commands, including usage, options, and help output.