### PR TITLE
add published in push element

### DIFF
--- a/exordos/repo/fs.py
+++ b/exordos/repo/fs.py
@@ -26,6 +26,7 @@ from exordos import constants as c
 from exordos import logger as logger_base
 from exordos.builder import base as builder_base
 from exordos.repo import base
+from exordos.repo.utils import get_published
 
 
 class FSRepoDriver(base.AbstractRepoDriver):
@@ -122,6 +123,8 @@ class FSRepoDriver(base.AbstractRepoDriver):
             spec[category] = [
                 os.path.basename(artifact) for artifact in getattr(element, category)
             ]
+
+        spec["published"] = get_published()
 
         with open(self.elements_inventory_path(element), "w") as f:
             json.dump(spec, f, indent=2)

--- a/exordos/repo/nginx.py
+++ b/exordos/repo/nginx.py
@@ -27,6 +27,7 @@ from exordos import constants as c
 from exordos import logger as logger_base
 from exordos.builder import base as builder_base
 from exordos.repo import base
+from exordos.repo.utils import get_published
 
 
 class NginxRepoDriver(base.AbstractRepoDriver):
@@ -214,6 +215,8 @@ class NginxRepoDriver(base.AbstractRepoDriver):
             spec[category] = [
                 os.path.basename(artifact) for artifact in getattr(element, category)
             ]
+
+        spec["published"] = get_published()
 
         # Upload the inventory file
         response = self._session.put(

--- a/exordos/repo/utils.py
+++ b/exordos/repo/utils.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import pathlib
@@ -36,6 +37,13 @@ from exordos.repo import fs as repo_fs
 
 POLL_INTERVAL = 2.0
 STABLE_CHECKS = 10
+
+
+def get_published() -> str:
+    """Return the current UTC timestamp in ISO format with trailing Z."""
+    return datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    )
 
 
 def load_repo_driver_from_settings(


### PR DESCRIPTION
## Summary by Sourcery

Add publication timestamps to element inventories when pushing artifacts.

New Features:
- Record the UTC publication timestamp in pushed element inventories.

Enhancements:
- Centralize generation of ISO-formatted UTC publication timestamps for repository drivers.