### PR TITLE
Replace boto3 with an internal S3 backup client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,3 +95,51 @@ jobs:
       - name: check ascii
         run: |
           ! grep -rnPq "#.*[^\\x00-\\x7f]" ./exordos
+  MinIO:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build test MinIO image
+        run: docker build -t exordos-test-minio -f etc/tests/minio/Dockerfile .
+      - name: Generate test credentials
+        run: |
+          access_key=$(openssl rand -hex 10)
+          secret_key=$(openssl rand -hex 24)
+          echo "::add-mask::$access_key"
+          echo "::add-mask::$secret_key"
+          printf 'MINIO_ROOT_USER=%s\n' "$access_key" >> "$GITHUB_ENV"
+          printf 'MINIO_ROOT_PASSWORD=%s\n' "$secret_key" >> "$GITHUB_ENV"
+      - name: Start MinIO
+        run: |
+          docker run --detach --name exordos-test-minio \
+            --publish 9000:9000 \
+            --env MINIO_ROOT_USER \
+            --env MINIO_ROOT_PASSWORD \
+            exordos-test-minio
+          for attempt in $(seq 1 30); do
+            if [ "$(docker inspect --format='{{.State.Health.Status}}' exordos-test-minio)" = healthy ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs exordos-test-minio
+          exit 1
+      - name: Test S3 upload
+        run: |
+          docker exec exordos-test-minio mkdir /data/backups
+          python -m pip install requests
+          python - <<'PY'
+          import io
+          import os
+
+          from exordos.backup.s3_client import S3BackupClient
+
+          payload = b"exordos MinIO test"
+          client = S3BackupClient(
+              endpoint_url="http://127.0.0.1:9000",
+              access_key=os.environ["MINIO_ROOT_USER"],
+              secret_key=os.environ["MINIO_ROOT_PASSWORD"],
+              region="us-east-1",
+          )
+          client.upload(io.BytesIO(payload), "backups", "test/backup", len(payload))
+          PY

--- a/data/backups/s3.yaml
+++ b/data/backups/s3.yaml
@@ -3,5 +3,6 @@ driver:
         endpoint_url: ""
         access_key: ""
         secret_key: ""
+        region: "us-east-1"
         bucket_name: ""
         host: "localhost"

--- a/etc/tests/minio/Dockerfile
+++ b/etc/tests/minio/Dockerfile
@@ -1,0 +1,28 @@
+#    Copyright 2026 Genesis Corporation.
+#    Licensed under the Apache License, Version 2.0 (the "License")
+
+FROM golang:1.24-alpine AS build
+
+ARG MINIO_COMMIT=07c3a429bfed433e49018cb0f78a52145d4bedeb
+
+RUN CGO_ENABLED=0 go install github.com/minio/minio@${MINIO_COMMIT}
+
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates curl \
+    && addgroup -S minio \
+    && adduser -S -G minio minio \
+    && mkdir /data \
+    && chown minio:minio /data
+
+COPY --from=build /go/bin/minio /usr/local/bin/minio
+
+USER minio
+VOLUME ["/data"]
+EXPOSE 9000 9001
+
+HEALTHCHECK --interval=2s --timeout=2s --start-period=5s --retries=15 \
+    CMD curl --fail --silent http://127.0.0.1:9000/minio/health/live || exit 1
+
+ENTRYPOINT ["minio"]
+CMD ["server", "/data", "--address", ":9000", "--console-address", ":9001"]

--- a/etc/tests/minio/README.md
+++ b/etc/tests/minio/README.md
@@ -1,0 +1,20 @@
+# MinIO backup test server
+
+Build and start an isolated S3-compatible server for manual backup tests:
+
+```shell
+docker build -t exordos-test-minio -f etc/tests/minio/Dockerfile .
+docker run --rm --name exordos-test-minio \
+  -p 9000:9000 -p 9001:9001 \
+  -e MINIO_ROOT_USER="$MINIO_ROOT_USER" \
+  -e MINIO_ROOT_PASSWORD="$MINIO_ROOT_PASSWORD" \
+  exordos-test-minio
+```
+
+Set both credentials in the shell before running the container. Use
+`http://127.0.0.1:9000` as `endpoint_url` in the S3 backup configuration. Create
+the configured bucket before running `exordos backup`; the MinIO console is at
+`http://127.0.0.1:9001`.
+
+This image is for tests only. It builds the pinned MinIO release from source and
+does not contain credentials or create buckets automatically.

--- a/exordos/backup/s3.py
+++ b/exordos/backup/s3.py
@@ -15,16 +15,40 @@
 #    under the License.
 from __future__ import annotations
 
+import configparser
 import io
 import os
 import typing as tp
-
-import boto3
 
 from exordos import logger as logger_base
 from exordos import utils
 from exordos.backup import base
 from exordos.backup import qcow
+from exordos.backup import s3_client
+
+
+def _resolve_region(region: str | None) -> str:
+    if region:
+        return region
+
+    environment_region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get(
+        "AWS_REGION"
+    )
+    if environment_region:
+        return environment_region
+
+    profile = os.environ.get("AWS_PROFILE") or os.environ.get(
+        "AWS_DEFAULT_PROFILE", "default"
+    )
+    section = "default" if profile == "default" else f"profile {profile}"
+    config_path = os.path.expanduser(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config"))
+    config = configparser.ConfigParser()
+    try:
+        config.read(config_path)
+        configured_region = config.get(section, "region", fallback=None)
+    except configparser.Error:
+        configured_region = None
+    return configured_region or "us-east-1"
 
 
 class S3QcowBackuper(qcow.AbstractQcowBackuper):
@@ -37,12 +61,14 @@ class S3QcowBackuper(qcow.AbstractQcowBackuper):
         bucket_name: str,
         snapshot_name: str = "backup_snap",
         logger: logger_base.AbstractLogger | None = None,
+        region: str | None = None,
     ):
         self._access_key = access_key
         self._secret_key = secret_key
         self._host = host
         self._bucket_name = bucket_name
         self._endpoint_url = endpoint_url
+        self._region = _resolve_region(region)
         self._logger = logger or logger_base.ClickLogger()
         self._snapshot_name = snapshot_name
 
@@ -53,17 +79,20 @@ class S3QcowBackuper(qcow.AbstractQcowBackuper):
         encryption: base.EncryptionCreds | None = None,
     ) -> None:
         """Upload a stream to S3."""
