### PR TITLE
Keyboard interrupt, resource info cmd

### DIFF
--- a/exordos/cmd/cli.py
+++ b/exordos/cmd/cli.py
@@ -378,6 +378,8 @@ if __name__ == "__main__":
             error_message = f"Error: {e}"
     except (ValueError, FileNotFoundError, exordos_exc.ExordosException) as e:
         error_message = f"Error: {e}"
+    except KeyboardInterrupt:
+        error_message = "Error: Interrupted by user"
     finally:
         if error_message:
             click.secho(error_message, fg="red")

--- a/exordos/cmd/em/resources/commands.py
+++ b/exordos/cmd/em/resources/commands.py
@@ -15,8 +15,12 @@
 #    under the License.
 from __future__ import annotations
 
+import rich_click as click
+
 from exordos import constants as c
+from exordos.clients import base_client
 from exordos.cmd.base import create_entity_group
+from exordos.common.table import show_data
 
 ENTITY = "resource"
 ENTITY_COLLECTION = c.RESOURCE_COLLECTION
@@ -38,3 +42,54 @@ resources_group = create_entity_group(
     FIELDS_MAP,
     add_delete_command=False,
 )
+
+
+@resources_group.command(
+    "info", help="Show resource and its target and actual resource"
+)
+@click.argument(
+    "uuid",
+    type=str,
+    required=True,
+)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+@click.pass_context
+def info_cmd(
+    ctx: click.Context,
+    uuid: str,
+    output: str,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    resource = base_client.get_entity(client, ENTITY_COLLECTION, uuid)
+    show_data(resource, output, "Resource")
+
+    # Find target_resource
+    targets = base_client.list_entities(client, c.TARGET_RESOURCE_COLLECTION, uuid=uuid)
+    target_resource = None
+    if targets:
+        target_resource = targets[0]
+        for target in targets:
+            show_data(target, output, "Target resource")
+
+    # Find actual_resource
+    actuals = base_client.list_entities(client, c.ACTUAL_RESOURCE_COLLECTION, uuid=uuid)
+    actual_resource = None
+    if actuals:
+        actual_resource = actuals[0]
+        for actual in actuals:
+            show_data(actual, output, "Actual resource")
+
+    if (
+        target_resource
+        and actual_resource
+        and target_resource["hash"] != actual_resource["hash"]
+    ):
+        click.secho(
+            "Target resource and actual resource hashes are different", fg="red"
+        )

--- a/exordos/common/table.py
+++ b/exordos/common/table.py
@@ -108,8 +108,8 @@ def print_table(
         rprint(table)
 
 
-def show_data(data: dict, output: str = "table") -> None:
+def show_data(data: dict, output: str = "table", msg: tp.Optional[str] = None) -> None:
     table = get_table(*SHOW_FIELDS)
     for key, value in data.items():
         table.add_row(key, str(value))
-    print_table(table, output)
+    print_table(table, output, msg)


### PR DESCRIPTION
## Summary by Sourcery

Improve resource inspection and handle keyboard interruptions gracefully.

New Features:
- Add a resource info command that displays a resource alongside its target and actual resource records.
- Highlight when target and actual resource hashes differ.

Bug Fixes:
- Report user-triggered keyboard interrupts as a clear CLI error instead of leaving them unhandled.

Enhancements:
- Allow contextual messages when rendering structured data output.