### PR TITLE
feat(cli): use fixed port for deploy local HTTP server

### DIFF
--- a/exordos/cmd/deploy/commands.py
+++ b/exordos/cmd/deploy/commands.py
@@ -15,6 +15,7 @@
 #    under the License.
 from __future__ import annotations
 
+import errno
 import ipaddress
 import json
 import pathlib
@@ -38,6 +39,7 @@ if tp.TYPE_CHECKING:
 DEFAULT_REPO_NAME = "exordos-dev-repo"
 DEFAULT_PRIORITY = 4096
 DEFAULT_TIMEOUT = 600.0
+DEFAULT_PORT = 33101
 
 
 def _load_build_inventory(element_dir: pathlib.Path) -> dict[str, dict]:
@@ -125,6 +127,24 @@ def _get_local_host_bind(config: dict[str, tp.Any], realm: str | None = None) ->
         "Ensure the current realm has a valid 'meta.cidr' set and this "
         "machine has an interface in that network."
     )
+
+
+def _check_port_available(host: str, port: int) -> None:
+    """Raise ``click.ClickException`` if *port* cannot be bound on *host*."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host, port))
+    except OSError as exc:
+        if exc.errno == errno.EADDRINUSE:
+            raise click.ClickException(
+                f"Port {port} is already in use on {host} ({exc}). "
+                "Stop the process holding it or rerun `exordos deploy` with "
+                "a different port via the `--port` option."
+            ) from exc
+        raise click.ClickException(
+            f"Failed to bind to {host}:{port} ({exc}). "
+            "Please check the host and port configuration and try again."
+        ) from exc
 
 
 def _cleanup_existing_repo_elements(
@@ -352,6 +372,16 @@ def _deploy_element(
     default=c.CONFIG_FILE,
     help="Name of the exordosctl configuration file",
 )
+@click.option(
+    "--port",
+    type=click.IntRange(1, 65535),
+    default=DEFAULT_PORT,
+    show_default=True,
+    help=(
+        "TCP port used by the in-process HTTP server in local mode. "
+        "If the port is already in use, the command aborts with an error."
+    ),
+)
 @click.pass_obj
 def deploy_cmd(
     obj: "ContextObject",
@@ -365,6 +395,7 @@ def deploy_cmd(
     element: str | None,
     exordosctl_cfg_file: str,
     realm: str | None,
+    port: int,
 ) -> None:
     inventory_elements = _load_build_inventory(element_dir)
     if realm:
@@ -404,8 +435,11 @@ def deploy_cmd(
     # host and the realm's Core VM.
     if not repository and _is_local_realm(obj.cfg, realm):
         bind_host = _get_local_host_bind(obj.cfg, realm)
+        _check_port_available(bind_host, port)
 
-        with local_server.serve_directory(element_dir, bind_host) as base_url:
+        with local_server.serve_directory(
+            element_dir, bind_host, port=port
+        ) as base_url:
             url = f"{base_url}{c.ELEMENT_REPO_PATH}/"
             driver_spec = {"kind": "nginx", "url": url}
             repository_spec = repo_utils.ensure_repository(

--- a/exordos/tests/unit/test_deploy_cli.py
+++ b/exordos/tests/unit/test_deploy_cli.py
@@ -416,7 +416,7 @@ class TestDeployCmdLocalMode:
 
         @contextlib.contextmanager
         def fake_serve_directory(path, host, port=0):
-            yield f"http://{host}:9999/"
+            yield f"http://{host}:{port}/"
 
         runner = CliRunner()
         with (
@@ -429,11 +429,12 @@ class TestDeployCmdLocalMode:
             patch.object(
                 deploy_commands, "_get_local_host_bind", return_value="192.168.1.5"
             ),
+            patch.object(deploy_commands, "_check_port_available") as port_check_mock,
             patch.object(
                 deploy_commands.local_server,
                 "serve_directory",
                 side_effect=fake_serve_directory,
-            ),
+            ) as serve_mock,
             patch.object(
                 deploy_commands.repo_utils,
                 "ensure_repository",
@@ -448,10 +449,113 @@ class TestDeployCmdLocalMode:
             )
 
         assert result.exit_code == 0, result.output
+        port_check_mock.assert_called_once_with(
+            "192.168.1.5", deploy_commands.DEFAULT_PORT
+        )
+        serve_mock.assert_called_once_with(
+            output_dir, "192.168.1.5", port=deploy_commands.DEFAULT_PORT
+        )
         find_repo_mock.assert_called_once()
         assert find_repo_mock.call_args[0][2] == {
             "kind": "nginx",
-            "url": "http://192.168.1.5:9999/exordos-elements/",
+            "url": f"http://192.168.1.5:{deploy_commands.DEFAULT_PORT}/exordos-elements/",
         }
         assert find_repo_mock.call_args[1]["sync_mode"] == "copy"
         deploy_elements_mock.assert_called_once()
+
+    def test_busy_port_aborts(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+        port = deploy_commands.DEFAULT_PORT
+
+        runner = CliRunner()
+        with (
+            patch.object(
+                deploy_commands.base_client,
+                "get_user_api_client",
+                return_value=MagicMock(),
+            ),
+            patch.object(deploy_commands, "_is_local_realm", return_value=True),
+            patch.object(
+                deploy_commands, "_get_local_host_bind", return_value="192.168.1.5"
+            ),
+            patch.object(
+                deploy_commands,
+                "_check_port_available",
+                side_effect=click.ClickException(
+                    f"Port {port} is already in use on 192.168.1.5 "
+                    "([Errno 98] Address already in use). "
+                    "Stop the process holding it or rerun `exordos deploy` "
+                    "with a different port via the `--port` option."
+                ),
+            ),
+            patch.object(deploy_commands.local_server, "serve_directory") as serve_mock,
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd,
+                ["-e", str(output_dir), "--port", str(port)],
+                obj=_obj(),
+            )
+
+        assert result.exit_code != 0
+        assert f"Port {port} is already in use" in result.output
+        serve_mock.assert_not_called()
+
+    def test_local_deploy_uses_custom_port(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+        custom_port = 8080
+
+        @contextlib.contextmanager
+        def fake_serve_directory(path, host, port=0):
+            yield f"http://{host}:{port}/"
+
+        runner = CliRunner()
+        with (
+            patch.object(
+                deploy_commands.base_client,
+                "get_user_api_client",
+                return_value=MagicMock(),
+            ),
+            patch.object(deploy_commands, "_is_local_realm", return_value=True),
+            patch.object(
+                deploy_commands, "_get_local_host_bind", return_value="192.168.1.5"
+            ),
+            patch.object(deploy_commands, "_check_port_available") as port_check_mock,
+            patch.object(
+                deploy_commands.local_server,
+                "serve_directory",
+                side_effect=fake_serve_directory,
+            ) as serve_mock,
+            patch.object(
+                deploy_commands.repo_utils,
+                "ensure_repository",
+                return_value={"uuid": "repo-uuid"},
+            ) as find_repo_mock,
+            patch.object(deploy_commands, "_deploy_element"),
+        ):
+            result = runner.invoke(
+                deploy_commands.deploy_cmd,
+                ["-e", str(output_dir), "--port", str(custom_port)],
+                obj=_obj(),
+            )
+
+        assert result.exit_code == 0, result.output
+        port_check_mock.assert_called_once_with("192.168.1.5", custom_port)
+        serve_mock.assert_called_once_with(output_dir, "192.168.1.5", port=custom_port)
+        find_repo_mock.assert_called_once()
+        assert find_repo_mock.call_args[0][2] == {
+            "kind": "nginx",
+            "url": f"http://192.168.1.5:{custom_port}/exordos-elements/",
+        }
+
+    def test_invalid_port_rejected(self, tmp_path: pathlib.Path) -> None:
+        output_dir = _make_build_output(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy_commands.deploy_cmd,
+            ["-e", str(output_dir), "--port", "70000"],
+            obj=_obj(),
+        )
+
+        assert result.exit_code != 0
+        assert "70000" in result.output


### PR DESCRIPTION
- Add `--port` option (default 33101) to `exordos deploy`
- Fail fast with an actionable error if the port is already in use
- Wire the port through to `local_server.serve_directory`
- Add unit tests for default port wiring and busy-port abort

## Summary by Sourcery

Add a configurable fixed TCP port for the local deploy HTTP server and ensure the command aborts with a clear error when the port is already in use.

New Features:
- Introduce a --port option to exordos deploy with a default fixed port for the local HTTP server.

Bug Fixes:
- Prevent local-mode deployments from starting when the chosen HTTP server port is already in use, with an actionable error message.

Enhancements:
- Wire the chosen port through to the local HTTP server and repository URL construction for local deployments.

Tests:
- Add unit tests covering default port wiring into the local server and URL, and abort behavior when the selected port is busy.