-        s3_client = boto3.client(
-            "s3",
+        client = s3_client.S3BackupClient(
             endpoint_url=self._endpoint_url,
-            aws_access_key_id=self._access_key,
-            aws_secret_access_key=self._secret_key,
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            region=self._region,
         )
 
         if encryption:
             stream = utils.ReaderEncryptorIO(stream, encryption.key, encryption.iv)
             s3_path += self.ENCRYPTED_SUFFIX
-        s3_client.upload_fileobj(stream, self._bucket_name, s3_path)
+
+        stream.seek(0, os.SEEK_END)
+        stream_size = stream.tell()
+        client.upload(stream, self._bucket_name, s3_path, stream_size)
 
     def _upload_file(
         self,

--- a/exordos/backup/s3_client.py
+++ b/exordos/backup/s3_client.py
@@ -1,0 +1,456 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import logging
+import time
+import typing as tp
+from urllib import parse
+from xml.etree import ElementTree
+
+import requests
+
+_LOG = logging.getLogger(__name__)
+
+_MIN_MULTIPART_PART_SIZE = 5 * 1024 * 1024
+_MAX_MULTIPART_PART_SIZE = 5 * 1024 * 1024 * 1024
+_MAX_MULTIPART_PARTS = 10_000
+_REQUEST_TIMEOUT = (10, 300)
+_MAX_REQUEST_ATTEMPTS = 4
+_BACKOFF_FACTOR = 0.5
+_TRANSIENT_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+_TRANSIENT_ERROR_CODES = frozenset(
+    {"InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown"}
+)
+
+
+class S3BackupError(RuntimeError):
+    """An S3 request required to create a backup failed."""
+
+
+class S3BackupClient:
+    """Minimal path-style S3 client used only for backup uploads."""
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        access_key: str,
+        secret_key: str,
+        region: str,
+        session: requests.Session | None = None,
+    ) -> None:
+        endpoint = parse.urlsplit(endpoint_url.rstrip("/"))
+        if (
+            endpoint.scheme not in {"http", "https"}
+            or not endpoint.netloc
+            or endpoint.username is not None
+            or endpoint.password is not None
+            or endpoint.path not in {"", "/"}
+            or endpoint.query
+            or endpoint.fragment
+        ):
+            raise ValueError("S3 endpoint must be an HTTP(S) origin without a path")
+
+        self._endpoint = f"{endpoint.scheme}://{endpoint.netloc}"
+        self._host = endpoint.netloc
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._region = region
+        self._session = session or requests.Session()
+
+    def upload(
+        self,
+        stream: tp.BinaryIO,
+        bucket: str,
+        key: str,
+        size: int,
+    ) -> None:
+        """Upload a seekable stream and verify the resulting object size."""
+        if not bucket or not key:
+            raise ValueError("S3 bucket and key must not be empty")
+        if size < 0:
+            raise ValueError("S3 object size must not be negative")
+
+        part_size = max(
+            _MIN_MULTIPART_PART_SIZE,
+            (size + _MAX_MULTIPART_PARTS - 1) // _MAX_MULTIPART_PARTS,
+        )
+        if part_size > _MAX_MULTIPART_PART_SIZE:
+            raise ValueError("S3 object is too large for a multipart upload")
+
+        stream.seek(0)
+        if size <= part_size:
+            self._put_object(stream, bucket, key, size)
+        else:
+            self._upload_multipart(stream, bucket, key, size, part_size)
+
+        self._verify_object(bucket, key, size)
+
+    def _put_object(
+        self, stream: tp.BinaryIO, bucket: str, key: str, size: int
+    ) -> None:
+        path = self._object_path(bucket, key)
+        body_hash = self._stream_hash(stream, size)
+        url = self._endpoint + path
+        for attempt in range(_MAX_REQUEST_ATTEMPTS):
+            stream.seek(0)
+            headers = self._signed_headers("PUT", path, "", body_hash)
+            try:
+                response = self._session.request(
+                    "PUT",
+                    url,
+                    headers=headers,
+                    data=stream,
+                    timeout=_REQUEST_TIMEOUT,
+                    allow_redirects=False,
+                )
+            except (requests.ConnectionError, requests.Timeout) as error:
+                if attempt + 1 == _MAX_REQUEST_ATTEMPTS:
+                    raise S3BackupError(f"S3 PUT request failed: {error}") from error
+                self._sleep(attempt)
+                continue
+            except requests.RequestException as error:
+                raise S3BackupError(f"S3 PUT request failed: {error}") from error
+
+            if response.status_code == 200:
+                return
+            if (
+                response.status_code in _TRANSIENT_STATUS_CODES
+                and attempt + 1 < _MAX_REQUEST_ATTEMPTS
+            ):
+                self._sleep(attempt)
+                continue
+            code, message = self._xml_error(response.content)
+            raise S3BackupError(
+                f"S3 PUT request failed with HTTP {response.status_code}: "
+                f"{code}: {message}"
+            )
+
+        raise AssertionError("Unreachable S3 PUT state")
+
+    def _upload_multipart(
+        self,
+        stream: tp.BinaryIO,
+        bucket: str,
+        key: str,
+        size: int,
+        part_size: int,
+    ) -> None:
+        upload_id = self._create_multipart_upload(bucket, key)
+        completed = False
+        try:
+            parts: list[tuple[int, str]] = []
+            remaining = size
+            part_number = 1
+            while remaining:
+                if part_number > _MAX_MULTIPART_PARTS:
+                    raise S3BackupError("S3 multipart upload exceeds 10,000 parts")
+
+                body = self._read_exact(stream, min(part_size, remaining))
+                response = self._request(
+                    "PUT",
+                    bucket,
+                    key,
+                    query={"partNumber": str(part_number), "uploadId": upload_id},
+                    body=body,
+                )
+                etag = response.headers.get("ETag")
+                if not etag:
+                    raise S3BackupError(
+                        f"S3 did not return an ETag for part {part_number}"
+                    )
+                parts.append((part_number, etag))
+                remaining -= len(body)
+                part_number += 1
+
+            self._complete_multipart_upload(bucket, key, upload_id, parts)
+            completed = True
+        except BaseException:
+            if not completed:
+                self._abort_multipart_upload(bucket, key, upload_id)
+            raise
+
+    def _create_multipart_upload(self, bucket: str, key: str) -> str:
+        response = self._request(
+            "POST",
+            bucket,
+            key,
+            query={"uploads": ""},
+            retry=False,
+        )
+        upload_id = self._xml_value(response.content, "UploadId")
+        if not upload_id:
+            raise S3BackupError("S3 did not return a multipart upload ID")
+        return upload_id
+
+    def _complete_multipart_upload(
+        self,
+        bucket: str,
+        key: str,
+        upload_id: str,
+        parts: list[tuple[int, str]],
+    ) -> None:
+        root = ElementTree.Element("CompleteMultipartUpload")
+        for part_number, etag in parts:
+            part = ElementTree.SubElement(root, "Part")
+            ElementTree.SubElement(part, "ETag").text = etag
+            ElementTree.SubElement(part, "PartNumber").text = str(part_number)
+        body = ElementTree.tostring(root, encoding="utf-8")
+
+        for attempt in range(_MAX_REQUEST_ATTEMPTS):
+            response = self._request(
+                "POST",
+                bucket,
+                key,
+                query={"uploadId": upload_id},
+                body=body,
+            )
+            root_name = self._xml_root_name(response.content)
+            if root_name == "CompleteMultipartUploadResult":
+                return
+            if root_name != "Error":
+                raise S3BackupError(
+                    "S3 returned an invalid multipart completion response"
+                )
+
+            code, message = self._xml_error(response.content)
+            if (
+                code not in _TRANSIENT_ERROR_CODES
+                or attempt + 1 == _MAX_REQUEST_ATTEMPTS
+            ):
+                raise S3BackupError(
+                    f"S3 multipart completion failed: {code}: {message}"
+                )
+            self._sleep(attempt)
+
+        raise AssertionError("Unreachable multipart completion state")
+
+    def _abort_multipart_upload(self, bucket: str, key: str, upload_id: str) -> None:
+        try:
+            self._request(
+                "DELETE",
+                bucket,
+                key,
+                query={"uploadId": upload_id},
+                expected_statuses=frozenset({204}),
+            )
+        except S3BackupError as error:
+            _LOG.warning("Failed to abort S3 multipart upload: %s", error)
+
+    def _verify_object(self, bucket: str, key: str, expected_size: int) -> None:
+        response = self._request(
+            "HEAD",
+            bucket,
+            key,
+            retry_statuses=_TRANSIENT_STATUS_CODES | {404},
+        )
+        content_length = response.headers.get("Content-Length")
+        try:
+            actual_size = int(content_length) if content_length is not None else None
+        except ValueError as error:
+            raise S3BackupError("S3 returned an invalid object size") from error
+        if actual_size != expected_size:
+            raise S3BackupError(
+                f"S3 object size mismatch: expected {expected_size}, got {actual_size}"
+            )
+
+    def _request(
+        self,
+        method: str,
+        bucket: str,
+        key: str,
+        *,
+        query: dict[str, str] | None = None,
+        body: bytes = b"",
+        expected_statuses: frozenset[int] = frozenset({200}),
+        retry: bool = True,
+        retry_statuses: frozenset[int] = _TRANSIENT_STATUS_CODES,
+    ) -> requests.Response:
+        path = self._object_path(bucket, key)
+        canonical_query = self._canonical_query(query or {})
+        url = self._endpoint + path
+        if canonical_query:
+            url += "?" + canonical_query
+        attempts = _MAX_REQUEST_ATTEMPTS if retry else 1
+
+        for attempt in range(attempts):
+            body_hash = hashlib.sha256(body).hexdigest()
+            headers = self._signed_headers(method, path, canonical_query, body_hash)
+            try:
+                response = self._session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    data=body,
+                    timeout=_REQUEST_TIMEOUT,
+                    allow_redirects=False,
+                )
+            except (requests.ConnectionError, requests.Timeout) as error:
+                if attempt + 1 == attempts:
+                    raise S3BackupError(
+                        f"S3 {method} request failed: {error}"
+                    ) from error
+                self._sleep(attempt)
+                continue
+            except requests.RequestException as error:
+                raise S3BackupError(f"S3 {method} request failed: {error}") from error
+
+            if response.status_code in expected_statuses:
+                return response
+            if response.status_code in retry_statuses and attempt + 1 < attempts:
+                self._sleep(attempt)
+                continue
+
+            code, message = self._xml_error(response.content)
+            raise S3BackupError(
+                f"S3 {method} request failed with HTTP {response.status_code}: "
+                f"{code}: {message}"
+            )
+
+        raise AssertionError("Unreachable S3 request state")
+
+    def _signed_headers(
+        self,
+        method: str,
+        path: str,
+        canonical_query: str,
+        payload_hash: str,
+    ) -> dict[str, str]:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+        date_stamp = now.strftime("%Y%m%d")
+        canonical_headers = (
+            f"host:{self._host}\n"
+            f"x-amz-content-sha256:{payload_hash}\n"
+            f"x-amz-date:{amz_date}\n"
+        )
+        signed_headers = "host;x-amz-content-sha256;x-amz-date"
+        canonical_request = "\n".join(
+            [
+                method,
+                path,
+                canonical_query,
+                canonical_headers,
+                signed_headers,
+                payload_hash,
+            ]
+        )
+        credential_scope = f"{date_stamp}/{self._region}/s3/aws4_request"
+        string_to_sign = "\n".join(
+            [
+                "AWS4-HMAC-SHA256",
+                amz_date,
+                credential_scope,
+                hashlib.sha256(canonical_request.encode()).hexdigest(),
+            ]
+        )
+        signing_key = self._signing_key(date_stamp)
+        signature = hmac.new(
+            signing_key, string_to_sign.encode(), hashlib.sha256
+        ).hexdigest()
+        authorization = (
+            "AWS4-HMAC-SHA256 "
+            f"Credential={self._access_key}/{credential_scope}, "
+            f"SignedHeaders={signed_headers}, Signature={signature}"
+        )
+        return {
+            "Authorization": authorization,
+            "Host": self._host,
+            "X-Amz-Content-SHA256": payload_hash,
+            "X-Amz-Date": amz_date,
+        }
+
+    def _signing_key(self, date_stamp: str) -> bytes:
+        key = hmac.new(
+            f"AWS4{self._secret_key}".encode(), date_stamp.encode(), hashlib.sha256
+        ).digest()
+        for value in (self._region, "s3", "aws4_request"):
+            key = hmac.new(key, value.encode(), hashlib.sha256).digest()
+        return key
+
+    @staticmethod
+    def _object_path(bucket: str, key: str) -> str:
+        encoded_bucket = parse.quote(bucket, safe="-_.~")
+        encoded_key = parse.quote(key, safe="/-_.~")
+        return f"/{encoded_bucket}/{encoded_key}"
+
+    @staticmethod
+    def _canonical_query(query: dict[str, str]) -> str:
+        encoded = [
+            (parse.quote(key, safe="-_.~"), parse.quote(value, safe="-_.~"))
+            for key, value in query.items()
+        ]
+        return "&".join(f"{key}={value}" for key, value in sorted(encoded))
+
+    @staticmethod
+    def _read_exact(stream: tp.BinaryIO, size: int) -> bytes:
+        chunks: list[bytes] = []
+        remaining = size
+        while remaining:
+            chunk = stream.read(remaining)
+            if not chunk:
+                raise S3BackupError(
+                    "Backup stream ended before the expected object size"
+                )
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    @staticmethod
+    def _stream_hash(stream: tp.BinaryIO, size: int) -> str:
+        digest = hashlib.sha256()
+        remaining = size
+        stream.seek(0)
+        while remaining:
+            chunk = stream.read(min(1024 * 1024, remaining))
+            if not chunk:
+                raise S3BackupError(
+                    "Backup stream ended before the expected object size"
+                )
+            digest.update(chunk)
+            remaining -= len(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _xml_root_name(content: bytes) -> str | None:
+        try:
+            return ElementTree.fromstring(content).tag.rsplit("}", 1)[-1]
+        except ElementTree.ParseError:
+            return None
+
+    @staticmethod
+    def _xml_value(content: bytes, name: str) -> str | None:
+        try:
+            root = ElementTree.fromstring(content)
+        except ElementTree.ParseError:
+            return None
+        for element in root.iter():
+            if element.tag.rsplit("}", 1)[-1] == name:
+                return element.text
+        return None
+
+    @classmethod
+    def _xml_error(cls, content: bytes) -> tuple[str, str]:
+        code = cls._xml_value(content, "Code") or "UnknownError"
+        message = cls._xml_value(content, "Message") or content.decode(errors="replace")
+        return code, message
+
+    @staticmethod
+    def _sleep(attempt: int) -> None:
+        time.sleep(_BACKOFF_FACTOR * (2**attempt))

--- a/exordos/tests/unit/test_s3_backup.py
+++ b/exordos/tests/unit/test_s3_backup.py
@@ -1,0 +1,141 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from unittest import mock
+
+from exordos.backup import base
+from exordos.backup.s3 import S3QcowBackuper
+from exordos.utils import ReaderEncryptorIO
+
+
+def _backuper(region: str | None = "us-east-1") -> S3QcowBackuper:
+    return S3QcowBackuper(
+        endpoint_url="https://s3.example.test",
+        access_key="access-key",
+        secret_key="secret-key",
+        host="test-host",
+        bucket_name="test-bucket",
+        region=region,
+    )
+
+
+@mock.patch("exordos.backup.s3.s3_client.S3BackupClient")
+def test_upload_stream_uses_internal_client(client_class: mock.MagicMock) -> None:
+    stream = io.BytesIO(b"backup")
+
+    _backuper(region="eu-central-1")._upload_stream(stream, "domain/disk.qcow2")
+
+    client_class.assert_called_once_with(
+        endpoint_url="https://s3.example.test",
+        access_key="access-key",
+        secret_key="secret-key",
+        region="eu-central-1",
+    )
+    client_class.return_value.upload.assert_called_once_with(
+        stream,
+        "test-bucket",
+        "domain/disk.qcow2",
+        6,
+    )
+
+
+@mock.patch("exordos.backup.s3.s3_client.S3BackupClient")
+def test_upload_stream_preserves_environment_region(
+    client_class: mock.MagicMock,
+) -> None:
+    with mock.patch.dict(os.environ, {"AWS_DEFAULT_REGION": "eu-west-1"}):
+        backuper = S3QcowBackuper(
+            "https://s3.example.test",
+            "access-key",
+            "secret-key",
+            "test-host",
+            "test-bucket",
+            "legacy-snapshot-name",
+        )
+
+    backuper._upload_stream(io.BytesIO(b"backup"), "domain/disk.qcow2")
+
+    assert backuper._snapshot_name == "legacy-snapshot-name"
+    assert client_class.call_args.kwargs["region"] == "eu-west-1"
+
+
+@mock.patch("exordos.backup.s3.s3_client.S3BackupClient")
+def test_upload_stream_preserves_aws_profile_region(
+    client_class: mock.MagicMock,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config"
+    config_path.write_text("[profile backup]\nregion = ap-southeast-2\n")
+    environment = {
+        "AWS_CONFIG_FILE": str(config_path),
+        "AWS_PROFILE": "backup",
+    }
+    with mock.patch.dict(os.environ, environment, clear=True):
+        backuper = _backuper(region=None)
+
+    backuper._upload_stream(io.BytesIO(b"backup"), "domain/disk.qcow2")
+
+    assert client_class.call_args.kwargs["region"] == "ap-southeast-2"
+
+
+@mock.patch("exordos.backup.s3.s3_client.S3BackupClient")
+def test_upload_stream_encrypts_content_and_suffixes_key(
+    client_class: mock.MagicMock,
+) -> None:
+    encryption = base.EncryptionCreds(b"0123456789abcdef", b"fedcba9876543210")
+
+    _backuper()._upload_stream(io.BytesIO(b"backup"), "domain.xml", encryption)
+
+    uploaded_stream, bucket, key, size = client_class.return_value.upload.call_args.args
+    assert isinstance(uploaded_stream, ReaderEncryptorIO)
+    assert bucket == "test-bucket"
+    assert key == "domain.xml.encrypted"
+    assert size == 6
+
+
+def test_reader_encryptor_supports_repeated_eof_reads() -> None:
+    stream = ReaderEncryptorIO(
+        io.BytesIO(b"backup"),
+        b"0123456789abcdef",
+        b"fedcba9876543210",
+    )
+
+    encrypted = stream.read(1024)
+
+    assert stream.read(1024) == b""
+    assert stream.read(1024) == b""
+    stream.seek(0)
+    assert stream.read(1024) == encrypted
+
+
+def test_reader_encryptor_preserves_length_and_read_size_contract() -> None:
+    plaintext = b"backup payload"
+    stream = ReaderEncryptorIO(
+        io.BytesIO(plaintext),
+        b"0123456789abcdef",
+        b"fedcba9876543210",
+    )
+
+    chunks = []
+    while chunk := stream.read(3):
+        assert len(chunk) <= 3
+        chunks.append(chunk)
+
+    assert len(b"".join(chunks)) == len(plaintext)

--- a/exordos/tests/unit/test_s3_client.py
+++ b/exordos/tests/unit/test_s3_client.py
@@ -1,0 +1,330 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from __future__ import annotations
+
+import io
+from unittest import mock
+
+import pytest
+import requests
+
+from exordos.backup import s3_client
+
+
+@pytest.fixture
+def small_multipart_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(s3_client, "_MIN_MULTIPART_PART_SIZE", 5)
+
+
+def _response(
+    status: int = 200,
+    content: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response._content = content
+    response.headers.update(headers or {})
+    return response
+
+
+def _client(session: mock.MagicMock) -> s3_client.S3BackupClient:
+    return s3_client.S3BackupClient(
+        endpoint_url="https://s3.example.test",
+        access_key="access-key",
+        secret_key="secret-key",
+        region="eu-central-1",
+        session=session,
+    )
+
+
+def test_upload_small_object_signs_encoded_path_and_verifies_size() -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(),
+        _response(headers={"Content-Length": "6"}),
+    ]
+
+    _client(session).upload(
+        io.BytesIO(b"backup"), "test-bucket", "domain/my disk+#?.qcow2", 6
+    )
+
+    put_call, head_call = session.request.call_args_list
+    assert put_call.args[:2] == (
+        "PUT",
+        "https://s3.example.test/test-bucket/domain/my%20disk%2B%23%3F.qcow2",
+    )
+    assert put_call.kwargs["timeout"] == (10, 300)
+    assert put_call.kwargs["allow_redirects"] is False
+    assert put_call.kwargs["data"] is not None
+    assert put_call.kwargs["data"].read() == b"backup"
+    assert put_call.kwargs["headers"]["Authorization"].startswith(
+        "AWS4-HMAC-SHA256 Credential=access-key/"
+    )
+    assert head_call.args[0] == "HEAD"
+
+
+def test_upload_multipart_completes_and_verifies_size(
+    small_multipart_parts: None,
+) -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(
+            content=(
+                b'<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/'
+                b'doc/2006-03-01/"><UploadId>upload+id/1</UploadId>'
+                b"</InitiateMultipartUploadResult>"
+            )
+        ),
+        _response(headers={"ETag": '"part-1"'}),
+        _response(headers={"ETag": '"part-2"'}),
+        _response(
+            content=(
+                b'<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/'
+                b'doc/2006-03-01/"><ETag>"complete"</ETag>'
+                b"</CompleteMultipartUploadResult>"
+            )
+        ),
+        _response(headers={"Content-Length": "6"}),
+    ]
+
+    _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    requests_made = session.request.call_args_list
+    assert [call.args[0] for call in requests_made] == [
+        "POST",
+        "PUT",
+        "PUT",
+        "POST",
+        "HEAD",
+    ]
+    assert requests_made[0].args[1].endswith("/bucket/disk?uploads=")
+    assert "partNumber=1&uploadId=upload%2Bid%2F1" in requests_made[1].args[1]
+    assert b"<PartNumber>2</PartNumber>" in requests_made[3].kwargs["data"]
+
+
+def test_upload_multipart_rejects_embedded_completion_error(
+    small_multipart_parts: None,
+) -> None:
+    session = mock.MagicMock()
+    completion_error = (
+        b"<Error><Code>AccessDenied</Code><Message>denied</Message></Error>"
+    )
+    session.request.side_effect = [
+        _response(content=b"<Result><UploadId>upload-id</UploadId></Result>"),
+        _response(headers={"ETag": '"part-1"'}),
+        _response(headers={"ETag": '"part-2"'}),
+        _response(content=completion_error),
+        _response(status=204),
+    ]
+
+    with pytest.raises(
+        s3_client.S3BackupError,
+        match="multipart completion failed: AccessDenied: denied",
+    ):
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    assert session.request.call_args_list[-1].args[0] == "DELETE"
+
+
+def test_upload_multipart_retries_transient_embedded_completion_error(
+    small_multipart_parts: None,
+) -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(content=b"<Result><UploadId>upload-id</UploadId></Result>"),
+        _response(headers={"ETag": '"part-1"'}),
+        _response(headers={"ETag": '"part-2"'}),
+        _response(
+            content=(
+                b"<Error><Code>InternalError</Code><Message>retry</Message></Error>"
+            )
+        ),
+        _response(content=b"<CompleteMultipartUploadResult/>"),
+        _response(headers={"Content-Length": "6"}),
+    ]
+
+    with mock.patch("exordos.backup.s3_client.time.sleep") as sleep:
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    sleep.assert_called_once_with(0.5)
+
+
+def test_upload_retries_timeout_and_transient_http_status() -> None:
+    session = mock.MagicMock()
+    uploaded_bodies: list[bytes] = []
+
+    def request(method: str, _url: str, **kwargs: object) -> requests.Response:
+        if method == "HEAD":
+            return _response(headers={"Content-Length": "6"})
+        body = kwargs["data"]
+        assert isinstance(body, io.BytesIO)
+        uploaded_bodies.append(body.read())
+        if len(uploaded_bodies) == 1:
+            raise requests.Timeout("timed out")
+        if len(uploaded_bodies) == 2:
+            return _response(
+                status=503, content=b"<Error><Code>SlowDown</Code></Error>"
+            )
+        return _response()
+
+    session.request.side_effect = request
+
+    with mock.patch("exordos.backup.s3_client.time.sleep") as sleep:
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    assert sleep.call_args_list == [mock.call(0.5), mock.call(1.0)]
+    assert uploaded_bodies == [b"backup", b"backup", b"backup"]
+
+
+def test_upload_multipart_retries_same_part_body_after_connection_error(
+    small_multipart_parts: None,
+) -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(content=b"<Result><UploadId>upload-id</UploadId></Result>"),
+        requests.ConnectionError("connection lost"),
+        _response(headers={"ETag": '"part-1"'}),
+        _response(headers={"ETag": '"part-2"'}),
+        _response(content=b"<CompleteMultipartUploadResult/>"),
+        _response(headers={"Content-Length": "6"}),
+    ]
+
+    with mock.patch("exordos.backup.s3_client.time.sleep"):
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    retried_part = session.request.call_args_list[2]
+    assert retried_part.kwargs["data"] == b"backu"
+
+
+def test_upload_multipart_aborts_when_stream_ends_early(
+    small_multipart_parts: None,
+) -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(content=b"<Result><UploadId>upload-id</UploadId></Result>"),
+        _response(headers={"ETag": '"part-1"'}),
+        _response(status=204),
+    ]
+
+    with pytest.raises(s3_client.S3BackupError, match="stream ended"):
+        _client(session).upload(io.BytesIO(b"short"), "bucket", "disk", 6)
+
+    assert session.request.call_args_list[-1].args[0] == "DELETE"
+
+
+def test_upload_retries_head_until_object_is_visible() -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(),
+        _response(status=404),
+        _response(headers={"Content-Length": "6"}),
+    ]
+
+    with mock.patch("exordos.backup.s3_client.time.sleep") as sleep:
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    sleep.assert_called_once_with(0.5)
+
+
+def test_upload_aborts_when_part_has_no_etag(small_multipart_parts: None) -> None:
+    session = mock.MagicMock()
+    session.request.side_effect = [
+        _response(content=b"<Result><UploadId>upload-id</UploadId></Result>"),
+        _response(),
+        _response(status=204),
+    ]
+
+    with pytest.raises(s3_client.S3BackupError, match="did not return an ETag"):
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+    assert session.request.call_args_list[-1].args[0] == "DELETE"
+
+
+@pytest.mark.parametrize("content_length", [None, "invalid", "5"])
+def test_upload_rejects_missing_invalid_or_wrong_object_size(
+    content_length: str | None,
+) -> None:
+    session = mock.MagicMock()
+    headers = {} if content_length is None else {"Content-Length": content_length}
+    session.request.side_effect = [_response(), _response(headers=headers)]
+
+    with pytest.raises(s3_client.S3BackupError, match="object size"):
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 6)
+
+
+@pytest.mark.parametrize(
+    ("bucket", "key", "size", "error"),
+    [
+        ("", "disk", 6, "bucket and key"),
+        ("bucket", "", 6, "bucket and key"),
+        ("bucket", "disk", -1, "must not be negative"),
+    ],
+)
+def test_upload_rejects_invalid_input(
+    bucket: str, key: str, size: int, error: str
+) -> None:
+    session = mock.MagicMock()
+
+    with pytest.raises(ValueError, match=error):
+        _client(session).upload(io.BytesIO(b"backup"), bucket, key, size)
+
+    session.request.assert_not_called()
+
+
+def test_upload_rejects_object_larger_than_multipart_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = mock.MagicMock()
+    monkeypatch.setattr(s3_client, "_MAX_MULTIPART_PART_SIZE", 2)
+    monkeypatch.setattr(s3_client, "_MAX_MULTIPART_PARTS", 2)
+
+    with pytest.raises(ValueError, match="too large"):
+        _client(session).upload(io.BytesIO(b"backup"), "bucket", "disk", 5)
+
+    session.request.assert_not_called()
+
+
+def test_upload_scales_multipart_part_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = mock.MagicMock()
+    client = _client(session)
+    stream = io.BytesIO(b"x" * 100)
+    monkeypatch.setattr(s3_client, "_MIN_MULTIPART_PART_SIZE", 1)
+    monkeypatch.setattr(s3_client, "_MAX_MULTIPART_PARTS", 10)
+
+    with (
+        mock.patch.object(client, "_upload_multipart") as upload_multipart,
+        mock.patch.object(client, "_verify_object"),
+    ):
+        client.upload(stream, "bucket", "disk", 100)
+
+    upload_multipart.assert_called_once_with(stream, "bucket", "disk", 100, 10)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "ftp://s3.example.test",
+        "https://user:password@s3.example.test",
+        "https://s3.example.test/path",
+        "https://s3.example.test?query=value",
+    ],
+)
+def test_init_rejects_invalid_endpoint(endpoint: str) -> None:
+    with pytest.raises(ValueError, match=r"HTTP\(S\) origin"):
+        s3_client.S3BackupClient(endpoint, "access", "secret", "us-east-1")

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -333,29 +333,35 @@ class ReaderEncryptorIO(io.BytesIO):
         )
 
         self._encryptor = self._cipher.encryptor()
