### PR TITLE
add: pool agent placement

### DIFF
--- a/docs/cli/exordos_bootstrap.md
+++ b/docs/cli/exordos_bootstrap.md
@@ -137,12 +137,19 @@ Bootstrap exordos locally
 
   If the option is specified the admin password is saved to the file. Otherwise it's printed to the console.
 
+* `pool_agent_placement`:
+    * Type: choice
+    * Default: `core`
+    * Usage: `--pool-agent-placement`
+
+  Where the pool agent that drives the hypervisor's libvirt runs. 'core' runs it inside core's own services, reaching libvirt over the network (see --hyper-connection-uri). 'local' installs a dedicated universal agent on this host that talks to the local libvirt socket directly (matching `exordos compute hypervisors init`); --hyper-connection-uri is not supported in this mode.
+
 * `hyper_connection_uri`:
     * Type: text
     * Default: ``
     * Usage: `--hyper-connection-uri`
 
-  Connection URI for the hypervisor, e.g. 'qemu+tcp://10.0.0.1/system' or 'qemu+ssh://user@10.0.0.1/system'. If not set, the first address of the network(--cidr option) will be used.
+  Connection URI for the hypervisor, e.g. 'qemu+tcp://10.0.0.1/system' or 'qemu+ssh://user@10.0.0.1/system'. Only used with --pool-agent-placement=core; if not set there, the main network's first address is used (qemu+tcp).
 
 * `hyper_storage_pool`:
     * Type: text
@@ -242,6 +249,13 @@ Bootstrap exordos locally
 
   Do not update the realm configuration in exordosctl.yaml after bootstrap
 
+* `agent_name`:
+    * Type: text
+    * Default: `universal_agent`
+    * Usage: `--pool-agent-name`
+
+  Name of the universal agent to run LocalPoolAgentDriver under on this host. The default targets the standard agent (merging in if this host is also a registered compute node). Use a different name to run a separate, dedicated agent instead - required if the standard agent here is already configured for a different core.
+
 * `help`:
     * Type: boolean
     * Default: `false`
@@ -277,7 +291,9 @@ Bootstrap exordos locally
 │ --repository                -r  TEXT                                 Default element repository (can be specified multiple times) [default: https://repo.exordos.com/exordos-elements/]                                                                                                                 │
 │ --admin-password                TEXT                                 A password for the admin user in. If not provided, the password will be generated.                                                                                                                                                 │
 │ --save-admin-password-file      TEXT                                 If the option is specified the admin password is saved to the file. Otherwise it's printed to the console.                                                                                                                         │
-│ --hyper-connection-uri          TEXT                                 Connection URI for the hypervisor, e.g. 'qemu+tcp://10.0.0.1/system' or 'qemu+ssh://user@10.0.0.1/system'. If not set, the first address of the network(--cidr option) will be used.                                               │
+│ --pool-agent-placement          [core|local]                         Where the pool agent that drives the hypervisor's libvirt runs. 'core' runs it inside core's own services, reaching libvirt over the network (see --hyper-connection-uri). 'local' installs a dedicated universal agent on this    │
+│                                                                      host that talks to the local libvirt socket directly (matching `exordos compute hypervisors init`); --hyper-connection-uri is not supported in this mode. [default: core]                                                          │
+│ --hyper-connection-uri          TEXT                                 Connection URI for the hypervisor, e.g. 'qemu+tcp://10.0.0.1/system' or 'qemu+ssh://user@10.0.0.1/system'. Only used with --pool-agent-placement=core; if not set there, the main network's first address is used (qemu+tcp).      │
 │ --hyper-storage-pool            TEXT                                 Storage pool for the hypervisor. [default: default]                                                                                                                                                                                │
 │ --hyper-machine-prefix          TEXT                                 A prefix for new VMs. [default: vm-]                                                                                                                                                                                               │
 │ --hyper-iface-rom-file          TEXT                                 A path to the custom ROM file of a network interface. [default: /usr/share/qemu/1af41041.rom]                                                                                                                                      │

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -15,7 +15,13 @@
 #    under the License.
 from __future__ import annotations
 
+import base64
+import configparser
+import getpass
+import io
 import os
+import secrets
+import typing as tp
 import uuid as sys_uuid
 
 import rich_click as click
@@ -24,10 +30,69 @@ from exordos import constants as c
 from exordos import utils
 from exordos.clients import base_client
 from exordos.cmd.base import create_entity_group
+from exordos.common.crypto import write_root_owned_file
 from exordos.common.run import run_command
 from exordos.common.run import runsh
 from exordos.common.table import show_data
 from exordos.logger import ClickLogger
+
+ENTITY = "hypervisor"
+ENTITY_COLLECTION = c.HYPERVISOR_COLLECTION
+DEFAULT_LOCAL_CONNECTION_URI = "qemu:///system"
+
+# The universal agent that runs LocalPoolAgentDriver so this hypervisor's
+# pool is actually managed. Named "universal_agent" by default, matching
+# the exordos-base image's own standard agent - if this host is also a
+# registered compute node, LocalPoolAgentDriver is merged into that
+# existing agent instead of running a second, competing one. A custom
+# --pool-agent-name runs a separate, dedicated agent under parallel paths
+# instead (see _agent_*_path below), e.g. when the standard agent here
+# is already configured for a different core and isn't ours to touch.
+DEFAULT_AGENT_NAME = "universal_agent"
+AGENT_CONFIG_DIR = "/etc/exordos_universal_agent"
+STANDARD_AGENT_BIN_SYMLINK = "/usr/bin/exordos-universal-agent"
+
+
+def _agent_venv_path(agent_name: str) -> str:
+    return f"/opt/{agent_name}/.venv"
+
+
+def _agent_config_path(agent_name: str) -> str:
+    return f"{AGENT_CONFIG_DIR}/exordos_{agent_name}.conf"
+
+
+def _agent_work_dir(agent_name: str) -> str:
+    return f"/var/lib/exordos/{agent_name}"
+
+
+def _agent_unit_name(agent_name: str) -> str:
+    return f"exordos-{agent_name.replace('_', '-')}.service"
+
+
+def _agent_exec_path(agent_name: str, venv_path: str) -> str:
+    # The standard agent is reached through its stable /usr/bin symlink
+    # (matching the exordos-base image's own unit); a custom-named one
+    # runs straight out of its own venv - it has no symlink to rely on,
+    # and mustn't hijack the standard one since it may belong to an
+    # agent this code isn't managing.
+    if agent_name == DEFAULT_AGENT_NAME:
+        return STANDARD_AGENT_BIN_SYMLINK
+    return f"{venv_path}/bin/exordos-universal-agent"
+
+
+STANDARD_AGENT_VENV_PATH = _agent_venv_path(DEFAULT_AGENT_NAME)
+AGENT_CONFIG_PATH = _agent_config_path(DEFAULT_AGENT_NAME)
+AGENT_WORK_DIR = _agent_work_dir(DEFAULT_AGENT_NAME)
+AGENT_META_FILE = f"{AGENT_WORK_DIR}/pool_meta.json"
+AGENT_PRIVATE_KEY_PATH = f"{AGENT_WORK_DIR}/private_key"
+AGENT_SYSTEMD_UNIT_NAME = _agent_unit_name(DEFAULT_AGENT_NAME)
+AGENT_SYSTEMD_UNIT_PATH = f"/etc/systemd/system/{AGENT_SYSTEMD_UNIT_NAME}"
+
+# Ports the core's Orch/Status APIs are reachable on (exordos_core.conf.j2:
+# [orch_api] bind_port = 11011, [status_api] bind_port = 11012; both bind
+# 0.0.0.0, so reachable from this host over the main network).
+ORCH_API_PORT = 11011
+STATUS_API_PORT = 11012
 
 ENTITY = "hypervisor"
 ENTITY_COLLECTION = c.HYPERVISOR_COLLECTION
@@ -272,12 +337,265 @@ def _install_packages(add_sudo: bool = False) -> None:
         "libvirt-dev",
         "genisoimage",
         "unzip",
+        "python3-venv",
     ]
     cmd = ["apt-get", "update"]
     run_command(cmd, sudo=add_sudo)
     cmd = ["apt-get", "install", "-y"]
     cmd.extend(packages)
     run_command(cmd, env=dict(DEBIAN_FRONTEND="noninteractive"), sudo=add_sudo)
