### PR TITLE
Download release binaries by artifact pattern

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -420,30 +420,11 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Download Linux binary
+    - name: Download binary artifacts
       uses: actions/download-artifact@v8
       with:
-        name: exordos-linux
-        path: dist/
-    - name: Download Linux ubuntu-resolute binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-linux-ubuntu-resolute
-        path: dist/
-    - name: Download macOS arm64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-arm64
-        path: dist/
-    - name: Download macOS x86_64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-x86_64
-        path: dist/
-    - name: Download Windows binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-windows
+        pattern: exordos-*
+        merge-multiple: true
         path: dist/
     - name: Create GitHub Release
       env:
@@ -470,30 +451,11 @@ jobs:
       uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - name: Download Linux binary
+    - name: Download binary artifacts
       uses: actions/download-artifact@v8
       with:
-        name: exordos-linux
-        path: dist/
-    - name: Download Linux ubuntu-resolute binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-linux-ubuntu-resolute
-        path: dist/
-    - name: Download macOS arm64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-arm64
-        path: dist/
-    - name: Download macOS x86_64 bundle
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-macos-x86_64
-        path: dist/
-    - name: Download Windows binary
-      uses: actions/download-artifact@v8
-      with:
-        name: exordos-windows
+        pattern: exordos-*
+        merge-multiple: true
         path: dist/
     - name: Push artifacts to repository
       run: |


### PR DESCRIPTION
## Summary

- replace five sequential binary artifact downloads in `github-release` with one `exordos-*` pattern download
- apply the same pattern download to the internal `exordos-release` job
- merge matched artifacts directly into `dist/` while leaving Python distributions separate

## Verification

- parsed the workflow as YAML and validated the two consumer job structures
- `actionlint` passed, ignoring only the pre-existing unsupported `ubuntu-26.04` runner-label warning
- `git diff --check`
- matched the pattern against release `3.1.17`: exactly five binary artifacts
- downloaded and merged those artifacts locally: seven expected release files, zero filename collisions

## Summary by Sourcery

Build:
- Update GitHub Actions workflow to download all exordos binary artifacts via a single pattern-based download step with merged outputs in both release jobs.