+        self._finalized = False
         self._chunk_size = chunk_size_kb << 10
 
     def tell(self) -> int:
         return self._file.tell()
 
     def read(self, size: int = -1) -> bytes:
-        if size == 0:
+        if size == 0 or self._finalized:
             return b""
 
         if size < 0:
-            return (
+            encrypted = (
                 self._encryptor.update(self._file.read()) + self._encryptor.finalize()
             )
+            self._finalized = True
+            return encrypted
 
         data = self._file.read(size)
         if len(data) < size:
-            return self._encryptor.update(data) + self._encryptor.finalize()
+            encrypted = self._encryptor.update(data) + self._encryptor.finalize()
+            self._finalized = True
+            return encrypted
 
         return self._encryptor.update(data)
 
     def seek(self, offset: int, whence: int = 0) -> int:
         if offset == 0 and whence == 0:
             self._encryptor = self._cipher.encryptor()
+            self._finalized = False
 
         return self._file.seek(offset, whence)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "GitPython>=3.1.50,<4.0.0",  # BSD
     "bazooka>=1.0.0,<2.0.0",  # Apache-2.0
     "cryptography>=49.0.0",  # BSD-3
-    "boto3>=1.37.0,<2.0.0",  # Apache-2.0
+    "requests>=2.31.0,<3.0.0",  # Apache-2.0
     "Jinja2>=3.1.5,<4.0.0",  # BSD License (BSD-3-Clause)
     "packaging==26.0",  # Apache-2.0 or BSD
     "simple-term-menu>=1.6.6,<2.0.0",  # MIT License (MIT)

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ basepython = python3.14
 extras =
   bin
 runner = uv-venv-lock-runner
-commands = pyinstaller {posargs:--onefile} --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator ./exordos/cmd/cli.py
+commands = pyinstaller {posargs:--onefile} --name exordos --recursive-copy-metadata exordos --add-data="exordos/packer/*:exordos/packer" --hidden-import=exordos.packer --add-data="exordos/repo/*:exordos/repo" --hidden-import=exordos.repo --hidden-import=exordos.backup.s3 --add-data="exordos/templates/*:exordos/templates" --add-data="exordos/autocomplete/*:exordos/autocomplete" --add-data="exordos/spec/*:exordos/spec" --collect-data openapi_schema_validator ./exordos/cmd/cli.py
 
 [testenv:installer]
 extras =

--- a/uv.lock
+++ b/uv.lock
@@ -48,34 +48,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.42.74"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/ec/636ab2aa7ad9e6bf6e297240ac2d44dba63cc6611e2d5038db318436d449/boto3-1.42.74.tar.gz", hash = "sha256:dbacd808cf2a3dadbf35f3dbd8de97b94dc9f78b1ebd439f38f552e0f9753577", size = 112739, upload-time = "2026-03-23T19:34:09.815Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/16/a264b4da2af99f4a12609b93fea941cce5ec41da14b33ed3fef77a910f0c/boto3-1.42.74-py3-none-any.whl", hash = "sha256:4bf89c044d618fe4435af854ab820f09dd43569c0df15d7beb0398f50b9aa970", size = 140557, upload-time = "2026-03-23T19:34:07.084Z" },
-]
-
-[[package]]
-name = "botocore"
-version = "1.42.74"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/c7/cab8a14f0b69944bd0dd1fd58559163455b347eeda00bf836e93ce2684e4/botocore-1.42.74.tar.gz", hash = "sha256:9cf5cdffc6c90ed87b0fe184676806182588be0d0df9b363e9fe3e2923ac8e80", size = 15014379, upload-time = "2026-03-23T19:33:57.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/65/75852e04de5423c9b0c5b88241d0bdea33e6c6f454c88b71377d230216f2/botocore-1.42.74-py3-none-any.whl", hash = "sha256:3a76a8af08b5de82e51a0ae132394e226e15dbf21c8146ac3f7c1f881517a7a7", size = 14688218, upload-time = "2026-03-23T19:33:52.677Z" },
-]
-
-[[package]]
 name = "cachetools"
 version = "7.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -497,7 +469,6 @@ name = "exordos"
 source = { editable = "." }
 dependencies = [
     { name = "bazooka" },
-    { name = "boto3" },
     { name = "certifi" },
     { name = "click" },
     { name = "cryptography" },
@@ -509,6 +480,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "qrcode" },
     { name = "questionary" },
