### PR TITLE
refactor(cli): defer heavy imports to speed up CLI startup

### DIFF
--- a/exordos/builder/builder.py
+++ b/exordos/builder/builder.py
@@ -28,7 +28,6 @@ import tempfile
 import typing as tp
 import uuid as sys_uuid
 
-import jinja2
 import rich_click as click
 import yaml
 
@@ -353,6 +352,8 @@ class SimpleBuilder:
         if str(element.manifest).endswith(jinja2_extensions):
             # Render Jinja2 manifest
             with open(orig_manifest_path) as f:
+                import jinja2
+
                 template = jinja2.Template(f.read())
             rendered_manifest = template.render(
                 manifests=[element.manifest.name],

--- a/exordos/builder/dependency.py
+++ b/exordos/builder/dependency.py
@@ -21,9 +21,6 @@ import pathlib
 import shutil
 import typing as tp
 
-import bazooka
-import git
-
 from exordos.builder import base
 
 
@@ -197,6 +194,8 @@ class HttpDependency(base.AbstractDependency):
         filename = os.path.basename(self._endpoint)
         output_path = os.path.join(output_dir, filename)
 
+        import bazooka
+
         with bazooka.get(self._endpoint, stream=True) as r:
             r.raise_for_status()
             with open(output_path, "wb") as f:
@@ -248,6 +247,8 @@ class GitDependency(base.AbstractDependency):
         if repo_dir.endswith(".git"):
             repo_dir = repo_dir[:-4]
         repo_dir = os.path.join(output_dir, repo_dir)
+
+        import git
 
         if self._branch is not None:
             git.Repo.clone_from(self._repo_url, repo_dir, branch=self._branch)

--- a/exordos/cmd/base.py
+++ b/exordos/cmd/base.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 from collections.abc import Callable
 import time
 
-import questionary
-from rich.live import Live
 import rich_click as click
 
 from exordos import constants as c
@@ -142,6 +140,8 @@ def create_entity_group(
             url = entity_collection.format(**kwargs)
             url = base_client.add_fields_to_url(url, fields)
             if watch:
+                from rich.live import Live
+
                 with Live(refresh_per_second=4) as live:
                     while True:
                         entities = base_client.list_entities(
@@ -226,6 +226,8 @@ def create_entity_group(
             y: bool,
             **kwargs,
         ) -> None:
+            import questionary
+
             client = base_client.get_user_api_client(ctx.obj.auth_data)
             for entity_uuid in uuid:
                 if (
@@ -248,6 +250,8 @@ def create_entity_group(
         @add_dynamic_parents(parents)
         @click.pass_context
         def clear_cmd(ctx: click.Context, y: bool, **kwargs) -> None:
+            import questionary
+
             client = base_client.get_user_api_client(ctx.obj.auth_data)
             entities = base_client.list_entities(
                 client, entity_collection.format(**kwargs)

--- a/exordos/cmd/deploy/commands.py
+++ b/exordos/cmd/deploy/commands.py
@@ -23,7 +23,6 @@ import socket
 import typing as tp
 import uuid as sys_uuid
 
-import questionary
 import rich_click as click
 
 from exordos import constants as c
@@ -397,6 +396,8 @@ def deploy_cmd(
     realm: str | None,
     port: int,
 ) -> None:
+    import questionary
+
     inventory_elements = _load_build_inventory(element_dir)
     if realm:
         if realm not in (obj.cfg.get("realms") or {}):

--- a/exordos/cmd/em/elements/commands.py
+++ b/exordos/cmd/em/elements/commands.py
@@ -24,7 +24,6 @@ import typing as tp
 import uuid as sys_uuid
 
 from packaging import version as packaging_version
-import questionary
 from rich.prompt import Confirm
 from rich.text import Text
 import rich_click as click
@@ -313,6 +312,8 @@ def install_cmd(
     uuid_or_name_or_path: str | None,
 ) -> None:
     """Install element from repository API by UUID, name, or manifest path"""
+    import questionary
+
     if not uuid_or_name_or_path:
         all_elements = base_client.list_entities(
             base_client.get_user_api_client(ctx.obj.auth_data),
@@ -414,6 +415,8 @@ def update_cmd(
     uuid_or_name_or_path: str | None,
 ) -> None:
     """Update element from repository API by UUID, name, or manifest path"""
+    import questionary
+
     if not uuid_or_name_or_path:
         all_elements = base_client.list_entities(
             base_client.get_user_api_client(ctx.obj.auth_data),
@@ -525,6 +528,8 @@ def update_cmd(
 @click.pass_context
 def uninstall_cmd(ctx: click.Context, uuid_or_name: str, y: bool) -> None:
     """Uninstall element by UUID or name"""
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
 
     if not (y or questionary.confirm(f"Delete {ENTITY} {uuid_or_name}?").ask()):
@@ -642,6 +647,8 @@ def define(
     resource_name: str,
 ) -> None:
     # Get Openapi schema
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
     schema = client.filter(f"{c.MANIFEST_COLLECTION}schema/")
 
@@ -832,6 +839,8 @@ def ssh_cmd(
     y: bool,
     name: str,
 ) -> None:
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
 
     element_data = base_client.get_entity(client, c.ELEMENT_COLLECTION, name)

--- a/exordos/cmd/iam/user/commands.py
+++ b/exordos/cmd/iam/user/commands.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import uuid as sys_uuid
 
-import questionary
 import rich_click as click
 
 from exordos import constants as c
@@ -139,6 +138,8 @@ def add_cmd(
     otp_secret: str | None,
     otp_enabled: bool,
 ) -> None:
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
     if uuid is None:
         uuid = sys_uuid.uuid4()
@@ -202,6 +203,8 @@ def reset_password_cmd(
     code: str | None,
     new_password: str | None,
 ) -> None:
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
 
     new_password = (
@@ -250,6 +253,8 @@ def change_password_cmd(
     old_password: str,
     new_password: str | None,
 ) -> None:
+    import questionary
+
     client = base_client.get_user_api_client(ctx.obj.auth_data)
 
     data = {

--- a/exordos/cmd/realms/commands.py
+++ b/exordos/cmd/realms/commands.py
@@ -23,7 +23,6 @@ import subprocess
 from urllib.parse import urljoin
 import uuid as sys_uuid
 
-import questionary
 import requests
 import rich_click as click
 
@@ -287,6 +286,8 @@ def add_cmd(
     core_version: str | None,
     ssh_public_key: str | None,
 ) -> None:
+    import questionary
+
     ecosystem_client = get_ecosystem_client(ctx)
     if uuid is None:
         uuid = sys_uuid.uuid4()

--- a/exordos/cmd/stand/utils_commands.py
+++ b/exordos/cmd/stand/utils_commands.py
@@ -20,7 +20,6 @@ import uuid as sys_uuid
 
 import requests
 from rich.console import Console
-from rich.markdown import Markdown
 from rich.prompt import Confirm
 from rich.text import Text
 import rich_click as click
@@ -330,6 +329,8 @@ Use `exordos --help` to see all available commands.
 @click.command("introduction", help="Display introduction guide")
 def introduction() -> None:
     console = Console()
+    from rich.markdown import Markdown
+
     md = Markdown(INTRODUCTION_TEXT)
     console.print(md)
 

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -21,8 +21,6 @@ import os
 import secrets
 import tempfile
 
-from cryptography.hazmat.primitives.ciphers import aead
-
 from exordos.common.run import run_command
 
 KEY_SIZE = 32
@@ -63,6 +61,8 @@ def encrypt_chacha20_poly1305(
 ) -> bytes:
     _validate_key_and_nonce(key, nonce)
 
+    from cryptography.hazmat.primitives.ciphers import aead
+
     cipher = aead.ChaCha20Poly1305(key)
     return cipher.encrypt(nonce, plaintext, associated_data)
 
@@ -74,6 +74,8 @@ def decrypt_chacha20_poly1305(
     associated_data: bytes | None = None,
 ) -> bytes:
     _validate_key_and_nonce(key, nonce)
+
+    from cryptography.hazmat.primitives.ciphers import aead
 
     cipher = aead.ChaCha20Poly1305(key)
     return cipher.decrypt(nonce, ciphertext, associated_data)

--- a/exordos/common/ssh.py
+++ b/exordos/common/ssh.py
@@ -21,9 +21,6 @@ import tempfile
 import time
 import typing as tp
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 import rich_click as click
 
 from exordos.clients import base_client
@@ -78,6 +75,10 @@ def generate_keys(
     keys_exist = os.path.exists(private_key_path) and os.path.exists(public_key_path)
 
     if not keys_exist:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
         # Generate new keys
         private_key = rsa.generate_private_key(
             public_exponent=65537, key_size=2048, backend=default_backend()

--- a/exordos/common/table.py
+++ b/exordos/common/table.py
@@ -22,7 +22,6 @@ from rich import print_json as rprint_json
 from rich.console import Console
 from rich.table import Table
 import rich_click as click
-import ruamel.yaml
 
 SHOW_FIELDS = [
     "Field",
@@ -31,6 +30,8 @@ SHOW_FIELDS = [
 
 
 def dump_yaml_ruamel_to_str(data: tp.Union[dict, list]) -> str:
+    import ruamel.yaml
+
     loader = ruamel.yaml.YAML()
     loader.indent(sequence=4, offset=2)
     string_stream = StringIO()

--- a/exordos/common/version.py
+++ b/exordos/common/version.py
@@ -18,7 +18,6 @@ import os
 import re
 import time
 
-import git
 from packaging import version as packaging_version
 
 import exordos.constants as c
@@ -43,6 +42,8 @@ def get_project_version(
         raise ValueError(f"Path {path} is not a directory")
 
     # Open the git repo
+    import git
+
     repo = git.Repo(path)
 
     # If a tag is set, return the highest semver tag on this commit

--- a/exordos/repo/utils.py
+++ b/exordos/repo/utils.py
@@ -24,7 +24,6 @@ import time
 import typing as tp
 import uuid as sys_uuid
 
-import rich.status as rich_status
 import rich_click as click
 import yaml
 
@@ -144,6 +143,8 @@ def do_push(
     Shared by `push_cmd` and `deploy_cmd` so both go through the exact same
     push logic.
     """
+    import rich.status as rich_status
+
     # Every build creates a local repo with built elements into it.
     build_repo = repo_fs.FSRepoDriver(element_dir)
     build_repo_dir = pathlib.Path(build_repo.elements_path)

--- a/exordos/utils.py
+++ b/exordos/utils.py
@@ -29,28 +29,49 @@ import typing as tp
 import urllib.parse
 import uuid
 
-from cryptography.hazmat import backends as crypto_back
-from cryptography.hazmat.primitives import ciphers
-from cryptography.hazmat.primitives.ciphers import algorithms
-from cryptography.hazmat.primitives.ciphers import modes as cipher_models
-import git
 import rich_click as click
-import ruamel.yaml
 
 from exordos.common.version import get_project_version
 import exordos.constants as c
 
-yaml = ruamel.yaml.YAML()
+if tp.TYPE_CHECKING:
+    import git
+
+_yaml = None
+
+
+def _get_yaml():
+    """Return the shared ruamel YAML instance, importing it on first use."""
+    global _yaml
+    if _yaml is None:
+        import ruamel.yaml
+
+        _yaml = ruamel.yaml.YAML()
+    return _yaml
+
+
+def _aes_cfb_cipher(key: bytes, iv: bytes):
+    """Build an AES-CFB cipher, importing cryptography on first use."""
+    from cryptography.hazmat import backends as crypto_back
+    from cryptography.hazmat.primitives import ciphers
+    from cryptography.hazmat.primitives.ciphers import algorithms
+    from cryptography.hazmat.primitives.ciphers import modes as cipher_models
+
+    return ciphers.Cipher(
+        algorithms.AES(key),
+        cipher_models.CFB(iv),
+        backend=crypto_back.default_backend(),
+    )
 
 
 def load_yaml(file_path: str) -> tp.Any:
     """Load YAML file."""
     with open(file_path, "r") as f:
-        return yaml.load(f)
+        return _get_yaml().load(f)
 
 
 def dump_yaml(data, tf) -> tp.Any:
-    yaml.dump(data, tf)
+    _get_yaml().dump(data, tf)
 
 
 def load_from_entry_point(group: str, name: str) -> tp.Any:
@@ -137,7 +158,9 @@ def installation_name_from_bootstrap(bootstrap_name: str) -> str:
     return bootstrap_name.replace("-bootstrap", "")
 
 
-def get_repo(path: str) -> git.Repo:
+def get_repo(path: str) -> "git.Repo":
+    import git
+
     repo = git.Repo(path)
     return repo
 
@@ -239,11 +262,7 @@ def encrypt_file(
         raise ValueError("Key and IV must be 16 bytes long")
 
     # Create a cipher object
-    cipher = ciphers.Cipher(
-        algorithms.AES(key),
-        cipher_models.CFB(iv),
-        backend=crypto_back.default_backend(),
-    )
+    cipher = _aes_cfb_cipher(key, iv)
     chunk_size = chunk_size_kb << 10
     encrypted_path = path + extension
 
@@ -279,11 +298,7 @@ def decrypt_file(
         raise ValueError("Key and IV must be 16 bytes long")
 
     # Create a cipher object
-    cipher = ciphers.Cipher(
-        algorithms.AES(key),
-        cipher_models.CFB(iv),
-        backend=crypto_back.default_backend(),
-    )
+    cipher = _aes_cfb_cipher(key, iv)
     chunk_size = chunk_size_kb << 10
     plain_path = path[: -len(extension)] if path.endswith(extension) else path
     tmp_path = plain_path + ".tmp"
@@ -326,11 +341,7 @@ class ReaderEncryptorIO(io.BytesIO):
             raise ValueError("Key and IV must be 16 bytes long")
 
         self._file = file
-        self._cipher = ciphers.Cipher(
-            algorithms.AES(key),
-            cipher_models.CFB(iv),
-            backend=crypto_back.default_backend(),
-        )
+        self._cipher = _aes_cfb_cipher(key, iv)
 
         self._encryptor = self._cipher.encryptor()
         self._finalized = False

--- a/exordos/wizards/engines/templaters/templaters.py
+++ b/exordos/wizards/engines/templaters/templaters.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 import os
 import pathlib
 
-import jinja2
-
 from exordos.wizards import constants as c
 from exordos.wizards.engines import base
 from exordos.wizards.engines.templaters import settings
@@ -69,6 +67,8 @@ class JinjaTemplateEngine(base.AbstractEngine):
         template_files: list[str],
         all_settings: dict,
     ) -> list[str]:
+        import jinja2
+
         target_files = [
             jinja2.Template(template_file).render(**all_settings)
             for template_file in template_files

--- a/exordos/wizards/wizards/terminal.py
+++ b/exordos/wizards/wizards/terminal.py
@@ -19,7 +19,6 @@ import readline
 import sys
 
 from rich import console as rich_console
-from rich import markdown as rich_markdown
 from rich import panel as rich_panel
 from rich import text as rich_text
 import rich.align
@@ -51,6 +50,8 @@ def markdown_message(
     length_ratio: float = 0.5,
 ) -> None:
     """Render Markdown text for wizard intro/outro style messages."""
+    from rich import markdown as rich_markdown
+
     markdown = rich_markdown.Markdown(text, style=text_color)
     console = get_console()
     content_width = max(20, int(console.size.width * length_ratio))
@@ -159,6 +160,8 @@ def framed_prompt(
         # Render Markdown with a constrained width so that the right border is
         # always preserved. Then wrap each rendered line with frame borders.
         content_width = max(0, width - 6)
+        from rich import markdown as rich_markdown
+
         md = rich_markdown.Markdown(description)
         options = console.options.update(width=content_width)
         rendered = console.render_lines(md, options)


### PR DESCRIPTION
Profiling with -X importtime showed that most of the startup time was spent importing libraries needed only by individual commands. All of them were used inside functions only, so the imports moved to the call sites:

- prompt_toolkit (via questionary): cmd/base, deploy, realms, em/elements, iam/user
- cryptography: utils, common/ssh, common/crypto
- GitPython: utils, common/version, builder/dependency
- markdown_it and pygments (via rich.markdown): wizards/terminal, cmd/stand/utils_commands
- ruamel.yaml: utils, common/table
- jinja2: builder/builder, wizards/engines/templaters
- rich.console (via rich.status) and rich.live: repo/utils, cmd/base

Two spots needed a bit more than moving a line to avoid duplicating the imports: the three identical AES-CFB cipher blocks in utils are folded into _aes_cfb_cipher(), and the module level ruamel YAML singleton became a lazy _get_yaml().

Startup on python3.12:

- import exordos.cmd.cli: 570 ms -> 340 ms
- exordos --help: 0.57 s -> 0.34 s
- --onefile binary: 1.17 s -> 0.87 s

## Summary by Sourcery

Reduce CLI startup time by lazily loading heavy dependencies and consolidating repeated cryptographic and YAML initialization.

Enhancements:
- Defer imports for command-specific and optional dependencies until they are needed, reducing CLI startup overhead.
- Centralize AES-CFB cipher creation and lazily initialize the shared YAML serializer while preserving existing behavior.