### PR TITLE
add core version to bootstrap summary

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -55,6 +55,7 @@ from exordos.stand import models as stand_models
 
 def _print_bootstrap_summary(
     installation_name: str,
+    core_version: str,
     admin_password: str,
     core_ip: ipaddress.IPv4Address | None,
     ssh_public_key_path: str,
@@ -67,6 +68,7 @@ def _print_bootstrap_summary(
     table.add_column()
 
     table.add_row("Realm", installation_name)
+    table.add_row("Version", core_version)
     table.add_row("Username", "admin")
     table.add_row("Password", admin_password)
 
@@ -1201,6 +1203,7 @@ def bootstrap_cmd(
 
     _print_bootstrap_summary(
         installation_name=name,
+        core_version=inventory_instance.version,
         admin_password=admin_password,
         core_ip=core_ip_result,
         ssh_public_key_path=ssh_public_key_path,

--- a/exordos/tests/unit/test_cmd_stand.py
+++ b/exordos/tests/unit/test_cmd_stand.py
@@ -19,6 +19,8 @@ import pathlib
 import stat
 from unittest import mock
 
+import rich.console
+
 from exordos.cmd.stand import commands
 
 
@@ -36,3 +38,18 @@ def test_save_admin_password_file_uses_owner_only_permissions(
 
     assert password_path.read_text(encoding="utf-8") == "test-password"
     assert stat.S_IMODE(password_path.stat().st_mode) == 0o600
+
+
+def test_print_bootstrap_summary_includes_core_version_in_realm() -> None:
+    console = rich.console.Console(record=True)
+    with mock.patch("rich.console.Console", return_value=console):
+        commands._print_bootstrap_summary(
+            installation_name="test-realm",
+            core_version="1.2.3",
+            admin_password="test-password",
+            core_ip=None,
+            ssh_public_key_path="~/.ssh/test.pub",
+            ssh_private_key_path=None,
+        )
+
+    assert "1.2.3" in console.export_text()


### PR DESCRIPTION
## Summary by Sourcery

Include the core version in the bootstrap summary output for stand installations.

New Features:
- Display the core version alongside the realm name in the bootstrap summary for stand installations.

Tests:
- Add a unit test ensuring the bootstrap summary includes the core version in the realm line.