+    { name = "requests" },
     { name = "rich" },
     { name = "rich-click" },
     { name = "ruamel-yaml" },
@@ -549,7 +521,6 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "bazooka", specifier = ">=1.0.0,<2.0.0" },
-    { name = "boto3", specifier = ">=1.37.0,<2.0.0" },
     { name = "certifi", specifier = ">=2026.2.25" },
     { name = "click", specifier = ">=8.1.7,<9.0.0" },
     { name = "coverage", marker = "extra == 'test'", specifier = ">=4.0" },
@@ -572,6 +543,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
     { name = "qrcode", specifier = ">=8.0,<9.0.0" },
     { name = "questionary", specifier = ">=2.1.1" },
+    { name = "requests", specifier = ">=2.31.0,<3.0.0" },
     { name = "rich", specifier = ">=13.3.3,<14.0.0" },
     { name = "rich-click", specifier = ">=1.9.7,<2.0.0" },
     { name = "ruamel-yaml", specifier = "==0.17.26" },
@@ -656,15 +628,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jmespath"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2200,18 +2163,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace `boto3` with a small internal S3 transport scoped to backup creation
- support SigV4 path-style PUT and multipart uploads with bounded retries, timeouts, cleanup, and final object-size verification
- keep existing S3 backup configuration compatible while adding an optional `region` setting
- preserve retry-safe streaming encryption and include the dynamically loaded S3 driver in the one-file binary
- add a pinned, source-built MinIO test image and CI upload smoke test

