### PR TITLE
feat(cli): add profiles info command

### DIFF
--- a/exordos/cmd/vs/__init__.py
+++ b/exordos/cmd/vs/__init__.py
@@ -23,6 +23,6 @@ def vs_group():
     pass
 
 
-vs_group.add_command(profiles_commands.profiles_group)
+vs_group.add_command(profiles_commands.profiles_group, aliases=["p", "pr"])
 vs_group.add_command(values_commands.values_group)
 vs_group.add_command(vars_commands.vv_group, aliases=["v", "variables", "vars"])

--- a/exordos/cmd/vs/profiles/commands.py
+++ b/exordos/cmd/vs/profiles/commands.py
@@ -20,9 +20,10 @@ import uuid as sys_uuid
 import rich_click as click
 
 from exordos import constants as c
-from exordos import utils
 from exordos.clients import base_client
 from exordos.cmd.base import create_entity_group
+from exordos.common.table import fill_table
+from exordos.common.table import print_table
 from exordos.common.table import show_data
 
 ENTITY = "profile"
@@ -35,9 +36,65 @@ FIELDS_MAP = {
     "Active": "active",
     "Status": "status",
 }
+VARIABLE_FIELDS_MAP = {
+    "UUID": "uuid",
+    "Name": "name",
+    "Value": "value",
+    "Status": "status",
+}
 
 
 profiles_group = create_entity_group(ENTITY, ENTITY_COLLECTION, FIELDS_MAP)
+
+
+@profiles_group.command(
+    "info", help="Show profile and variables which take their value from it"
+)
+@click.argument(
+    "uuid",
+    type=str,
+    required=True,
+)
+@click.option(
+    "--output",
+    "-o",
+    default=c.DEFAULT_TABLE_FORMAT,
+    type=click.Choice(c.TABLE_FORMATS, case_sensitive=False),
+    help="the output format, defaults to table",
+)
+@click.pass_context
+def info_cmd(
+    ctx: click.Context,
+    uuid: str,
+    output: str,
+) -> None:
+    client = base_client.get_user_api_client(ctx.obj.auth_data)
+    profile = base_client.get_entity(client, ENTITY_COLLECTION, uuid)
+    show_data(profile, output, "Profile")
+
+    # Find variables with the profile setter bound to this profile
+    variables = []
+    for variable in base_client.list_entities(client, c.VARIABLE_COLLECTION):
+        setter = variable.get("setter") or {}
+        if setter.get("kind") != "profile":
+            continue
+        for item in setter.get("profiles", []):
+            if str(item["profile"]) == str(profile["uuid"]):
+                variables.append(
+                    {
+                        "uuid": variable["uuid"],
+                        "name": variable["name"],
+                        "value": item["value"],
+                        "status": variable.get("status", ""),
+                    }
+                )
+                break
+
+    print_table(
+        fill_table(variables, VARIABLE_FIELDS_MAP),
+        output,
+        "Variables in this profile",
+    )
 
 
 @profiles_group.command("activate", help="Activate profile")
@@ -51,13 +108,10 @@ def activate_profile_cmd(
     uuid: sys_uuid.UUID | None,
 ) -> None:
     client = base_client.get_user_api_client(ctx.obj.auth_data)
-    if not utils.is_valid_uuid(uuid):
-        entities = base_client.list_entities(client, ENTITY_COLLECTION, name=uuid)
-        if entities:
-            uuid = entities[0]["uuid"]
-        else:
-            raise click.ClickException(f"Profile with name {uuid} not found")
+    data = base_client.get_entity(client, ENTITY_COLLECTION, uuid)
+    uuid = data["uuid"]
     base_client.action_entity(client, ENTITY_COLLECTION, "activate", uuid)
+    click.echo(f"Profile with name {data['name']} was activated")
 
 
 @click.command("add", help="Add a new profile to the Exordos installation")


### PR DESCRIPTION
- Show profile data and variables bound to it via the profile setter
- Print the value each variable takes in this profile

## Summary by Sourcery

Add profile inspection capabilities and streamline profile command usage in the CLI.

New Features:
- Add a profile info command that displays profile details and the variables bound to it with their profile-specific values.

Enhancements:
- Improve profile activation by consistently resolving the selected profile and confirming successful activation.

Chores:
- Add short aliases for the profiles command group.