### PR TITLE
Replace boto3 with light-s3-client for S3 backups

### DIFF
--- a/data/backups/s3.yaml
+++ b/data/backups/s3.yaml
@@ -3,5 +3,6 @@ driver:
         endpoint_url: ""
         access_key: ""
         secret_key: ""
+        region: "us-east-1"
         bucket_name: ""
         host: "localhost"

--- a/exordos/backup/s3.py
+++ b/exordos/backup/s3.py
@@ -19,12 +19,15 @@ import io
 import os
 import typing as tp
 
-import boto3
+from light_s3_client import Client
 
 from exordos import logger as logger_base
 from exordos import utils
 from exordos.backup import base
 from exordos.backup import qcow
+
+_MIN_MULTIPART_PART_SIZE = 5 * 1024 * 1024
+_MAX_MULTIPART_PARTS = 9_999
 
 
 class S3QcowBackuper(qcow.AbstractQcowBackuper):
@@ -35,6 +38,7 @@ class S3QcowBackuper(qcow.AbstractQcowBackuper):
         secret_key: str,
         host: str,
         bucket_name: str,
+        region: str = "us-east-1",
         snapshot_name: str = "backup_snap",
         logger: logger_base.AbstractLogger | None = None,
     ):
@@ -43,6 +47,7 @@ class S3QcowBackuper(qcow.AbstractQcowBackuper):
         self._host = host
         self._bucket_name = bucket_name
         self._endpoint_url = endpoint_url
+        self._region = region
         self._logger = logger or logger_base.ClickLogger()
         self._snapshot_name = snapshot_name
 
@@ -53,17 +58,37 @@ class S3QcowBackuper(qcow.AbstractQcowBackuper):
         encryption: base.EncryptionCreds | None = None,
     ) -> None:
         """Upload a stream to S3."""