## Why an internal client

The backup path only needs object creation. Keeping that narrow protocol surface in-tree removes `boto3`, `botocore`, `s3transfer`, and `jmespath` without replacing them with another externally maintained S3 client. The implementation uses the existing direct `requests` dependency plus the standard-library XML and cryptographic signing primitives.

## Failure handling

- connect/read timeout: 10/300 seconds
- four attempts with exponential backoff for transport errors and transient S3 responses
- handling for S3 `<Error>` payloads returned with HTTP 200 during multipart completion
- best-effort multipart abort on failed uploads
- HEAD verification of the committed object's `Content-Length`
- URL encoding for object keys and signed query parameters
- redirects disabled so signed requests and backup bodies are not forwarded to an untrusted destination

## Validation

- `tox -e py312` (290 passed)
- `tox -e ruff`
- `tox -e bin`
- one-file binary smoke: `exordos --help` and `exordos backup --help`
- MinIO integration: small and multipart objects uploaded, sizes verified, multipart content hash matched
- isolated libvirt/MinIO end-to-end backup: a 2.21 GB active-domain backup completed successfully; all 39 sampled domain states remained `running`; no snapshot or incomplete multipart upload remained
- test Dockerfile smoke: pinned MinIO source build, health endpoint, and upload through `S3BackupClient`

## Summary by Sourcery

Replace the external boto3 dependency with an internal, SigV4-based S3 backup client and integrate it into the S3 qcow backuper.

New Features:
- Introduce a minimal internal S3BackupClient supporting path-style PUT and multipart uploads with verification and bounded retries.
- Add optional region configuration for S3 backups while maintaining compatibility with existing S3 backup settings.

Enhancements:
- Update S3 backup streaming encryption to support repeated EOF reads and seeking while remaining retry-safe.
- Include the S3 backup driver in the one-file binary build configuration and adjust multipart part sizing for large backups.

Build:
- Remove boto3 from project dependencies and add requests as the HTTP client dependency.
- Update pyinstaller configuration to ensure the S3 backup module is bundled into the one-file executable.

Documentation:
- Extend the S3 backup YAML configuration to document the new region field.

Tests:
- Add unit tests for the new S3BackupClient covering multipart upload flows, error handling, retries, and object size verification.
- Add unit tests for S3QcowBackuper to validate use of the internal client, part sizing, and encrypted upload behavior.
- Add tests for ReaderEncryptorIO to confirm correct behavior after EOF and on seek/reset.