### PR TITLE
Add single-element selection to exordos build

### DIFF
--- a/docs/cli/exordos_build.md
+++ b/docs/cli/exordos_build.md
@@ -60,6 +60,14 @@ Additional variables can be passed using the --manifest-var options.
 
   Rebuild if the output already exists
 
+- `element`:
+    - Type: text
+    - Default: `sentinel.unset`
+    - Usage: `-e
+--element`
+
+  Name of the element to build. Builds all elements when omitted
+
 - `manifest_var`:
     - Type: text
     - Default: `sentinel.unset`
@@ -105,6 +113,7 @@ Additional variables can be passed using the --manifest-var options.
 │ --output-dir              -o  PATH  Directory where output artifacts will be stored                                                                                                                                                                                                                     │
 │ --ssh-public-key          -i  PATH  Path to a public SSH key file to inject into the VM. Can be specified multiple times. If not provided, no key will be injected.                                                                                                                                     │
 │ --force                   -f        Rebuild if the output already exists                                                                                                                                                                                                                                │
+│ --element                 -e  TEXT  Name of the element to build. Builds all elements when omitted                                                                                                                                                                                                      │
 │ --manifest-var                TEXT  Additional variables to pass to the manifest template. The format is 'key=value'. For example: --manifest-var key1=value1 --manifest-var key2=value2                                                                                                                │
 │ --validate/--no-validate            Validate the manifest after building [default: validate]                                                                                                                                                                                                            │
 │ --help                              Show this message and exit.                                                                                                                                                                                                                                         │

--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -382,6 +382,26 @@ class SimpleBuilder:
             self._logger.info(f"Fetching dependency: {dep}")
             dep.fetch(deps_dir)
 