-        s3_client = boto3.client(
-            "s3",
-            endpoint_url=self._endpoint_url,
-            aws_access_key_id=self._access_key,
-            aws_secret_access_key=self._secret_key,
+        s3_client = Client(
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            region=self._region,
+            server=self._endpoint_url,
         )
 
         if encryption:
             stream = utils.ReaderEncryptorIO(stream, encryption.key, encryption.iv)
             s3_path += self.ENCRYPTED_SUFFIX
-        s3_client.upload_fileobj(stream, self._bucket_name, s3_path)
+
+        stream.seek(0, os.SEEK_END)
+        stream_size = stream.tell()
+        stream.seek(0)
+        part_size = max(
+            _MIN_MULTIPART_PART_SIZE,
+            (stream_size + _MAX_MULTIPART_PARTS - 1) // _MAX_MULTIPART_PARTS,
+        )
+        response = s3_client.upload_file_multipart(
+            stream,
+            self._bucket_name,
+            s3_path,
+            part_size=part_size,
+        )
+        if response is None or not 200 <= response.status_code < 300:
+            status_code = (
+                response.status_code if response is not None else "no response"
+            )
+            raise RuntimeError(
+                f"Failed to upload {s3_path} to S3 (status: {status_code})"
+            )
 
     def _upload_file(
         self,

--- a/exordos/tests/unit/test_s3_backup.py
+++ b/exordos/tests/unit/test_s3_backup.py
@@ -1,0 +1,120 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from exordos.backup import base
+from exordos.backup.s3 import S3QcowBackuper
+from exordos.utils import ReaderEncryptorIO
+
+
+def _backuper(region: str = "us-east-1") -> S3QcowBackuper:
+    return S3QcowBackuper(
+        endpoint_url="https://s3.example.test",
+        access_key="access-key",
+        secret_key="secret-key",
+        host="test-host",
+        bucket_name="test-bucket",
+        region=region,
+    )
+
+
+@patch("exordos.backup.s3.Client")
+def test_upload_stream_uses_light_s3_client(client_class: MagicMock) -> None:
+    client = client_class.return_value
+    client.upload_file_multipart.return_value.status_code = 200
+    stream = io.BytesIO(b"backup")
+
+    _backuper(region="eu-central-1")._upload_stream(stream, "domain/disk.qcow2")
+
+    client_class.assert_called_once_with(
+        access_key="access-key",
+        secret_key="secret-key",
+        region="eu-central-1",
+        server="https://s3.example.test",
+    )
+    client.upload_file_multipart.assert_called_once_with(
+        stream,
+        "test-bucket",
+        "domain/disk.qcow2",
+        part_size=5 * 1024 * 1024,
+    )
+
+
+@patch("exordos.backup.s3.Client")
+def test_upload_stream_scales_part_size_for_large_files(
+    client_class: MagicMock,
+) -> None:
+    client = client_class.return_value
+    client.upload_file_multipart.return_value.status_code = 200
+    stream = MagicMock()
+    stream.tell.return_value = 100 * 1024**3
+
+    _backuper()._upload_stream(stream, "domain/disk.qcow2")
+
+    assert client.upload_file_multipart.call_args.kwargs["part_size"] == 10_738_493
+
+
+@patch("exordos.backup.s3.Client")
+def test_upload_stream_encrypts_content_and_suffixes_key(
+    client_class: MagicMock,
+) -> None:
+    client = client_class.return_value
+    client.upload_file_multipart.return_value.status_code = 200
+    encryption = base.EncryptionCreds(b"0123456789abcdef", b"fedcba9876543210")
+
+    _backuper()._upload_stream(io.BytesIO(b"backup"), "domain.xml", encryption)
+
+    uploaded_stream, bucket, key = client.upload_file_multipart.call_args.args
+    assert isinstance(uploaded_stream, ReaderEncryptorIO)
+    assert bucket == "test-bucket"
+    assert key == "domain.xml.encrypted"
+
+
+def test_reader_encryptor_supports_repeated_eof_reads() -> None:
+    stream = ReaderEncryptorIO(
+        io.BytesIO(b"backup"),
+        b"0123456789abcdef",
+        b"fedcba9876543210",
+    )
+
+    encrypted = stream.read(1024)
+
+    assert stream.read(1024) == b""
+    assert stream.read(1024) == b""
+    stream.seek(0)
+    assert stream.read(1024) == encrypted
+
+
+@pytest.mark.parametrize("status_code", [None, 500])
+@patch("exordos.backup.s3.Client")
+def test_upload_stream_raises_when_upload_fails(
+    client_class: MagicMock,
+    status_code: int | None,
+) -> None:
+    client = client_class.return_value
+    if status_code is None:
+        client.upload_file_multipart.return_value = None
+    else:
+        client.upload_file_multipart.return_value.status_code = status_code
+
+    with pytest.raises(RuntimeError, match="Failed to upload domain.xml to S3"):
+        _backuper()._upload_stream(io.BytesIO(b"backup"), "domain.xml")

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -333,29 +333,35 @@ class ReaderEncryptorIO(io.BytesIO):
         )
 
         self._encryptor = self._cipher.encryptor()
+        self._finalized = False
         self._chunk_size = chunk_size_kb << 10
 
     def tell(self) -> int:
         return self._file.tell()
 
     def read(self, size: int = -1) -> bytes:
-        if size == 0:
+        if size == 0 or self._finalized:
             return b""
 
         if size < 0:
-            return (
+            encrypted = (
                 self._encryptor.update(self._file.read()) + self._encryptor.finalize()
             )
+            self._finalized = True
+            return encrypted
 
         data = self._file.read(size)
         if len(data) < size:
-            return self._encryptor.update(data) + self._encryptor.finalize()
+            encrypted = self._encryptor.update(data) + self._encryptor.finalize()
+            self._finalized = True
+            return encrypted
 
         return self._encryptor.update(data)
 
     def seek(self, offset: int, whence: int = 0) -> int:
         if offset == 0 and whence == 0:
             self._encryptor = self._cipher.encryptor()
+            self._finalized = False
 
         return self._file.seek(offset, whence)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "GitPython>=3.1.50,<4.0.0",  # BSD
     "bazooka>=1.0.0,<2.0.0",  # Apache-2.0
     "cryptography>=49.0.0",  # BSD-3
-    "boto3>=1.37.0,<2.0.0",  # Apache-2.0
+    "light-s3-client>=0.0.39,<0.1.0",  # MIT
     "Jinja2>=3.1.5,<4.0.0",  # BSD License (BSD-3-Clause)
     "packaging==26.0",  # Apache-2.0 or BSD
     "simple-term-menu>=1.6.6,<2.0.0",  # MIT License (MIT)

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ basepython = python3.14
 extras =
   bin
 runner = uv-venv-lock-runner
-commands = pyinstaller {posargs:--onefile} --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator ./exordos/cmd/cli.py
+commands = pyinstaller {posargs:--onefile} --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --hidden-import=exordos.backup.s3 --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator ./exordos/cmd/cli.py
 
 [testenv:installer]
 extras =

--- a/uv.lock
+++ b/uv.lock
@@ -48,34 +48,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.42.74"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/ec/636ab2aa7ad9e6bf6e297240ac2d44dba63cc6611e2d5038db318436d449/boto3-1.42.74.tar.gz", hash = "sha256:dbacd808cf2a3dadbf35f3dbd8de97b94dc9f78b1ebd439f38f552e0f9753577", size = 112739, upload-time = "2026-03-23T19:34:09.815Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/16/a264b4da2af99f4a12609b93fea941cce5ec41da14b33ed3fef77a910f0c/boto3-1.42.74-py3-none-any.whl", hash = "sha256:4bf89c044d618fe4435af854ab820f09dd43569c0df15d7beb0398f50b9aa970", size = 140557, upload-time = "2026-03-23T19:34:07.084Z" },
-]
-
-[[package]]
-name = "botocore"
-version = "1.42.74"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/c7/cab8a14f0b69944bd0dd1fd58559163455b347eeda00bf836e93ce2684e4/botocore-1.42.74.tar.gz", hash = "sha256:9cf5cdffc6c90ed87b0fe184676806182588be0d0df9b363e9fe3e2923ac8e80", size = 15014379, upload-time = "2026-03-23T19:33:57.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/65/75852e04de5423c9b0c5b88241d0bdea33e6c6f454c88b71377d230216f2/botocore-1.42.74-py3-none-any.whl", hash = "sha256:3a76a8af08b5de82e51a0ae132394e226e15dbf21c8146ac3f7c1f881517a7a7", size = 14688218, upload-time = "2026-03-23T19:33:52.677Z" },
-]
-
-[[package]]
 name = "cachetools"
 version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -497,12 +469,12 @@ name = "exordos"
 source = { editable = "." }
 dependencies = [
     { name = "bazooka" },
-    { name = "boto3" },
     { name = "certifi" },
     { name = "click" },
     { name = "cryptography" },
     { name = "gitpython" },
     { name = "jinja2" },
+    { name = "light-s3-client" },
     { name = "openapi-schema-validator" },
     { name = "orjson" },
     { name = "packaging" },
@@ -549,13 +521,13 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "bazooka", specifier = ">=1.0.0,<2.0.0" },
-    { name = "boto3", specifier = ">=1.37.0,<2.0.0" },
     { name = "certifi", specifier = ">=2026.2.25" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "coverage", marker = "extra == 'test'", specifier = ">=4.0" },
     { name = "cryptography", specifier = ">=49.0.0" },
     { name = "gitpython", specifier = ">=3.1.50,<4.0.0" },
     { name = "jinja2", specifier = ">=3.1.5,<4.0.0" },
