### PR TITLE
download artifacts by pattern

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,8 +2,8 @@ name: Publish Python 🐍 distribution 📦 and binaries
 
 on:
   push:
-    tags:
-      - '*'
+    #tags:
+    #  - '*'
 
 env:
   PROJECT_NAME: exordos
@@ -420,31 +420,12 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Download Linux binary
+    - name: Download binaries
       uses: actions/download-artifact@v8
       with:
-        name: exordos-linux
+        pattern: exordos-*
         path: dist/
-    - name: Download Linux ubuntu-resolute binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-linux-ubuntu-resolute
-        path: dist/
-    - name: Download macOS arm64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-arm64
-        path: dist/
-    - name: Download macOS x86_64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-x86_64
-        path: dist/
-    - name: Download Windows binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-windows
-        path: dist/
+        merge-multiple: true
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary by Sourcery

Update the PyPI publish workflow to download all platform binaries via a single pattern-based artifact step and temporarily disable tag-based triggering for pushes.

Build:
- Consolidate multiple platform-specific artifact downloads into one pattern-based download-artifact invocation with merged outputs.
- Comment out tag-based push trigger configuration in the publish-to-pypi GitHub Actions workflow.