### PR TITLE
update default eco_endpoint

### DIFF
--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -870,7 +870,7 @@ def _update_realm_config(
 )
 @click.option(
     "--ecosystem-endpoint",
-    default="https://console.genesis-core.tech",
+    default=c.ECOSYSTEM_ENDPOINT,
     type=str,
     envvar="ECOSYSTEM_ENDPOINT",
     help="Ecosystem's endpoint to connect to",

--- a/exordos/constants.py
+++ b/exordos/constants.py
@@ -21,6 +21,7 @@ import typing as tp
 PKG_NAME = "exordos"
 GITHUB_RELEASES_URL = f"https://api.github.com/repos/infraguys/{PKG_NAME}/releases"
 EXORDOS_REPO_URL = "https://repo.exordos.com"
+ECOSYSTEM_ENDPOINT = "https://exordos.com"
 ELEMENT_REPO_PATH = "exordos-elements"
 ELEMENT_REPO_URL = f"{EXORDOS_REPO_URL}/{ELEMENT_REPO_PATH}"
 LIBVIRT_DEF_POOL_PATH = "/var/lib/libvirt/images"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce an ECOSYSTEM_ENDPOINT constant in the shared configuration module and use it as the default for the CLI ecosystem-endpoint option.