+    { name = "light-s3-client", specifier = ">=0.0.39,<0.1.0" },
     { name = "mkdocs-glightbox", marker = "extra == 'docs'" },
     { name = "mkdocs-include-dir-to-nav", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.1.0" },
@@ -656,15 +628,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jmespath"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -778,6 +741,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "light-s3-client"
+version = "0.0.40"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/3e/e3b09bf358e030f43bb1a71e95b5517473e7bfd54a0e6e82bb4a13233d25/light_s3_client-0.0.40.tar.gz", hash = "sha256:73cd22d141a19813b5351edebd962db00a770d26be52e3c47eae5ce5d3b41851", size = 11312, upload-time = "2026-07-12T00:02:29.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f7/dc0da16ce05f84d03428f33b391b5ef855db323eeb887c3b66e2e57fe89f/light_s3_client-0.0.40-py3-none-any.whl", hash = "sha256:9bea67138cc1b451965ee559f7f34e6b6818c2cd1b725f7eb6abccb03b9800a8", size = 15669, upload-time = "2026-07-12T00:02:28.773Z" },
 ]
 
 [[package]]
@@ -2203,18 +2179,6 @@ wheels = [
 ]
 
 [[package]]
-name = "s3transfer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
-]
-
-[[package]]
 name = "selectolax"
 version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2546,6 +2510,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/0d/40df5be1e684bbaecdb9d1e0e40d5d482465de6b00cbb92b84ee5d243c7f/xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56", size = 33813, upload-time = "2022-05-08T07:00:04.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/db/fd0326e331726f07ff7f40675cd86aa804bfd2e5016c727fa761c934990e/xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852", size = 9971, upload-time = "2022-05-08T07:00:02.898Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace boto3 with light-s3-client in the S3 backup driver
- preserve region configuration and scale multipart part size for large qcow images
- make encrypted streams safe for repeated EOF reads performed by requests
- include the dynamically loaded S3 driver and its dependencies in the one-file binary
- add focused coverage for client configuration, multipart sizing, encryption, EOF behavior, and upload failures

## Validation

- tox -e develop: 269 passed
- tox -e ruff: passed
- tox -e bin: passed
- uv lock --check: passed
- one-file binary S3 driver import smoke: passed
- S3-compatible server smoke: plain, multipart, and encrypted multipart upload/readback passed

## Binary size

The one-file binary decreases from 44,419,784 bytes to 29,073,592 bytes, a reduction of 15,346,192 bytes (34.55%).

## Notes

light-s3-client has a narrower transfer feature set than boto3. This change preserves the current backup path, but a smoke test against the intended production S3-compatible endpoint is recommended before merge.

## Summary by Sourcery

Replace the S3 backup implementation with a light-s3-client-based driver, tightening multipart upload sizing, improving encrypted stream handling, and updating build and tests to support the new client and configuration.

New Features:
- Switch the S3 backup driver to use light-s3-client instead of boto3 while preserving region-aware configuration.
- Support configurable S3 regions in backup configuration with a default of us-east-1.

Bug Fixes:
- Make encrypted backup streams safe for repeated EOF reads so they can be consumed reliably by HTTP clients like requests.
- Fail S3 uploads explicitly when the multipart upload response is missing or indicates a non-success status.

Enhancements:
- Scale multipart part size based on stream size to stay within S3 limits for large qcow images.

Build:
- Replace the boto3 dependency with light-s3-client and update the one-file build to include the S3 backup driver and its metadata.

Tests:
- Add unit tests covering light-s3-client usage, multipart part sizing, encryption behavior and EOF handling, and failure handling for S3 uploads.