### PR TITLE
feat(cli): update clear cmd, and add lb info cmd

### DIFF
--- a/docs/cli/backend_pools_clear.md
+++ b/docs/cli/backend_pools_clear.md
@@ -1,0 +1,49 @@
+
+# backend_pools_clear
+
+Delete all backend_pools
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos network backend_pools clear [OPTIONS]                           
+                                                                                
+```
+
+## Options
+
+* `y`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--y
+-y`
+
+  Automatically answer yes for all questions
+
+* `lb_uuid` (REQUIRED):
+    * Type: uuid
+    * Default: `sentinel.unset`
+    * Usage: `--lb-uuid`
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos network backend_pools clear [OPTIONS]                           
+                                                                                
+ Delete all backend_pools                                                       
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│    --y        -y        Automatically answer yes for all questions           │
+│ *  --lb-uuid      UUID  [required]                                           │
+│    --help               Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```

--- a/docs/cli/load_balancers_info.md
+++ b/docs/cli/load_balancers_info.md
@@ -1,0 +1,48 @@
+
+# load_balancers_info
+
+Show load balancer details with vhosts and backend_pools
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos network load_balancers info [OPTIONS] UUID                      
+                                                                                
+```
+
+## Options
+
+* `uuid` (REQUIRED):
+    * Type: text
+    * Default: `sentinel.unset`
+    * Usage: `uuid`
+
+* `output`:
+    * Type: choice
+    * Default: `table`
+    * Usage: `--output
+-o`
+
+  the output format, defaults to table
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos network load_balancers info [OPTIONS] UUID                      
+                                                                                
+ Show load balancer details with vhosts and backend_pools                       
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --output  -o  [json|html|table|yaml]  the output format, defaults to table   │
+│ --help                                Show this message and exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```

--- a/docs/cli/vhosts_clear.md
+++ b/docs/cli/vhosts_clear.md
@@ -1,0 +1,49 @@
+
+# vhosts_clear
+
+Delete all vhosts
+
+## Usage
+
+```console
+                                                                                
+ Usage: exordos network vhosts clear [OPTIONS]                                  
+                                                                                
+```
+
+## Options
+
+* `y`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--y
+-y`
+
+  Automatically answer yes for all questions
+
+* `lb_uuid` (REQUIRED):
+    * Type: uuid
+    * Default: `sentinel.unset`
+    * Usage: `--lb-uuid`
+
+* `help`:
+    * Type: boolean
+    * Default: `false`
+    * Usage: `--help`
+
+  Show this message and exit.
+
+## CLI Help
+
+```console
+                                                                                
+ Usage: exordos network vhosts clear [OPTIONS]                                  
+                                                                                
+ Delete all vhosts                                                              
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│    --y        -y        Automatically answer yes for all questions           │
+│ *  --lb-uuid      UUID  [required]                                           │
+│    --help               Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```

