### PR TITLE
Publish the Resolute binary to its latest path

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -527,7 +527,7 @@ jobs:
         # Upload latest release
         upload ./dist/exordos-linux \
           "${PROJECT_NAME}/latest/exordos-linux"
-        upload ./dist/exordos-linux \
+        upload ./dist/exordos-linux-ubuntu-resolute \
           "${PROJECT_NAME}/latest/exordos-linux-ubuntu-resolute"
         upload ./dist/exordos-macos-arm64.zip \
           "${PROJECT_NAME}/latest/exordos-macos-arm64.zip"


### PR DESCRIPTION
## Summary

- publish the dedicated Ubuntu Resolute binary to the matching `latest` repository path
- keep the generic Linux binary limited to the generic `latest/exordos-linux` path
- make the versioned and latest upload mappings consistent

## Verification

- parsed `.github/workflows/publish-to-pypi.yml` as YAML
- validated the complete versioned/latest source-to-destination upload map
- `actionlint` passed, ignoring only the pre-existing unsupported `ubuntu-26.04` runner-label warning
- `git diff --check`

Closes #320

## Summary by Sourcery

CI:
- Update the publish-to-pypi workflow to upload the Ubuntu Resolute binary to the latest/exordos-linux-ubuntu-resolute destination instead of reusing the generic Linux artifact.