+    def select_element(
+        self,
+        name: str,
+        manifest_vars: dict[str, tp.Any] | None = None,
+    ) -> bool:
+        """Restrict this builder to elements with the requested name."""
+        manifest_vars = manifest_vars or {}
+        selected = []
+
+        for element in self._elements:
+            if not element.manifest:
+                continue
+
+            element_name = manifest_vars.get("name") or element.name(self._exordos_dir)
+            if element_name and element_name.strip() == name:
+                selected.append(element)
+
+        self._elements = selected
+        return bool(selected)
+
     def build_element(
         self,
         element: base.Element,

--- a/exordos/cmd/builds/commands.py
+++ b/exordos/cmd/builds/commands.py
@@ -31,6 +31,22 @@ from exordos.logger import ClickLogger
 from exordos.spec import schema
 
 
+def _prepare_output_dir(output_dir: pathlib.Path, force: bool) -> bool:
+    if not os.path.exists(output_dir):
+        return True
+
+    if not force:
+        click.secho(
+            f"The '{output_dir}' directory already exists. Use '--force' "
+            "flag to remove current artifacts and new build.",
+            fg="yellow",
+        )
+        return False
+
+    shutil.rmtree(output_dir)
+    return True
+
+
 @click.command(
     "build",
     help=(
@@ -83,6 +99,11 @@ from exordos.spec import schema
     help="Rebuild if the output already exists",
 )
 @click.option(
+    "-e",
+    "--element",
+    help="Name of the element to build. Builds all elements when omitted",
+)
+@click.option(
     "--manifest-var",
     multiple=True,
     help=(
@@ -107,21 +128,16 @@ def build_cmd(
     output_dir: pathlib.Path,
     ssh_public_key: tuple[pathlib.Path, ...],
     force: bool,
+    element: str | None,
     manifest_var: tuple[str, ...],
     validate: bool,
     project_dir: str,
 ) -> None:
     manifest_vars = utils.convert_input_multiply(manifest_var)
+    output_dir_existed = os.path.exists(output_dir)
 
-    if os.path.exists(output_dir) and not force:
-        click.secho(
-            f"The '{output_dir}' directory already exists. Use '--force' "
-            "flag to remove current artifacts and new build.",
-            fg="yellow",
-        )
+    if element is None and not _prepare_output_dir(output_dir, force):
         return
-    elif os.path.exists(output_dir) and force:
-        shutil.rmtree(output_dir)
 
     # Load SSH keys
     developer_keys = ""
@@ -158,10 +174,29 @@ def build_cmd(
     # Path where exordos.yaml configuration file is located
     exordos_dir = pathlib.Path(gen_config_path).parent
 
+    builders = []
     for _, build_cfg in builds.items():
         builder = simple_builder.SimpleBuilder.from_config(
             exordos_dir, build_cfg, packer_image_builder, output_dir, version, logger
         )
+        if element and not builder.select_element(element, manifest_vars):
+            continue
+
+        builders.append(builder)
+
+    if element and not builders:
+        raise click.ClickException(
+            f"Element '{element}' not found in the configuration"
+        )
+
+    if (
+        element is not None
+        and output_dir_existed
+        and not _prepare_output_dir(output_dir, force)
+    ):
+        return
+
+    for builder in builders:
         with tempfile.TemporaryDirectory() as temp_dir:
             builder.fetch_dependency(deps_dir or temp_dir)
             builder.build(developer_keys, manifest_vars, validate)

--- a/exordos/tests/unit/test_build_cli.py
+++ b/exordos/tests/unit/test_build_cli.py
@@ -1,0 +1,110 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+import yaml
+
+from exordos.cmd.builds import commands
+
+
+def test_build_cmd_element_builds_only_requested_element(monkeypatch, tmp_path) -> None:
+    project_dir = tmp_path / "project"
+    output_dir = tmp_path / "output"
+    project_dir.mkdir()
+    (project_dir / "app1.yaml").write_text("name: app1\n")
+    (project_dir / "app2.yaml").write_text("name: app2\n")
+    (project_dir / "exordos.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "build": {
+                    "elements": [
+                        {"manifest": "app1.yaml"},
+                        {"manifest": "app2.yaml"},
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(commands.utils, "load_spec", lambda: {})
+    monkeypatch.setattr(commands.schema, "validate_yaml", MagicMock())
+    monkeypatch.setattr(commands, "get_project_version", lambda _: "1.0.0")
+    monkeypatch.setattr(commands.utils, "get_keys_by_path_or_env", lambda *_: "")
+
+    result = CliRunner().invoke(
+        commands.build_cmd,
+        [
+            "-e",
+            "app2",
+            "--no-validate",
+            "--output-dir",
+            str(output_dir),
+            str(project_dir),
+        ],
+        obj=SimpleNamespace(developer_key_path=None),
+    )
+
+    assert result.exit_code == 0, result.output
+    inventory = json.loads(
+        (output_dir / "exordos-elements" / "inventory.json").read_text()
+    )
+    assert inventory["elements"].keys() == {"app2"}
+    assert not (output_dir / "exordos-elements" / "app1").exists()
+
+
+def test_build_cmd_unknown_element_exits_before_build(monkeypatch, tmp_path) -> None:
+    builder = MagicMock()
+    builder.select_element.return_value = False
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    marker = output_dir / "existing-artifact"
+    marker.write_text("keep")
+    monkeypatch.setattr(
+        commands.utils,
+        "get_exordos_config",
+        lambda *_: ({"build": {"elements": [{}]}}, tmp_path / "exordos.yaml"),
+    )
+    monkeypatch.setattr(commands.utils, "load_spec", lambda: {})
+    monkeypatch.setattr(commands.schema, "validate_yaml", MagicMock())
+    monkeypatch.setattr(commands, "get_project_version", lambda _: "1.0.0")
+    monkeypatch.setattr(commands, "PackerBuilder", MagicMock())
+    monkeypatch.setattr(
+        commands.simple_builder.SimpleBuilder,
+        "from_config",
+        MagicMock(return_value=builder),
+    )
+    monkeypatch.setattr(commands.utils, "get_keys_by_path_or_env", lambda *_: "")
+
+    result = CliRunner().invoke(
+        commands.build_cmd,
+        [
+            "--element",
+            "missing",
+            "--force",
+            "--output-dir",
+            str(output_dir),
+            ".",
+        ],
+        obj=SimpleNamespace(developer_key_path=None),
+    )
+
+    assert result.exit_code == 1
+    assert "Element 'missing' not found in the configuration" in result.output
+    assert marker.read_text() == "keep"
+    builder.fetch_dependency.assert_not_called()
+    builder.build.assert_not_called()

--- a/exordos/tests/unit/test_builder.py
+++ b/exordos/tests/unit/test_builder.py
@@ -57,6 +57,45 @@ class TestBuilder:
         assert len(builder._elements) == 1
         assert builder._exordos_dir == work_dir
 
+    def test_select_element_filters_by_manifest_name(self, tmp_path) -> None:
+        work_dir = tmp_path / "work"
+        output_dir = tmp_path / "output"
+        work_dir.mkdir()
+        output_dir.mkdir()
+        (work_dir / "app1.yaml").write_text("name: app1\n")
+        (work_dir / "app2.yaml").write_text("name: app2\n")
+        app1 = base.Element(manifest=pathlib.Path("app1.yaml"))
+        app2 = base.Element(manifest=pathlib.Path("app2.yaml"))
+        builder = SimpleBuilder(
+            exordos_dir=work_dir,
+            deps=[],
+            elements=[app1, app2],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=output_dir,
+        )
+
+        assert builder.select_element("app2") is True
+        assert builder._elements == [app2]
+
+    def test_select_element_returns_false_for_unknown_name(self, tmp_path) -> None:
+        work_dir = tmp_path / "work"
+        output_dir = tmp_path / "output"
+        work_dir.mkdir()
+        output_dir.mkdir()
+        (work_dir / "app.yaml").write_text("name: app\n")
+        builder = SimpleBuilder(
+            exordos_dir=work_dir,
+            deps=[],
+            elements=[base.Element(manifest=pathlib.Path("app.yaml"))],
+            image_builder=MagicMock(spec=base.AbstractImageBuilder),
+            logger=DummyLogger(),
+            elements_output_dir=output_dir,
+        )
+
+        assert builder.select_element("missing") is False
+        assert builder._elements == []
+
     def test_manifest_rendering_jinja2_variables(self, tmp_path) -> None:
         """Ensure Jinja2 variables render correctly."""
         # Arrange: temp work dir and output dir


### PR DESCRIPTION
## Summary

- add -e/--element to build one element by manifest name
- preserve the existing build-all behavior when the option is omitted
- reject unknown element names before replacing existing output
- document the option and cover selection and error handling with regression tests

## Testing

- tox -e py312 (263 passed)
- tox -e ruff
- tox -e cli_docs
- make mdlint (not run: markdownlint-cli2 is unavailable in the local environment)

Closes #293

## Summary by Sourcery

Add support for building a single manifest element via the exordos build CLI while preserving the existing build-all behavior and improving output directory handling.

New Features:
- Introduce an --element/-e option to the exordos build command to build a single element by manifest name.

Enhancements:
- Refine output directory preparation logic to avoid removing existing artifacts unless explicitly requested.

Documentation:
- Document the new --element option in the exordos build CLI reference, including usage and defaults.

Tests:
- Add unit tests for element selection in SimpleBuilder and for the build CLI to cover single-element builds and unknown element error handling.