### PR TITLE
feat(elements): select current element by installation_state

### DIFF
--- a/exordos/cmd/em/elements/commands.py
+++ b/exordos/cmd/em/elements/commands.py
@@ -243,7 +243,19 @@ def _select_element_by_name(
 def _select_current_element_by_name(
     client: "CollectionBaseClient", name: str
 ) -> dict[str, tp.Any]:
-    """Select current installed element by name (ACTIVE or IN_PROGRESS status).
+    """Select current installed element by name.
+
+    The canonical signal that an element is the "current" one is
+    ``installation_state == "INSTALLED"``. This is what the server uses to
+    decide whether ``uninstall``/``upgrade`` are allowed, so selecting by it
+    keeps the CLI in sync with the server even during an in-flight update,
+    where the freshly-installed element is ``INSTALLED`` but its ``status`` is
+    still ``NEW``/``IN_PROGRESS`` and the stale element being replaced is
+    ``UNINSTALLED`` but still ``ACTIVE``.
+
+    Falls back to ``status in (ACTIVE, IN_PROGRESS)`` when no element reports
+    ``installation_state`` (e.g. an older server that does not expose the
+    field), preserving the previous behavior.
 
     Args:
         client: API client for making requests.
@@ -253,17 +265,26 @@ def _select_current_element_by_name(
         Dictionary representing the current element.
 
     Raises:
-        click.ClickException: If no active or in-progress elements found.
+        click.ClickException: If no installed element is found, or if several
+            elements are installed at once (ambiguous, user must give a UUID).
     """
     elements = base_client.list_entities(
         client, c.REPOSITORY_ELEMENT_COLLECTION, name=name
     )
 
+    installed = [e for e in elements if e.get("installation_state") == "INSTALLED"]
+    if len(installed) > 1:
+        raise click.ClickException(
+            f"Multiple installed elements found with name '{name}'. "
+            "Please specify the UUID of the element to update."
+        )
+    if installed:
+        return installed[0]
+
+    # Fallback for servers that do not expose installation_state: pick by
+    # status, matching the historical behavior.
     active_elements = [
-        e
-        for e in elements
-        if e.get("status") in ("ACTIVE", "IN_PROGRESS")
-        or e.get("installation_state") == "INSTALLED"
+        e for e in elements if e.get("status") in ("ACTIVE", "IN_PROGRESS")
     ]
 
     if not active_elements:

--- a/exordos/tests/unit/test_repo_cli.py
+++ b/exordos/tests/unit/test_repo_cli.py
@@ -346,3 +346,74 @@ class TestSelectCurrentElementByName:
         )
         with pytest.raises(click.ClickException, match="Multiple installed"):
             em_elements._select_current_element_by_name(client, "foo")
+
+    def test_prefers_installed_over_active_status(self) -> None:
+        # Reproduces #589 Window 1: right after `ee update`, the freshly
+        # installed element is INSTALLED but status=NEW, while the stale
+        # element being replaced is UNINSTALLED but still status=ACTIVE.
+        client = self._client(
+            [
+                {
+                    "name": "foo",
+                    "version": "0.0.12",
+                    "uuid": "u_old",
+                    "status": "ACTIVE",
+                    "installation_state": "UNINSTALLED",
+                },
+                {
+                    "name": "foo",
+                    "version": "0.0.11",
+                    "uuid": "u_new",
+                    "status": "NEW",
+                    "installation_state": "INSTALLED",
+                },
+            ]
+        )
+        selected = em_elements._select_current_element_by_name(client, "foo")
+        assert selected["uuid"] == "u_new"
+
+    def test_prefers_installed_in_progress_over_active(self) -> None:
+        # Reproduces #589 Window 2: new element is now IN_PROGRESS, old one
+        # is still ACTIVE but UNINSTALLED.
+        client = self._client(
+            [
+                {
+                    "name": "foo",
+                    "version": "0.0.12",
+                    "uuid": "u_old",
+                    "status": "ACTIVE",
+                    "installation_state": "UNINSTALLED",
+                },
+                {
+                    "name": "foo",
+                    "version": "0.0.11",
+                    "uuid": "u_new",
+                    "status": "IN_PROGRESS",
+                    "installation_state": "INSTALLED",
+                },
+            ]
+        )
+        selected = em_elements._select_current_element_by_name(client, "foo")
+        assert selected["uuid"] == "u_new"
+
+    def test_multiple_installed_by_state_raises(self) -> None:
+        client = self._client(
+            [
+                {
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "uuid": "u1",
+                    "status": "ACTIVE",
+                    "installation_state": "INSTALLED",
+                },
+                {
+                    "name": "foo",
+                    "version": "2.0.0",
+                    "uuid": "u2",
+                    "status": "ACTIVE",
+                    "installation_state": "INSTALLED",
+                },
+            ]
+        )
+        with pytest.raises(click.ClickException, match="Multiple installed"):
+            em_elements._select_current_element_by_name(client, "foo")


### PR DESCRIPTION
- Prioritize elements with installation_state=="INSTALLED" over status-based selection
- Fixes #590(exordos_core) where freshly installed elements during updates were incorrectly ignored
- Maintains backward compatibility with servers that don't expose installation_state
- Add tests for the new selection logic and edge cases

The canonical signal for a "current" element is now installation_state, matching server-side logic for uninstall/upgrade permissions.

## Summary by Sourcery

Align current-element selection with installation state while preserving compatibility with older servers.

Bug Fixes:
- Select the current element using the server-authoritative INSTALLED installation state, preventing stale ACTIVE elements from being chosen during updates.

Enhancements:
- Retain status-based selection for servers that do not expose installation_state and report ambiguous multiple-installed elements clearly.

Tests:
- Add coverage for update-in-progress selection and multiple elements marked INSTALLED.