+
+
+def generate_node_private_key_base64() -> str:
+    """Generate a node encryption key for the local agent.
+
+    Matches gcl_sdk's `agents.universal.api.crypto.generate_key_base64`
+    (32 random bytes, base64-encoded) without depending on gcl_sdk itself,
+    which the exordos CLI doesn't otherwise install.
+    """
+    return base64.b64encode(secrets.token_bytes(32)).decode()
+
+
+def _agent_config_content(
+    orch_endpoint: str,
+    status_endpoint: str,
+    meta_file: str,
+    private_key_path: str,
+) -> str:
+    return f"""[universal_agent]
+orch_secure_communication = True
+orch_endpoint = {orch_endpoint}
+status_endpoint = {status_endpoint}
+private_key_path = {private_key_path}
+caps_drivers = LocalPoolAgentDriver
+verify_node_on_register = False
+
+[LocalPoolAgentDriver]
+meta_file = {meta_file}
+"""
+
+
+def _read_existing_config(config_path: str) -> str | None:
+    """Return the agent config's content, or None if not installed yet."""
+    if not os.path.exists(config_path):
+        return None
+    try:
+        with open(config_path) as f:
+            return f.read()
+    except PermissionError:
+        # A config containing a private_key_path may be root-only
+        # readable; this command is expected to run as a regular
+        # sudo-capable user, not as root.
+        return run_command(["sudo", "cat", config_path]).stdout
+
+
+def _config_value(content: str, section: str, option: str, fallback: str) -> str:
+    parser = configparser.ConfigParser()
+    parser.read_string(content)
+    return parser.get(section, option, fallback=fallback)
+
+
+def _merge_local_pool_into_config(existing_content: str, meta_file: str) -> str:
+    """Add LocalPoolAgentDriver to an already-installed agent's config.
+
+    This host already runs the standard universal agent (it's also a
+    registered compute node, provisioned from the exordos-base image),
+    so the pool capability is appended to its existing caps_drivers and
+    everything else (orch_endpoint, its own private_key_path, other
+    drivers) is left untouched - one shared agent identity, not a
+    second, competing one.
+    """
+    raw = _config_value(existing_content, "universal_agent", "caps_drivers", "")
+    drivers = [d.strip() for d in raw.replace("\n", ",").split(",") if d.strip()]
+    if "LocalPoolAgentDriver" not in drivers:
+        drivers.append("LocalPoolAgentDriver")
+
+    parser = configparser.ConfigParser()
+    parser.read_string(existing_content)
+    parser.set("universal_agent", "caps_drivers", ", ".join(drivers))
+    if not parser.has_section("LocalPoolAgentDriver"):
+        parser.add_section("LocalPoolAgentDriver")
+    parser.set("LocalPoolAgentDriver", "meta_file", meta_file)
+
+    buf = io.StringIO()
+    parser.write(buf)
+    return buf.getvalue()
+
+
+def _agent_systemd_unit_content(exec_path: str, config_path: str) -> str:
+    # ExecStart uses exec_path's full path rather than a bare command
+    # name: relying on $PATH is fragile if some other
+    # exordos-universal-agent happens to resolve first (e.g. a dev
+    # checkout installed under /usr/local/bin, which typically precedes
+    # /usr/bin in systemd's default PATH).
+    return f"""[Unit]
+Description=Genesis Universal Agent Service
+After=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=5
+ExecStart={exec_path} --config-file {config_path}
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+class AgentInstallTarget(tp.NamedTuple):
+    venv_path: str
+    exec_path: str
+    config_path: str
+    meta_file: str
+    default_private_key_path: str
+    unit_path: str
+    unit_name: str
+
+
+def resolve_agent_install_target(
+    agent_name: str, orch_endpoint: str, status_endpoint: str
+) -> AgentInstallTarget:
+    """Resolve the venv/config/unit paths for the named universal agent.
+
+    Refuses (raises ClickException) if an agent config already exists
+    under this name but for a *different* core - e.g. --pool-agent-name
+    defaulted to the standard agent, but this host is a compute node
+    managed by some other, unrelated exordos deployment. That agent
+    isn't ours to reconfigure; the caller should pass --pool-agent-name
+    to target a separate, dedicated agent instead.
+    """
+    venv_path = _agent_venv_path(agent_name)
+    config_path = _agent_config_path(agent_name)
+    work_dir = _agent_work_dir(agent_name)
+    unit_name = _agent_unit_name(agent_name)
+
+    existing = _read_existing_config(config_path)
+    if existing is not None:
+        existing_orch = _config_value(existing, "universal_agent", "orch_endpoint", "")
+        existing_status = _config_value(
+            existing, "universal_agent", "status_endpoint", ""
+        )
+        if existing_orch != orch_endpoint or existing_status != status_endpoint:
+            raise click.ClickException(
+                f"Agent '{agent_name}' ({config_path}) is already configured "
+                f"for a different core (orch_endpoint={existing_orch!r}, "
+                f"expected {orch_endpoint!r}). Pass --pool-agent-name to use "
+                "a separate, dedicated agent instead of reconfiguring this one."
+            )
+
+    return AgentInstallTarget(
+        venv_path=venv_path,
+        exec_path=_agent_exec_path(agent_name, venv_path),
+        config_path=config_path,
+        meta_file=f"{work_dir}/pool_meta.json",
+        default_private_key_path=f"{work_dir}/private_key",
+        unit_path=f"/etc/systemd/system/{unit_name}",
+        unit_name=unit_name,
+    )
+
+
+def install_agent_venv(venv_path: str = STANDARD_AGENT_VENV_PATH) -> None:
+    """Install (or extend) the universal agent's venv with gcl_sdk[libvirt].
+
+    A venv may already exist at this path - either the standard agent's
+    (this host is also a registered compute node, provisioned from the
+    exordos-base image) or a previous isolated install - in which case
+    libvirt-python just needs adding, via sudo since the standard venv
+    is root-owned. Otherwise a fresh one is created, owned by the
+    current (non-root) user so future pip runs don't need elevation.
+    The /usr/bin symlink is only (re)pointed at it when installing to
+    the standard path - an isolated install must not hijack it, since
+    it may belong to an agent this code isn't managing.
+    """
+    if os.path.isdir(venv_path):
+        run_command(["sudo", f"{venv_path}/bin/pip", "install", "gcl_sdk[libvirt]"])
+        return
+
+    agent_home = os.path.dirname(venv_path)
+    run_command(["sudo", "mkdir", "-p", agent_home])
+    run_command(["sudo", "chown", getpass.getuser(), agent_home])
+    run_command(["python3", "-m", "venv", venv_path])
+    run_command([f"{venv_path}/bin/pip", "install", "gcl_sdk[libvirt]"])
+    if venv_path == STANDARD_AGENT_VENV_PATH:
+        run_command(
+            [
+                "sudo",
+                "ln",
+                "-sf",
+                f"{venv_path}/bin/exordos-universal-agent",
+                STANDARD_AGENT_BIN_SYMLINK,
+            ]
+        )
+
+
+def write_agent_config(
+    orch_endpoint: str,
+    status_endpoint: str,
+    config_path: str = AGENT_CONFIG_PATH,
+    meta_file: str = AGENT_META_FILE,
+    default_private_key_path: str = AGENT_PRIVATE_KEY_PATH,
+) -> str:
+    """Configure the universal agent to (also) run LocalPoolAgentDriver.
+
+    If a config already exists here (this host already runs an agent
+    for the same core), LocalPoolAgentDriver is merged into its
+    caps_drivers instead of replacing the file. Otherwise a fresh,
+    pool-only config is written; `verify_node_on_register` is disabled
+    since a bare hypervisor host isn't itself a registered compute node.
+
+    Returns the private_key_path this config ends up using, so the
+    caller writes the key to the right place.
+    """
+    existing = _read_existing_config(config_path)
+
+    if existing is None:
+        private_key_path = default_private_key_path
+        content = _agent_config_content(
+            orch_endpoint, status_endpoint, meta_file, private_key_path
+        )
+    else:
+        private_key_path = _config_value(
+            existing, "universal_agent", "private_key_path", default_private_key_path
+        )
+        content = _merge_local_pool_into_config(existing, meta_file)
+
+    write_root_owned_file(content, config_path)
+    return private_key_path
+
+
+def reset_agent_meta_file(meta_file: str = AGENT_META_FILE) -> None:
+    """Drop the local agent's cached pool/volume/machine state.
+
+    A fresh `bootstrap` means a fresh core, so any resources the agent
+    previously tracked (pool_machine/pool_volume uuids, pool references)
+    belong to a core that no longer exists. Left in place, the agent
+    tries to reconcile them against the new core and fails.
+    """
+    run_command(["sudo", "rm", "-f", meta_file])
+
+
+def install_agent_systemd_unit(
+    exec_path: str = STANDARD_AGENT_BIN_SYMLINK,
+    config_path: str = AGENT_CONFIG_PATH,
+    unit_path: str = AGENT_SYSTEMD_UNIT_PATH,
+    unit_name: str = AGENT_SYSTEMD_UNIT_NAME,
+) -> None:
+    """Install (or re-install) and (re)start the universal agent's
+    systemd service.
+
+    Always (re)written: this template is a faithful, more robust
+    version of the exordos-base image's own unit (same Restart/
+    RestartSec/TimeoutStopSec, just a fully-qualified ExecStart), so
+    overwriting a genuinely pre-existing standard unit is a no-op past
+    that one difference - and skipping the write when a *stale* one
+    from an earlier run of this same code is already in place would
+    leave it stuck on outdated content instead of picking up fixes.
+    """
+    write_root_owned_file(_agent_systemd_unit_content(exec_path, config_path), unit_path)
+    run_command(["sudo", "systemctl", "daemon-reload"])
+    run_command(["sudo", "systemctl", "enable", unit_name])
+    run_command(["sudo", "systemctl", "restart", unit_name])
 
 
 def _add_user_to_groups(user: str | None, add_sudo: bool = False) -> None:
@@ -410,6 +728,27 @@ def _install_packer(add_sudo: bool = False) -> None:
     cmd = ["/usr/local/bin/packer", "-version"]
     run_command(cmd, sudo=add_sudo)
     return None
+
+
+def local_agent_node_uuid(
+    node_id_path: str = "/var/lib/exordos/node-id",
+    product_uuid_path: str = "/sys/class/dmi/id/product_uuid",
+) -> str:
+    """Return this machine's node uuid.
+
+    Matches gcl_sdk.agents.universal.utils.node_uuid(), so a local pool's
+    driver_spec.node lines up with the node uuid the local universal agent
+    (LocalPoolAgentDriver) will report for itself.
+    """
+    path = node_id_path if os.path.exists(node_id_path) else product_uuid_path
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        raise click.ClickException(
+            f"Unable to determine this machine's node uuid: neither "
+            f"{node_id_path} nor {product_uuid_path} exists."
+        )
 
 
 @hypervisors_group.command("init", help="Initialize hypervisor")

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -21,7 +21,9 @@ import getpass
 import io
 import os
 import secrets
+import socket
 import typing as tp
+from urllib.parse import urlparse
 import uuid as sys_uuid
 
 import rich_click as click
@@ -453,6 +455,27 @@ class AgentInstallTarget(tp.NamedTuple):
     unit_name: str
 
 
+def _endpoint_identity(url: str) -> tuple[str, int | None]:
+    """Resolve a URL's host to an IP, paired with its port.
+
+    Lets an endpoint given as a DNS name (the exordos-base image's own
+    convention, e.g. core.local.genesis-core.tech) and one given as a
+    literal IP compare equal when they're actually the same core,
+    instead of comparing the raw strings. Falls back to the raw
+    hostname if resolution fails - erring towards "different core"
+    (the safer default) rather than silently treating an unresolvable
+    host as a match.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if host:
+        try:
+            host = socket.gethostbyname(host)
+        except OSError:
+            pass
+    return host, parsed.port
+
+
 def resolve_agent_install_target(
     agent_name: str, orch_endpoint: str, status_endpoint: str
 ) -> AgentInstallTarget:
@@ -476,7 +499,9 @@ def resolve_agent_install_target(
         existing_status = _config_value(
             existing, "universal_agent", "status_endpoint", ""
         )
-        if existing_orch != orch_endpoint or existing_status != status_endpoint:
+        if _endpoint_identity(existing_orch) != _endpoint_identity(
+            orch_endpoint
+        ) or _endpoint_identity(existing_status) != _endpoint_identity(status_endpoint):
             raise click.ClickException(
                 f"Agent '{agent_name}' ({config_path}) is already configured "
                 f"for a different core (orch_endpoint={existing_orch!r}, "

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -375,18 +375,25 @@ meta_file = {meta_file}
 """
 
 
+def read_with_sudo(path: str) -> str:
+    """Read a file's content, falling back to `sudo cat` on PermissionError.
+
+    Some files this command reads (e.g. an agent config containing a
+    private_key_path, or product_uuid) may be root-only readable; this
+    command is expected to run as a regular sudo-capable user, not as root.
+    """
+    try:
+        with open(path) as f:
+            return f.read()
+    except PermissionError:
+        return run_command(["sudo", "cat", path]).stdout
+
+
 def _read_existing_config(config_path: str) -> str | None:
     """Return the agent config's content, or None if not installed yet."""
     if not os.path.exists(config_path):
         return None
-    try:
-        with open(config_path) as f:
-            return f.read()
-    except PermissionError:
-        # A config containing a private_key_path may be root-only
-        # readable; this command is expected to run as a regular
-        # sudo-capable user, not as root.
-        return run_command(["sudo", "cat", config_path]).stdout
+    return read_with_sudo(config_path)
 
 
 def _config_value(content: str, section: str, option: str, fallback: str) -> str:
@@ -429,7 +436,7 @@ def _agent_systemd_unit_content(exec_path: str, config_path: str) -> str:
     # checkout installed under /usr/local/bin, which typically precedes
     # /usr/bin in systemd's default PATH).
     return f"""[Unit]
-Description=Genesis Universal Agent Service
+Description=Exordos Universal Agent Service
 After=network-online.target
 
 [Service]
@@ -773,12 +780,7 @@ def local_agent_node_uuid(
     """
     path = node_id_path if os.path.exists(node_id_path) else product_uuid_path
     try:
-        with open(path) as f:
-            return f.read().strip()
-    except PermissionError:
-        # product_uuid is typically root-only readable; this command is
-        # expected to run as a regular sudo-capable user, not as root.
-        return run_command(["sudo", "cat", path]).stdout.strip()
+        return read_with_sudo(path).strip()
     except FileNotFoundError:
         raise click.ClickException(
             f"Unable to determine this machine's node uuid: neither "

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -560,7 +560,13 @@ def write_agent_config(
         )
         content = _merge_local_pool_into_config(existing, meta_file)
 
-    write_root_owned_file(content, config_path)
+    # Explicit mode, not left to `sudo cp`'s default: a brand-new
+    # destination inherits the source tempfile's mode (mkstemp -> 0600,
+    # root-only - unreadable by this non-root process on the next run),
+    # while an already-existing one keeps its own mode unchanged either
+    # way. Relying on either makes the outcome depend on whether this
+    # is the first write, so set it explicitly every time instead.
+    write_root_owned_file(content, config_path, mode="644")
     return private_key_path
 
 
@@ -592,7 +598,9 @@ def install_agent_systemd_unit(
     from an earlier run of this same code is already in place would
     leave it stuck on outdated content instead of picking up fixes.
     """
-    write_root_owned_file(_agent_systemd_unit_content(exec_path, config_path), unit_path)
+    write_root_owned_file(
+        _agent_systemd_unit_content(exec_path, config_path), unit_path, mode="644"
+    )
     run_command(["sudo", "systemctl", "daemon-reload"])
     run_command(["sudo", "systemctl", "enable", unit_name])
     run_command(["sudo", "systemctl", "restart", unit_name])

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -38,8 +38,6 @@ from exordos.common.run import runsh
 from exordos.common.table import show_data
 from exordos.logger import ClickLogger
 
-ENTITY = "hypervisor"
-ENTITY_COLLECTION = c.HYPERVISOR_COLLECTION
 DEFAULT_LOCAL_CONNECTION_URI = "qemu:///system"
 
 # The universal agent that runs LocalPoolAgentDriver so this hypervisor's

--- a/exordos/cmd/compute/hypervisors/commands.py
+++ b/exordos/cmd/compute/hypervisors/commands.py
@@ -777,6 +777,10 @@ def local_agent_node_uuid(
     try:
         with open(path) as f:
             return f.read().strip()
+    except PermissionError:
+        # product_uuid is typically root-only readable; this command is
+        # expected to run as a regular sudo-capable user, not as root.
+        return run_command(["sudo", "cat", path]).stdout.strip()
     except FileNotFoundError:
         raise click.ClickException(
             f"Unable to determine this machine's node uuid: neither "

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -1165,6 +1165,11 @@ def bootstrap_cmd(
         managed_network=False if boot_bridge else True,
     )
 
+    if subprocess.call(["sudo", "-n", "true"], stderr=subprocess.DEVNULL) != 0:
+        click.secho("Sudo privileges are required to proceed.", fg="yellow")
+        if subprocess.call(["sudo", "-v"]) != 0:
+            raise click.ClickException("Failed to obtain sudo privileges. Aborting.")
+
     hypervisors = []
 
     hyper_connection_uri, hyper_kind = _resolve_hypervisor_placement(
@@ -1237,11 +1242,6 @@ def bootstrap_cmd(
             ssh_public_key_path = public_key_path
             with open(public_key_path, encoding="utf-8") as f:
                 ssh_public_key_content = f.read().strip()
-
-    if subprocess.call(["sudo", "-n", "true"], stderr=subprocess.DEVNULL) != 0:
-        click.secho("Sudo privileges are required to proceed.", fg="yellow")
-        if subprocess.call(["sudo", "-v"]) != 0:
-            raise click.ClickException("Failed to obtain sudo privileges. Aborting.")
 
     with status_lib.status_done(f"Launching Exordos installation '{name}'... "):
         core_ip_result = _bootstrap_core(

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -39,12 +39,24 @@ from exordos import utils
 from exordos.backup import base as backup_base
 from exordos.backup import local as backup_local
 from exordos.builder import base as base_builder
+from exordos.cmd.compute.hypervisors.commands import DEFAULT_AGENT_NAME
+from exordos.cmd.compute.hypervisors.commands import DEFAULT_LOCAL_CONNECTION_URI
+from exordos.cmd.compute.hypervisors.commands import ORCH_API_PORT
+from exordos.cmd.compute.hypervisors.commands import STATUS_API_PORT
+from exordos.cmd.compute.hypervisors.commands import generate_node_private_key_base64
+from exordos.cmd.compute.hypervisors.commands import install_agent_systemd_unit
+from exordos.cmd.compute.hypervisors.commands import install_agent_venv
+from exordos.cmd.compute.hypervisors.commands import local_agent_node_uuid
+from exordos.cmd.compute.hypervisors.commands import reset_agent_meta_file
+from exordos.cmd.compute.hypervisors.commands import resolve_agent_install_target
+from exordos.cmd.compute.hypervisors.commands import write_agent_config
 from exordos.cmd.settings import config as settings_config
 from exordos.cmd.stand.constants import BackupPeriod
 from exordos.cmd.stand.constants import Profile
 from exordos.common import ssh
 from exordos.common import status as status_lib
 from exordos.common import version as version_lib
+from exordos.common.crypto import write_agent_private_key
 import exordos.constants as c
 from exordos.infra.driver import libvirt as libvirt_infra
 from exordos.infra.libvirt import libvirt
@@ -665,6 +677,30 @@ def _update_realm_config(
     logger.info(f"Realm '{realm_name}' configuration updated in {cfg_path}")
 
 
+def _resolve_hypervisor_placement(
+    pool_agent_placement: str,
+    hyper_connection_uri: str,
+    cidr: ipaddress.IPv4Network,
+) -> tp.Tuple[str, str]:
+    """Resolve the hypervisor's connection URI and driver kind.
+
+    Returns (connection_uri, driver_kind). Kind "libvirt" means the pool
+    agent lives in core and reaches libvirt over the network; kind
+    "exordos_local_hyper" means a dedicated local agent on this host
+    talks to the local libvirt socket directly.
+    """
+    if pool_agent_placement == "local":
+        if hyper_connection_uri:
+            raise click.UsageError(
+                "--hyper-connection-uri is not supported together with "
+                "--pool-agent-placement=local; the local agent always "
+                "talks to the local libvirt socket directly."
+            )
+        return DEFAULT_LOCAL_CONNECTION_URI, "exordos_local_hyper"
+
+    return hyper_connection_uri or f"qemu+tcp://{cidr[1]}/system", "libvirt"
+
+
 @click.command("bootstrap", help="Bootstrap exordos locally")
 @click.option(
     "-i",
@@ -810,14 +846,29 @@ def _update_realm_config(
     show_default=True,
 )
 @click.option(
+    "--pool-agent-placement",
+    type=click.Choice(["core", "local"]),
+    default="core",
+    show_default=True,
+    help=(
+        "Where the pool agent that drives the hypervisor's libvirt runs. "
+        "'core' runs it inside core's own services, reaching libvirt over "
+        "the network (see --hyper-connection-uri). 'local' installs a "
+        "dedicated universal agent on this host that talks to the local "
+        "libvirt socket directly (matching `exordos compute hypervisors "
+        "init`); --hyper-connection-uri is not supported in this mode."
+    ),
+)
+@click.option(
     "--hyper-connection-uri",
     default="",
     type=str,
     help=(
         "Connection URI for the hypervisor, "
         "e.g. 'qemu+tcp://10.0.0.1/system' or "
-        "'qemu+ssh://user@10.0.0.1/system'. If not set, "
-        "the first address of the network(--cidr option) will be used. "
+        "'qemu+ssh://user@10.0.0.1/system'. Only used with "
+        "--pool-agent-placement=core; if not set there, the main "
+        "network's first address is used (qemu+tcp)."
     ),
 )
 @click.option(
@@ -926,6 +977,21 @@ def _update_realm_config(
     default=False,
     help="Do not update the realm configuration in exordosctl.yaml after bootstrap",
 )
+@click.option(
+    "--pool-agent-name",
+    "agent_name",
+    type=str,
+    default=DEFAULT_AGENT_NAME,
+    show_default=True,
+    help=(
+        "Name of the universal agent to run LocalPoolAgentDriver under on "
+        "this host. The default targets the standard agent (merging in "
+        "if this host is also a registered compute node). Use a different "
+        "name to run a separate, dedicated agent instead - required if "
+        "the standard agent here is already configured for a different "
+        "core."
+    ),
+)
 @click.pass_context
 def bootstrap_cmd(
     ctx: click.Context,
@@ -946,6 +1012,7 @@ def bootstrap_cmd(
     repository: tp.Tuple[str, ...],
     admin_password: str | None,
     save_admin_password_file: str | None,
+    pool_agent_placement: str,
     hyper_connection_uri: str,
     hyper_storage_pool: str,
     hyper_machine_prefix: str,
@@ -961,6 +1028,7 @@ def bootstrap_cmd(
     ssh_public_key: tp.Tuple[str, ...],
     elements: tp.Tuple[str, ...],
     no_update_realm: bool,
+    agent_name: str,
 ) -> None:
     if not inventory:
         raise click.UsageError("No inventory specified")
@@ -1099,8 +1167,21 @@ def bootstrap_cmd(
 
     hypervisors = []
 
-    if not hyper_connection_uri:
-        hyper_connection_uri = f"qemu+tcp://{cidr[1]}/system"
+    hyper_connection_uri, hyper_kind = _resolve_hypervisor_placement(
+        pool_agent_placement, hyper_connection_uri, cidr
+    )
+
+    hyper_node = None
+    hyper_private_key = None
+    if hyper_kind == "exordos_local_hyper":
+        # This machine is the hypervisor, reachable over the local
+        # libvirt socket by the local universal agent (LocalPoolAgentDriver)
+        # only, matched by node uuid.
+        hyper_node = local_agent_node_uuid()
+        # Generated here (rather than left for the core to generate) so
+        # the same key can be written to the agent below, right after
+        # the core seeds its matching NodeEncryptionKey at bootstrap.
+        hyper_private_key = generate_node_private_key_base64()
 
     # Single hypervisor at bootstrap time is supported at the moment
     hypervisor = stand_models.Hypervisor(
@@ -1108,6 +1189,9 @@ def bootstrap_cmd(
         network_type="bridge" if bridge else "network",
         connection_uri=hyper_connection_uri,
         storage_pool=hyper_storage_pool,
+        kind=hyper_kind,
+        node=hyper_node,
+        private_key=hyper_private_key,
         machine_prefix=hyper_machine_prefix,
         iface_rom_file=hyper_iface_rom_file,
     )
@@ -1154,8 +1238,7 @@ def bootstrap_cmd(
             with open(public_key_path, encoding="utf-8") as f:
                 ssh_public_key_content = f.read().strip()
 
-    sudo_check = ["sudo", "-n", "true"]
-    if subprocess.call(sudo_check, stderr=subprocess.DEVNULL) != 0:
+    if subprocess.call(["sudo", "-n", "true"], stderr=subprocess.DEVNULL) != 0:
         click.secho("Sudo privileges are required to proceed.", fg="yellow")
         if subprocess.call(["sudo", "-v"]) != 0:
             raise click.ClickException("Failed to obtain sudo privileges. Aborting.")
@@ -1187,6 +1270,34 @@ def bootstrap_cmd(
             ssh_public_key=ssh_public_key_content,
             elements=list(elements) if elements else None,
         )
+
+    if hyper_kind == "exordos_local_hyper" and not no_start:
+        agent_ip = core_ip_result if core_ip_result is not None else core_ip
+        if agent_ip is not None:
+            with status_lib.status_done("Setting up the local universal agent..."):
+                orch_endpoint = f"http://{agent_ip}:{ORCH_API_PORT}"
+                status_endpoint = f"http://{agent_ip}:{STATUS_API_PORT}"
+                agent_target = resolve_agent_install_target(
+                    agent_name=agent_name,
+                    orch_endpoint=orch_endpoint,
+                    status_endpoint=status_endpoint,
+                )
+                install_agent_venv(agent_target.venv_path)
+                reset_agent_meta_file(agent_target.meta_file)
+                private_key_path = write_agent_config(
+                    orch_endpoint=orch_endpoint,
+                    status_endpoint=status_endpoint,
+                    config_path=agent_target.config_path,
+                    meta_file=agent_target.meta_file,
+                    default_private_key_path=agent_target.default_private_key_path,
+                )
+                write_agent_private_key(hyper_private_key, key_path=private_key_path)
+                install_agent_systemd_unit(
+                    exec_path=agent_target.exec_path,
+                    config_path=agent_target.config_path,
+                    unit_path=agent_target.unit_path,
+                    unit_name=agent_target.unit_name,
+                )
 
     realm_updated = False
     if not no_update_realm:

--- a/exordos/cmd/stand/commands.py
+++ b/exordos/cmd/stand/commands.py
@@ -39,17 +39,7 @@ from exordos import utils
 from exordos.backup import base as backup_base
 from exordos.backup import local as backup_local
 from exordos.builder import base as base_builder
-from exordos.cmd.compute.hypervisors.commands import DEFAULT_AGENT_NAME
-from exordos.cmd.compute.hypervisors.commands import DEFAULT_LOCAL_CONNECTION_URI
-from exordos.cmd.compute.hypervisors.commands import ORCH_API_PORT
-from exordos.cmd.compute.hypervisors.commands import STATUS_API_PORT
-from exordos.cmd.compute.hypervisors.commands import generate_node_private_key_base64
-from exordos.cmd.compute.hypervisors.commands import install_agent_systemd_unit
-from exordos.cmd.compute.hypervisors.commands import install_agent_venv
-from exordos.cmd.compute.hypervisors.commands import local_agent_node_uuid
-from exordos.cmd.compute.hypervisors.commands import reset_agent_meta_file
-from exordos.cmd.compute.hypervisors.commands import resolve_agent_install_target
-from exordos.cmd.compute.hypervisors.commands import write_agent_config
+from exordos.cmd.compute.hypervisors import commands as hv_commands
 from exordos.cmd.settings import config as settings_config
 from exordos.cmd.stand.constants import BackupPeriod
 from exordos.cmd.stand.constants import Profile
@@ -696,7 +686,7 @@ def _resolve_hypervisor_placement(
                 "--pool-agent-placement=local; the local agent always "
                 "talks to the local libvirt socket directly."
             )
-        return DEFAULT_LOCAL_CONNECTION_URI, "exordos_local_hyper"
+        return hv_commands.DEFAULT_LOCAL_CONNECTION_URI, "exordos_local_hyper"
 
     return hyper_connection_uri or f"qemu+tcp://{cidr[1]}/system", "libvirt"
 
@@ -981,7 +971,7 @@ def _resolve_hypervisor_placement(
     "--pool-agent-name",
     "agent_name",
     type=str,
-    default=DEFAULT_AGENT_NAME,
+    default=hv_commands.DEFAULT_AGENT_NAME,
     show_default=True,
     help=(
         "Name of the universal agent to run LocalPoolAgentDriver under on "
@@ -1182,11 +1172,11 @@ def bootstrap_cmd(
         # This machine is the hypervisor, reachable over the local
         # libvirt socket by the local universal agent (LocalPoolAgentDriver)
         # only, matched by node uuid.
-        hyper_node = local_agent_node_uuid()
+        hyper_node = hv_commands.local_agent_node_uuid()
         # Generated here (rather than left for the core to generate) so
         # the same key can be written to the agent below, right after
         # the core seeds its matching NodeEncryptionKey at bootstrap.
-        hyper_private_key = generate_node_private_key_base64()
+        hyper_private_key = hv_commands.generate_node_private_key_base64()
 
     # Single hypervisor at bootstrap time is supported at the moment
     hypervisor = stand_models.Hypervisor(
@@ -1271,33 +1261,41 @@ def bootstrap_cmd(
             elements=list(elements) if elements else None,
         )
 
-    if hyper_kind == "exordos_local_hyper" and not no_start:
-        agent_ip = core_ip_result if core_ip_result is not None else core_ip
-        if agent_ip is not None:
-            with status_lib.status_done("Setting up the local universal agent..."):
-                orch_endpoint = f"http://{agent_ip}:{ORCH_API_PORT}"
-                status_endpoint = f"http://{agent_ip}:{STATUS_API_PORT}"
-                agent_target = resolve_agent_install_target(
-                    agent_name=agent_name,
-                    orch_endpoint=orch_endpoint,
-                    status_endpoint=status_endpoint,
-                )
-                install_agent_venv(agent_target.venv_path)
-                reset_agent_meta_file(agent_target.meta_file)
-                private_key_path = write_agent_config(
-                    orch_endpoint=orch_endpoint,
-                    status_endpoint=status_endpoint,
-                    config_path=agent_target.config_path,
-                    meta_file=agent_target.meta_file,
-                    default_private_key_path=agent_target.default_private_key_path,
-                )
-                write_agent_private_key(hyper_private_key, key_path=private_key_path)
-                install_agent_systemd_unit(
-                    exec_path=agent_target.exec_path,
-                    config_path=agent_target.config_path,
-                    unit_path=agent_target.unit_path,
-                    unit_name=agent_target.unit_name,
-                )
+    if hyper_kind == "exordos_local_hyper":
+        # The local agent must be configured regardless of --no-start: the
+        # core's IP is fixed at network-creation time (not discovered once
+        # it boots), and the core needs to find the agent already
+        # configured the first time it does start.
+        if core_ip_result is not None:
+            agent_ip = core_ip_result
+        elif core_ip is not None:
+            agent_ip = core_ip
+        else:
+            agent_ip = cidr[2]
+        with status_lib.status_done("Setting up the local universal agent..."):
+            orch_endpoint = f"http://{agent_ip}:{hv_commands.ORCH_API_PORT}"
+            status_endpoint = f"http://{agent_ip}:{hv_commands.STATUS_API_PORT}"
+            agent_target = hv_commands.resolve_agent_install_target(
+                agent_name=agent_name,
+                orch_endpoint=orch_endpoint,
+                status_endpoint=status_endpoint,
+            )
+            hv_commands.install_agent_venv(agent_target.venv_path)
+            hv_commands.reset_agent_meta_file(agent_target.meta_file)
+            private_key_path = hv_commands.write_agent_config(
+                orch_endpoint=orch_endpoint,
+                status_endpoint=status_endpoint,
+                config_path=agent_target.config_path,
+                meta_file=agent_target.meta_file,
+                default_private_key_path=agent_target.default_private_key_path,
+            )
+            write_agent_private_key(hyper_private_key, key_path=private_key_path)
+            hv_commands.install_agent_systemd_unit(
+                exec_path=agent_target.exec_path,
+                config_path=agent_target.config_path,
+                unit_path=agent_target.unit_path,
+                unit_name=agent_target.unit_name,
+            )
 
     realm_updated = False
     if not no_update_realm:

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -97,6 +97,13 @@ def write_root_owned_file(
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+        # `install -m` sets the destination's mode atomically as it
+        # creates it - unlike `cp` followed by a separate `chmod`, which
+        # leaves a brief window where a freshly-created file (e.g. a
+        # private key) is readable at whatever mode `cp`/root's umask
+        # happens to produce. Default to a restrictive 600 rather than
+        # whatever that would be when the caller doesn't ask for a
+        # specific mode.
         run_command(["sudo", "install", "-m", mode or "600", tmp_path, dest_path])
     finally:
         os.remove(tmp_path)

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -82,7 +82,7 @@ def decrypt_chacha20_poly1305(
 
 
 def write_root_owned_file(
-    content: str, dest_path: str, mode: str | int | None = None
+    content: str, dest_path: str, mode: str | None = None
 ) -> None:
     """Write `content` to `dest_path`, a system path this (non-root, but
     sudo-capable) process can't write to directly.
@@ -104,8 +104,7 @@ def write_root_owned_file(
         # happens to produce. Default to a restrictive 600 rather than
         # whatever that would be when the caller doesn't ask for a
         # specific mode.
-        mode_str = f"{mode:o}" if isinstance(mode, int) else mode or "600"
-        run_command(["sudo", "install", "-m", mode_str, tmp_path, dest_path])
+        run_command(["sudo", "install", "-m", mode or "600", tmp_path, dest_path])
     finally:
         os.remove(tmp_path)
 

--- a/exordos/common/crypto.py
+++ b/exordos/common/crypto.py
@@ -82,7 +82,7 @@ def decrypt_chacha20_poly1305(
 
 
 def write_root_owned_file(
-    content: str, dest_path: str, mode: str | None = None
+    content: str, dest_path: str, mode: str | int | None = None
 ) -> None:
     """Write `content` to `dest_path`, a system path this (non-root, but
     sudo-capable) process can't write to directly.
@@ -104,7 +104,8 @@ def write_root_owned_file(
         # happens to produce. Default to a restrictive 600 rather than
         # whatever that would be when the caller doesn't ask for a
         # specific mode.
-        run_command(["sudo", "install", "-m", mode or "600", tmp_path, dest_path])
+        mode_str = f"{mode:o}" if isinstance(mode, int) else mode or "600"
+        run_command(["sudo", "install", "-m", mode_str, tmp_path, dest_path])
     finally:
         os.remove(tmp_path)
 

--- a/exordos/stand/models.py
+++ b/exordos/stand/models.py
@@ -133,6 +133,13 @@ class Hypervisor:
     connection_uri: str
     storage_pool: str = "default"
     kind: str = "libvirt"
+    # Required by the "exordos_local_hyper" kind: the node uuid of the
+    # local universal agent (LocalPoolAgentDriver) this pool is pinned to.
+    node: str | None = None
+    # Required by the "exordos_local_hyper" kind: the node encryption key
+    # (base64) already written to the local agent's disk, so the core
+    # stores the same key instead of generating a mismatched one.
+    private_key: str | None = None
     machine_prefix: str = "vm-"
     iface_rom_file: str = "/usr/share/qemu/1af41041.rom"
 

--- a/exordos/tests/unit/test_cmd_stand.py
+++ b/exordos/tests/unit/test_cmd_stand.py
@@ -24,6 +24,7 @@ import click
 import pytest
 import rich.console
 
+from exordos.cmd.compute.hypervisors import commands as hv_commands
 from exordos.cmd.stand import commands
 
 
@@ -78,7 +79,7 @@ class TestResolveHypervisorPlacement:
     def test_local_without_explicit_uri_uses_the_local_socket(self):
         uri, kind = commands._resolve_hypervisor_placement("local", "", self._CIDR)
 
-        assert uri == commands.DEFAULT_LOCAL_CONNECTION_URI
+        assert uri == hv_commands.DEFAULT_LOCAL_CONNECTION_URI
         assert kind == "exordos_local_hyper"
 
     def test_local_with_explicit_uri_is_rejected(self):

--- a/exordos/tests/unit/test_cmd_stand.py
+++ b/exordos/tests/unit/test_cmd_stand.py
@@ -14,11 +14,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ipaddress
 import os
 import pathlib
 import stat
 from unittest import mock
 
+import click
+import pytest
 import rich.console
 
 from exordos.cmd.stand import commands
@@ -53,3 +56,33 @@ def test_print_bootstrap_summary_includes_core_version_in_realm() -> None:
         )
 
     assert "1.2.3" in console.export_text()
+
+
+class TestResolveHypervisorPlacement:
+    _CIDR = ipaddress.IPv4Network("10.20.0.0/22")
+
+    def test_core_without_explicit_uri_defaults_to_network_first_address(self):
+        uri, kind = commands._resolve_hypervisor_placement("core", "", self._CIDR)
+
+        assert uri == "qemu+tcp://10.20.0.1/system"
+        assert kind == "libvirt"
+
+    def test_core_with_explicit_uri_uses_it_unchanged(self):
+        uri, kind = commands._resolve_hypervisor_placement(
+            "core", "qemu+ssh://user@10.0.0.5/system", self._CIDR
+        )
+
+        assert uri == "qemu+ssh://user@10.0.0.5/system"
+        assert kind == "libvirt"
+
+    def test_local_without_explicit_uri_uses_the_local_socket(self):
+        uri, kind = commands._resolve_hypervisor_placement("local", "", self._CIDR)
+
+        assert uri == commands.DEFAULT_LOCAL_CONNECTION_URI
+        assert kind == "exordos_local_hyper"
+
+    def test_local_with_explicit_uri_is_rejected(self):
+        with pytest.raises(click.UsageError, match="--pool-agent-placement=local"):
+            commands._resolve_hypervisor_placement(
+                "local", "qemu+tcp://10.0.0.5/system", self._CIDR
+            )

--- a/exordos/tests/unit/test_hypervisors_cli.py
+++ b/exordos/tests/unit/test_hypervisors_cli.py
@@ -54,6 +54,27 @@ class TestLocalAgentNodeUuid:
 
         assert result == "some-product-uuid"
 
+    def test_falls_back_to_sudo_cat_on_permission_error(self, tmp_path) -> None:
+        # product_uuid is typically root-only readable; this command runs
+        # as a regular sudo-capable user, not root.
+        product_uuid_path = tmp_path / "product_uuid"
+        product_uuid_path.write_text("some-product-uuid\n")
+
+        fake_result = MagicMock(stdout="some-product-uuid\n")
+        with (
+            patch.object(hv_commands, "open", side_effect=PermissionError, create=True),
+            patch.object(
+                hv_commands, "run_command", return_value=fake_result
+            ) as run_mock,
+        ):
+            result = hv_commands.local_agent_node_uuid(
+                node_id_path=str(tmp_path / "node-id"),
+                product_uuid_path=str(product_uuid_path),
+            )
+
+        assert result == "some-product-uuid"
+        run_mock.assert_called_once_with(["sudo", "cat", str(product_uuid_path)])
+
     def test_raises_a_clean_error_when_neither_path_exists(self, tmp_path) -> None:
         with pytest.raises(click.ClickException, match="Unable to determine"):
             hv_commands.local_agent_node_uuid(

--- a/exordos/tests/unit/test_hypervisors_cli.py
+++ b/exordos/tests/unit/test_hypervisors_cli.py
@@ -412,6 +412,38 @@ class TestAgentNamingHelpers:
         )
 
 
+class TestEndpointIdentity:
+    """Tests for _endpoint_identity: resolving a URL's host to an IP so
+    a DNS name and the literal IP it resolves to compare equal.
+    """
+
+    def test_resolves_hostname_to_ip(self) -> None:
+        with patch.object(
+            hv_commands.socket, "gethostbyname", return_value="10.100.0.2"
+        ):
+            assert hv_commands._endpoint_identity(
+                "http://core.local.genesis-core.tech:11011"
+            ) == ("10.100.0.2", 11011)
+
+    def test_falls_back_to_raw_hostname_when_resolution_fails(self) -> None:
+        with patch.object(hv_commands.socket, "gethostbyname", side_effect=OSError):
+            assert hv_commands._endpoint_identity("http://unresolvable:11011") == (
+                "unresolvable",
+                11011,
+            )
+
+    def test_empty_host_is_not_resolved(self) -> None:
+        # socket.gethostbyname("") resolves to "0.0.0.0" instead of
+        # raising - resolving it would make two differently-broken
+        # (hostless) endpoints compare equal, defeating the "erring
+        # towards different core" default.
+        with patch.object(hv_commands.socket, "gethostbyname") as gethostbyname_mock:
+            identity = hv_commands._endpoint_identity("http:///no-host-here")
+
+        gethostbyname_mock.assert_not_called()
+        assert identity == ("", None)
+
+
 class TestResolveAgentInstallTarget:
     """Tests for resolve_agent_install_target: fresh/matching vs a
     foreign agent already configured for a different core.
@@ -446,6 +478,34 @@ class TestResolveAgentInstallTarget:
 
         assert target.config_path == str(config_path)
 
+    def test_dns_name_and_literal_ip_for_the_same_core_are_accepted(
+        self, tmp_path
+    ) -> None:
+        """The exordos-base image's own agent config points at a DNS
+        name (e.g. core.local.genesis-core.tech); this code computes a
+        literal IP from --endpoint. Both must be recognized as the same
+        core when the name resolves to that IP, not rejected as a
+        string mismatch."""
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text(
+            "[universal_agent]\n"
+            "orch_endpoint = http://core.local.genesis-core.tech:11011\n"
+            "status_endpoint = http://core.local.genesis-core.tech:11012\n"
+        )
+        with (
+            patch.object(hv_commands, "AGENT_CONFIG_DIR", str(tmp_path)),
+            patch.object(
+                hv_commands.socket, "gethostbyname", return_value="10.100.0.2"
+            ),
+        ):
+            target = hv_commands.resolve_agent_install_target(
+                agent_name=hv_commands.DEFAULT_AGENT_NAME,
+                orch_endpoint="http://10.100.0.2:11011",
+                status_endpoint="http://10.100.0.2:11012",
+            )
+
+        assert target.config_path == str(config_path)
+
     def test_existing_config_for_a_different_core_raises(self, tmp_path) -> None:
         """A machine that's also a compute node of some other, unrelated
         exordos deployment must not have its agent silently
@@ -453,11 +513,12 @@ class TestResolveAgentInstallTarget:
         config_path = tmp_path / "exordos_universal_agent.conf"
         config_path.write_text(
             "[universal_agent]\n"
-            "orch_endpoint = http://10.30.0.2:11011\n"
-            "status_endpoint = http://10.30.0.2:11012\n"
+            "orch_endpoint = http://core.local.genesis-core.tech:11011\n"
+            "status_endpoint = http://core.local.genesis-core.tech:11012\n"
         )
         with (
             patch.object(hv_commands, "AGENT_CONFIG_DIR", str(tmp_path)),
+            patch.object(hv_commands.socket, "gethostbyname", side_effect=OSError),
             pytest.raises(click.ClickException, match="different core"),
         ):
             hv_commands.resolve_agent_install_target(

--- a/exordos/tests/unit/test_hypervisors_cli.py
+++ b/exordos/tests/unit/test_hypervisors_cli.py
@@ -1,0 +1,467 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import base64
+import configparser
+import getpass
+from unittest.mock import MagicMock
+from unittest.mock import call as mock_call
+from unittest.mock import patch
+
+import click
+import pytest
+
+from exordos.cmd.compute.hypervisors import commands as hv_commands
+from exordos.common import crypto
+
+
+class TestLocalAgentNodeUuid:
+    """Tests for local_agent_node_uuid: node-id file, DMI product_uuid
+    fallback, and the case where neither exists.
+    """
+
+    def test_reads_node_id_file_when_present(self, tmp_path) -> None:
+        node_id_path = tmp_path / "node-id"
+        node_id_path.write_text("some-node-uuid\n")
+
+        result = hv_commands.local_agent_node_uuid(
+            node_id_path=str(node_id_path),
+            product_uuid_path=str(tmp_path / "product_uuid"),
+        )
+
+        assert result == "some-node-uuid"
+
+    def test_falls_back_to_product_uuid_when_node_id_missing(self, tmp_path) -> None:
+        product_uuid_path = tmp_path / "product_uuid"
+        product_uuid_path.write_text("some-product-uuid\n")
+
+        result = hv_commands.local_agent_node_uuid(
+            node_id_path=str(tmp_path / "node-id"),
+            product_uuid_path=str(product_uuid_path),
+        )
+
+        assert result == "some-product-uuid"
+
+    def test_raises_a_clean_error_when_neither_path_exists(self, tmp_path) -> None:
+        with pytest.raises(click.ClickException, match="Unable to determine"):
+            hv_commands.local_agent_node_uuid(
+                node_id_path=str(tmp_path / "node-id"),
+                product_uuid_path=str(tmp_path / "product_uuid"),
+            )
+
+
+class TestAgentConfigContent:
+    """Tests for the pure content-building helpers:
+    _agent_config_content, _agent_systemd_unit_content.
+    """
+
+    def test_agent_config_content(self) -> None:
+        content = hv_commands._agent_config_content(
+            "http://10.20.0.2:11011",
+            "http://10.20.0.2:11012",
+            "/opt/exordos-hyper-agent/pool_meta.json",
+            "/etc/exordos_universal_agent/node_private_key",
+        )
+        assert "orch_secure_communication = True" in content
+        assert "orch_endpoint = http://10.20.0.2:11011" in content
+        assert "status_endpoint = http://10.20.0.2:11012" in content
+        assert (
+            "private_key_path = /etc/exordos_universal_agent/node_private_key"
+            in content
+        )
+        assert "caps_drivers = LocalPoolAgentDriver" in content
+        assert "verify_node_on_register = False" in content
+        assert "meta_file = /opt/exordos-hyper-agent/pool_meta.json" in content
+
+    def test_agent_systemd_unit_content(self) -> None:
+        content = hv_commands._agent_systemd_unit_content(
+            "/opt/universal_agent/.venv/bin/exordos-universal-agent",
+            "/etc/exordos_universal_agent/exordos_universal_agent.conf",
+        )
+        assert (
+            "ExecStart=/opt/universal_agent/.venv/bin/exordos-universal-agent "
+            "--config-file /etc/exordos_universal_agent/exordos_universal_agent.conf"
+            in content
+        )
+
+
+class TestAgentSetup:
+    """Tests for the local universal agent setup helpers:
+    install_agent_venv, write_agent_config, install_agent_systemd_unit.
+
+    All privileged filesystem/systemctl operations must go through sudo:
+    `exordos bootstrap` runs as a regular, sudo-capable user, not root.
+    """
+
+    def test_generate_node_private_key_base64_produces_32_byte_key(self) -> None:
+        key_base64 = hv_commands.generate_node_private_key_base64()
+
+        assert len(base64.b64decode(key_base64)) == 32
+
+    def test_reset_agent_meta_file_removes_it_via_sudo(self) -> None:
+        with patch.object(hv_commands, "run_command") as run_mock:
+            hv_commands.reset_agent_meta_file("/opt/exordos-hyper-agent/pool_meta.json")
+
+        run_mock.assert_called_once_with(
+            ["sudo", "rm", "-f", "/opt/exordos-hyper-agent/pool_meta.json"]
+        )
+
+    def test_install_agent_venv_creates_venv_and_symlinks_when_standard(
+        self, tmp_path
+    ) -> None:
+        """No venv at the standard path yet: create one fresh, owned by
+        the current user, plus the /usr/bin symlink."""
+        venv_path = str(tmp_path / "agent-home" / "venv")
+        with (
+            patch.object(hv_commands, "run_command") as run_mock,
+            patch.object(hv_commands, "STANDARD_AGENT_VENV_PATH", venv_path),
+            patch.object(hv_commands, "STANDARD_AGENT_BIN_SYMLINK", "/usr/bin/fake"),
+        ):
+            hv_commands.install_agent_venv(venv_path)
+
+        assert run_mock.call_args_list == [
+            mock_call(["sudo", "mkdir", "-p", str(tmp_path / "agent-home")]),
+            mock_call(
+                ["sudo", "chown", getpass.getuser(), str(tmp_path / "agent-home")]
+            ),
+            mock_call(["python3", "-m", "venv", venv_path]),
+            mock_call([f"{venv_path}/bin/pip", "install", "gcl_sdk[libvirt]"]),
+            mock_call(
+                [
+                    "sudo",
+                    "ln",
+                    "-sf",
+                    f"{venv_path}/bin/exordos-universal-agent",
+                    "/usr/bin/fake",
+                ]
+            ),
+        ]
+
+    def test_install_agent_venv_creates_venv_without_symlink_when_custom(
+        self, tmp_path
+    ) -> None:
+        """A custom-named agent's fresh venv must not hijack the
+        standard agent's /usr/bin symlink - it may belong to an agent
+        this code isn't managing."""
+        venv_path = str(tmp_path / "agent-home" / "venv")
+        with (
+            patch.object(hv_commands, "run_command") as run_mock,
+            patch.object(hv_commands, "STANDARD_AGENT_VENV_PATH", "/opt/other/.venv"),
+        ):
+            hv_commands.install_agent_venv(venv_path)
+
+        assert run_mock.call_args_list == [
+            mock_call(["sudo", "mkdir", "-p", str(tmp_path / "agent-home")]),
+            mock_call(
+                ["sudo", "chown", getpass.getuser(), str(tmp_path / "agent-home")]
+            ),
+            mock_call(["python3", "-m", "venv", venv_path]),
+            mock_call([f"{venv_path}/bin/pip", "install", "gcl_sdk[libvirt]"]),
+        ]
+
+    def test_install_agent_venv_extends_existing_venv_via_sudo_pip(
+        self, tmp_path
+    ) -> None:
+        """A venv already exists at this path (this host already runs the
+        standard universal agent): just add libvirt-python to it via
+        sudo, don't touch ownership or recreate anything."""
+        venv_path = tmp_path / "agent-home" / "venv"
+        venv_path.mkdir(parents=True)
+
+        with patch.object(hv_commands, "run_command") as run_mock:
+            hv_commands.install_agent_venv(str(venv_path))
+
+        run_mock.assert_called_once_with(
+            ["sudo", f"{venv_path}/bin/pip", "install", "gcl_sdk[libvirt]"]
+        )
+
+    def test_install_agent_systemd_unit_writes_enables_and_restarts(
+        self, tmp_path
+    ) -> None:
+        unit_path = str(tmp_path / "systemd" / "agent.service")
+        with (
+            patch.object(hv_commands, "write_root_owned_file") as write_mock,
+            patch.object(hv_commands, "run_command") as run_mock,
+        ):
+            hv_commands.install_agent_systemd_unit(
+                config_path="/etc/exordos_universal_agent/exordos_universal_agent.conf",
+                unit_path=unit_path,
+                unit_name="exordos-universal-agent.service",
+            )
+
+        write_call = write_mock.call_args[0]
+        assert write_call[1] == unit_path
+        assert write_mock.call_args.kwargs == {}
+        assert run_mock.call_args_list == [
+            mock_call(["sudo", "systemctl", "daemon-reload"]),
+            mock_call(
+                ["sudo", "systemctl", "enable", "exordos-universal-agent.service"]
+            ),
+            mock_call(
+                ["sudo", "systemctl", "restart", "exordos-universal-agent.service"]
+            ),
+        ]
+
+    def test_install_agent_systemd_unit_overwrites_a_stale_existing_unit(
+        self, tmp_path
+    ) -> None:
+        """A unit already exists at this path - from either a genuinely
+        pre-existing standard agent or a stale earlier run of this same
+        code - either way it gets rewritten with the current template
+        rather than left untouched."""
+        unit_path = tmp_path / "systemd" / "agent.service"
+        unit_path.parent.mkdir(parents=True)
+        unit_path.write_text("[Unit]\nold stale content\n")
+
+        with (
+            patch.object(hv_commands, "write_root_owned_file") as write_mock,
+            patch.object(hv_commands, "run_command") as run_mock,
+        ):
+            hv_commands.install_agent_systemd_unit(
+                config_path="/etc/exordos_universal_agent/exordos_universal_agent.conf",
+                unit_path=str(unit_path),
+                unit_name="exordos-universal-agent.service",
+            )
+
+        write_call = write_mock.call_args[0]
+        assert write_call[1] == str(unit_path)
+        assert write_mock.call_args.kwargs == {}
+        assert run_mock.call_args_list == [
+            mock_call(["sudo", "systemctl", "daemon-reload"]),
+            mock_call(
+                ["sudo", "systemctl", "enable", "exordos-universal-agent.service"]
+            ),
+            mock_call(
+                ["sudo", "systemctl", "restart", "exordos-universal-agent.service"]
+            ),
+        ]
+
+
+class TestReadExistingConfig:
+    """Tests for _read_existing_config: missing vs present vs root-only
+    readable (falls back to sudo cat, matching local_agent_node_uuid's
+    established pattern for a root-only-readable path).
+    """
+
+    def test_returns_none_when_missing(self, tmp_path) -> None:
+        assert hv_commands._read_existing_config(str(tmp_path / "missing")) is None
+
+    def test_reads_content_directly_when_readable(self, tmp_path) -> None:
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text("[universal_agent]\n")
+
+        assert (
+            hv_commands._read_existing_config(str(config_path)) == "[universal_agent]\n"
+        )
+
+    def test_falls_back_to_sudo_cat_on_permission_error(self, tmp_path) -> None:
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text("[universal_agent]\n")
+
+        fake_result = MagicMock(stdout="[universal_agent]\nfrom sudo cat\n")
+        with (
+            patch.object(hv_commands, "open", side_effect=PermissionError, create=True),
+            patch.object(
+                hv_commands, "run_command", return_value=fake_result
+            ) as run_mock,
+        ):
+            content = hv_commands._read_existing_config(str(config_path))
+
+        assert content == "[universal_agent]\nfrom sudo cat\n"
+        run_mock.assert_called_once_with(["sudo", "cat", str(config_path)])
+
+
+class TestWriteAgentConfig:
+    """Tests for write_agent_config: fresh-install vs merge-into-existing."""
+
+    def test_writes_fresh_config_when_none_exists(self, tmp_path) -> None:
+        config_path = str(tmp_path / "exordos_universal_agent.conf")
+        written = {}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["sudo", "install"]:
+                written["content"] = open(cmd[4]).read()
+
+        with patch.object(crypto, "run_command", side_effect=fake_run):
+            private_key_path = hv_commands.write_agent_config(
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+                config_path=config_path,
+                meta_file="/var/lib/exordos/universal_agent/pool_meta.json",
+            )
+
+        assert private_key_path == hv_commands.AGENT_PRIVATE_KEY_PATH
+        assert "caps_drivers = LocalPoolAgentDriver" in written["content"]
+        assert "orch_endpoint = http://10.20.0.2:11011" in written["content"]
+
+    def test_merges_local_pool_driver_into_existing_config(self, tmp_path) -> None:
+        """This host already runs the standard agent for other
+        capabilities (it's also a registered compute node): add
+        LocalPoolAgentDriver to its caps_drivers, leave orch_endpoint
+        and its own private_key_path untouched."""
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text(
+            "[universal_agent]\n"
+            "orch_endpoint = http://core.local.genesis-core.tech:11011\n"
+            "status_endpoint = http://core.local.genesis-core.tech:11012\n"
+            "private_key_path = /var/lib/exordos/universal_agent/private_key\n"
+            "caps_drivers = \n"
+            "    SSHKeyCapabilityDriver,\n"
+            "    GuestMachineCapabilityDriver\n"
+        )
+        written = {}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["sudo", "install"]:
+                written["content"] = open(cmd[4]).read()
+
+        with patch.object(crypto, "run_command", side_effect=fake_run):
+            private_key_path = hv_commands.write_agent_config(
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+                config_path=str(config_path),
+                meta_file="/var/lib/exordos/universal_agent/pool_meta.json",
+            )
+
+        assert private_key_path == "/var/lib/exordos/universal_agent/private_key"
+        content = written["content"]
+        assert "SSHKeyCapabilityDriver" in content
+        assert "GuestMachineCapabilityDriver" in content
+        assert "LocalPoolAgentDriver" in content
+        assert "core.local.genesis-core.tech" in content
+        assert "[LocalPoolAgentDriver]" in content
+        assert "meta_file = /var/lib/exordos/universal_agent/pool_meta.json" in content
+
+    def test_merge_is_idempotent_if_local_pool_driver_already_present(
+        self, tmp_path
+    ) -> None:
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text(
+            "[universal_agent]\n"
+            "caps_drivers = SSHKeyCapabilityDriver, LocalPoolAgentDriver\n"
+        )
+        written = {}
+
+        def fake_run(cmd):
+            if cmd[:2] == ["sudo", "install"]:
+                written["content"] = open(cmd[4]).read()
+
+        with patch.object(crypto, "run_command", side_effect=fake_run):
+            hv_commands.write_agent_config(
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+                config_path=str(config_path),
+                meta_file="/var/lib/exordos/universal_agent/pool_meta.json",
+            )
+
+        parser = configparser.ConfigParser()
+        parser.read_string(written["content"])
+        drivers = [
+            d.strip()
+            for d in parser.get("universal_agent", "caps_drivers").split(",")
+            if d.strip()
+        ]
+        assert drivers.count("LocalPoolAgentDriver") == 1
+
+
+class TestAgentNamingHelpers:
+    """Tests for the per-agent-name path builders."""
+
+    def test_standard_name_maps_to_the_exordos_base_conventions(self) -> None:
+        assert (
+            hv_commands._agent_venv_path(hv_commands.DEFAULT_AGENT_NAME)
+            == "/opt/universal_agent/.venv"
+        )
+        assert (
+            hv_commands._agent_config_path(hv_commands.DEFAULT_AGENT_NAME)
+            == "/etc/exordos_universal_agent/exordos_universal_agent.conf"
+        )
+        assert (
+            hv_commands._agent_unit_name(hv_commands.DEFAULT_AGENT_NAME)
+            == "exordos-universal-agent.service"
+        )
+        assert (
+            hv_commands._agent_exec_path(hv_commands.DEFAULT_AGENT_NAME, "/x/.venv")
+            == hv_commands.STANDARD_AGENT_BIN_SYMLINK
+        )
+
+    def test_custom_name_gets_parallel_paths_and_no_symlink(self) -> None:
+        assert hv_commands._agent_venv_path("hyper1_pool") == "/opt/hyper1_pool/.venv"
+        assert (
+            hv_commands._agent_config_path("hyper1_pool")
+            == "/etc/exordos_universal_agent/exordos_hyper1_pool.conf"
+        )
+        assert (
+            hv_commands._agent_unit_name("hyper1_pool") == "exordos-hyper1-pool.service"
+        )
+        assert (
+            hv_commands._agent_exec_path("hyper1_pool", "/opt/hyper1_pool/.venv")
+            == "/opt/hyper1_pool/.venv/bin/exordos-universal-agent"
+        )
+
+
+class TestResolveAgentInstallTarget:
+    """Tests for resolve_agent_install_target: fresh/matching vs a
+    foreign agent already configured for a different core.
+    """
+
+    def test_no_existing_config_resolves_the_named_paths(self, tmp_path) -> None:
+        config_path = str(tmp_path / "exordos_universal_agent.conf")
+        with patch.object(hv_commands, "AGENT_CONFIG_DIR", str(tmp_path)):
+            target = hv_commands.resolve_agent_install_target(
+                agent_name=hv_commands.DEFAULT_AGENT_NAME,
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+            )
+
+        assert target.config_path == config_path
+        assert target.venv_path == "/opt/universal_agent/.venv"
+        assert target.exec_path == hv_commands.STANDARD_AGENT_BIN_SYMLINK
+
+    def test_existing_config_for_the_same_core_is_accepted(self, tmp_path) -> None:
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text(
+            "[universal_agent]\n"
+            "orch_endpoint = http://10.20.0.2:11011\n"
+            "status_endpoint = http://10.20.0.2:11012\n"
+        )
+        with patch.object(hv_commands, "AGENT_CONFIG_DIR", str(tmp_path)):
+            target = hv_commands.resolve_agent_install_target(
+                agent_name=hv_commands.DEFAULT_AGENT_NAME,
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+            )
+
+        assert target.config_path == str(config_path)
+
+    def test_existing_config_for_a_different_core_raises(self, tmp_path) -> None:
+        """A machine that's also a compute node of some other, unrelated
+        exordos deployment must not have its agent silently
+        reconfigured to point at our core instead."""
+        config_path = tmp_path / "exordos_universal_agent.conf"
+        config_path.write_text(
+            "[universal_agent]\n"
+            "orch_endpoint = http://10.30.0.2:11011\n"
+            "status_endpoint = http://10.30.0.2:11012\n"
+        )
+        with (
+            patch.object(hv_commands, "AGENT_CONFIG_DIR", str(tmp_path)),
+            pytest.raises(click.ClickException, match="different core"),
+        ):
+            hv_commands.resolve_agent_install_target(
+                agent_name=hv_commands.DEFAULT_AGENT_NAME,
+                orch_endpoint="http://10.20.0.2:11011",
+                status_endpoint="http://10.20.0.2:11012",
+            )

--- a/exordos/tests/unit/test_hypervisors_cli.py
+++ b/exordos/tests/unit/test_hypervisors_cli.py
@@ -203,7 +203,7 @@ class TestAgentSetup:
 
         write_call = write_mock.call_args[0]
         assert write_call[1] == unit_path
-        assert write_mock.call_args.kwargs == {}
+        assert write_mock.call_args.kwargs == {"mode": "644"}
         assert run_mock.call_args_list == [
             mock_call(["sudo", "systemctl", "daemon-reload"]),
             mock_call(
@@ -237,7 +237,7 @@ class TestAgentSetup:
 
         write_call = write_mock.call_args[0]
         assert write_call[1] == str(unit_path)
-        assert write_mock.call_args.kwargs == {}
+        assert write_mock.call_args.kwargs == {"mode": "644"}
         assert run_mock.call_args_list == [
             mock_call(["sudo", "systemctl", "daemon-reload"]),
             mock_call(


### PR DESCRIPTION
## Summary by Sourcery

Support placing the pool agent locally or in core during bootstrap while provisioning the associated hypervisor and agent configuration.

New Features:
- Add configurable core or local placement for the pool agent during bootstrap.
- Install and configure a local universal agent to manage the host's libvirt pool, including support for shared or dedicated agent identities.

Bug Fixes:
- Prevent bootstrap from overwriting an existing universal agent configured for a different core.

Enhancements:
- Associate locally placed hypervisors with the host agent's node identity and encryption key.
- Improve privileged file handling with explicit secure permissions and support for root-owned configuration files.

Build:
- Install the virtual-environment package required by local universal agents.

Documentation:
- Document pool agent placement, hypervisor URI behavior, and custom pool agent naming options.

Tests:
- Add coverage for placement resolution, local node identification, agent installation, configuration merging, endpoint identity, and agent conflict handling.