--- a/exordos/cmd/base.py
+++ b/exordos/cmd/base.py
@@ -245,10 +245,13 @@ def create_entity_group(
         @click.option(
             "--y", "-y", help="Automatically answer yes for all questions", is_flag=True
         )
+        @add_dynamic_parents(parents)
         @click.pass_context
-        def clear_cmd(ctx: click.Context, y: bool) -> None:
+        def clear_cmd(ctx: click.Context, y: bool, **kwargs) -> None:
             client = base_client.get_user_api_client(ctx.obj.auth_data)
-            entities = base_client.list_entities(client, entity_collection)
+            entities = base_client.list_entities(
+                client, entity_collection.format(**kwargs)
+            )
             for entity in entities:
                 if (
                     y
@@ -256,7 +259,9 @@ def create_entity_group(
                         f"Delete {entity_name} {entity['uuid']} ({entity.get('name', '')})?"
                     ).ask()
                 ):
-                    base_client.delete_entity(client, entity_collection, entity["uuid"])
+                    base_client.delete_entity(
+                        client, entity_collection.format(**kwargs), entity["uuid"]
+                    )
                     click.echo(f"{entity_name} {entity['uuid']} deleted")
 
         entity_group.add_command(clear_cmd, aliases=["c"])

--- a/exordos/cmd/network/backend_pools/commands.py
+++ b/exordos/cmd/network/backend_pools/commands.py
@@ -31,5 +31,5 @@ FIELDS_MAP = {
 
 
 backend_pools_group = create_entity_group(
-    ENTITY, ENTITY_COLLECTION, FIELDS_MAP, parents=["lb"]
+    ENTITY, ENTITY_COLLECTION, FIELDS_MAP, add_clear_command=True, parents=["lb"]
 )

--- a/exordos/cmd/network/lb/commands.py
+++ b/exordos/cmd/network/lb/commands.py
@@ -15,8 +15,14 @@
 #    under the License.
 from __future__ import annotations
 
+import rich_click as click
+
 from exordos import constants as c
+from exordos.clients import base_client
 from exordos.cmd.base import create_entity_group
+from exordos.common.table import fill_table
+from exordos.common.table import print_table
+from exordos.common.table import show_data
 
 ENTITY = "load_balancer"
 ENTITY_COLLECTION = c.LB_COLLECTION
@@ -31,3 +37,48 @@ FIELDS_MAP = {
 
 
 lbs_group = create_entity_group(ENTITY, ENTITY_COLLECTION, FIELDS_MAP)
+
+
+@click.command("info", help="Show load balancer details with vhosts and backend_pools")
+@click.argument(
+    "uuid",
+    type=str,
+    required=True,
+)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+@click.pass_context
+def info_cmd(ctx: click.Context, uuid: str, output: str) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+
+    # Show LB details
+    lb_data = base_client.get_entity(client, ENTITY_COLLECTION, uuid)
+    show_data(lb_data, output)
+
+    # Show associated vhosts
+    vhosts = base_client.list_entities(
+        client, c.VHOST_COLLECTION.format(lb_uuid=lb_data["uuid"])
+    )
+    if vhosts:
+        from exordos.cmd.network.vhosts.commands import FIELDS_MAP as VHOSTS_FIELDS_MAP
+
+        print_table(fill_table(vhosts, VHOSTS_FIELDS_MAP), output)
+
+    # Show associated backend_pools
+    backend_pools = base_client.list_entities(
+        client, c.BACKEND_POOL_COLLECTION.format(lb_uuid=lb_data["uuid"])
+    )
+    if backend_pools:
+        from exordos.cmd.network.backend_pools.commands import (
+            FIELDS_MAP as BACKEND_POOLS_FIELDS_MAP,
+        )
+
+        print_table(fill_table(backend_pools, BACKEND_POOLS_FIELDS_MAP), output)
+
+
+lbs_group.add_command(info_cmd, aliases=["i"])

--- a/exordos/cmd/network/vhosts/commands.py
+++ b/exordos/cmd/network/vhosts/commands.py
@@ -33,5 +33,5 @@ FIELDS_MAP = {
 }
 
 vhosts_group = create_entity_group(
-    ENTITY, ENTITY_COLLECTION, FIELDS_MAP, parents=["lb"]
+    ENTITY, ENTITY_COLLECTION, FIELDS_MAP, add_clear_command=True, parents=["lb"]
 )

--- a/exordos/cmd/version/commands.py
+++ b/exordos/cmd/version/commands.py
@@ -99,13 +99,14 @@ def version_cmd() -> None:
 @click.command(name="latest", help="Check for the latest version on GitHub")
 @click.pass_context
 def latest_cmd(ctx: click.Context) -> None:
-    if ctx.obj.need_update is False:
-        from exordos import version as exordos_version
+    if ctx.obj.need_update is not None:
+        if ctx.obj.need_update is False:
+            from exordos import version as exordos_version
 
-        click.secho(
-            f"You are using the latest version: {exordos_version.version_info}",
-            fg="green",
-        )
+            click.secho(
+                f"You are using the latest version: {exordos_version.version_info}",
+                fg="green",
+            )
         return
     check_latest_version(echo_on_latest=True)
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a load balancer info CLI command and make clear commands support load-balancer-scoped deletions for vhosts and backend pools.

New Features:
- Add `exordos network load_balancers info` command to show a load balancer along with its associated vhosts and backend pools.

Enhancements:
- Update the generic `clear` command to support dynamic parent parameters, enabling scoped bulk deletions based on formatted entity collections.

Documentation:
- Add CLI documentation pages for `backend_pools clear`, `vhosts clear`, and `load_balancers info` commands, including usage and options.