### PR TITLE
feat(repo): add optional project field to push cmd

### DIFF
--- a/docs/cli/repo_push.md
+++ b/docs/cli/repo_push.md
@@ -68,6 +68,14 @@ Push the element to the repository
 
   Push the element too as the latest version (if stable version)
 
+* `project`:
+    * Type: text
+    * Default: `none`
+    * Usage: `-p
+--project`
+
+  Project UUID or name to store in the element inventory
+
 * `project_dir`:
     * Type: path
     * Default: `.`
@@ -96,6 +104,7 @@ Push the element to the repository
 │ --element-dir       -e  PATH  Directory where element artifacts are stored                                                                                                                                                                                                                              │
 │ --force             -f        Force push even if the element already exists                                                                                                                                                                                                                             │
 │ --latest            -l        Push the element too as the latest version (if stable version)                                                                                                                                                                                                            │
+│ --project           -p  TEXT  Project UUID or name to store in the element inventory                                                                                                                                                                                                                    │
 │ --help                        Show this message and exit.                                                                                                                                                                                                                                               │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/exordos/cmd/repo/commands.py
+++ b/exordos/cmd/repo/commands.py
@@ -396,6 +396,12 @@ repository_group.add_command(elements_commands.elements_group, aliases=["e"])
     is_flag=True,
     help="Push the element too as the latest version (if stable version)",
 )
+@click.option(
+    "-p",
+    "--project",
+    default=None,
+    help="Project UUID or name to store in the element inventory",
+)
 @click.argument("project_dir", type=click.Path(), default=".")
 @click.pass_obj
 def push_cmd(
@@ -407,9 +413,10 @@ def push_cmd(
     element_dir: pathlib.Path,
     force: bool,
     latest: bool,
+    project: str | None,
     project_dir: pathlib.Path,
 ) -> None:
     repo_driver = repo_utils.load_repo_driver(
         exordos_cfg_file, target, project_dir, obj.cfg_path, driver, driver_params
     )
-    repo_utils.do_push(repo_driver, element_dir, force, latest)
+    repo_utils.do_push(repo_driver, element_dir, force, latest, project)

--- a/exordos/repo/base.py
+++ b/exordos/repo/base.py
@@ -73,7 +73,10 @@ class AbstractRepoDriver(abc.ABC):
 
     @abc.abstractmethod
     def push(
-        self, element: builder_base.ElementInventory, latest: bool = False
+        self,
+        element: builder_base.ElementInventory,
+        latest: bool = False,
+        project: str | None = None,
     ) -> None:
         """Push the element to the repo."""
 

--- a/exordos/repo/fs.py
+++ b/exordos/repo/fs.py
@@ -102,7 +102,10 @@ class FSRepoDriver(base.AbstractRepoDriver):
             os.remove(meta_path)
 
     def push(
-        self, element: builder_base.ElementInventory, latest: bool = False
+        self,
+        element: builder_base.ElementInventory,
+        latest: bool = False,
+        project: str | None = None,
     ) -> None:
         """Push the element to the repo."""
         element_path = os.path.join(self.elements_path, element.name, element.version)
@@ -125,6 +128,8 @@ class FSRepoDriver(base.AbstractRepoDriver):
             ]
 
         spec["published"] = get_published()
+        if project:
+            spec["project"] = project
 
         with open(self.elements_inventory_path(element), "w") as f:
             json.dump(spec, f, indent=2)

--- a/exordos/repo/nginx.py
+++ b/exordos/repo/nginx.py
@@ -186,7 +186,10 @@ class NginxRepoDriver(base.AbstractRepoDriver):
         self._logger.info(f"Deleted repo at {self._base_url}")
 
     def push(
-        self, element: builder_base.ElementInventory, latest: bool = False
+        self,
+        element: builder_base.ElementInventory,
+        latest: bool = False,
+        project: str | None = None,
     ) -> None:
         """Push the element to the repo."""
         element_url = f"{self.elements_path}/{element.name}/{element.version}"
@@ -217,6 +220,8 @@ class NginxRepoDriver(base.AbstractRepoDriver):
             ]
 
         spec["published"] = get_published()
+        if project:
+            spec["project"] = project
 
         # Upload the inventory file
         response = self._session.put(

--- a/exordos/repo/utils.py
+++ b/exordos/repo/utils.py
@@ -137,6 +137,7 @@ def do_push(
     element_dir: pathlib.Path,
     force: bool,
     latest: bool,
+    project: str | None = None,
 ) -> None:
     """Push every element found in a local build output dir to a repo driver.
 
@@ -164,14 +165,14 @@ def do_push(
 
         try:
             with rich_status.Status("Push the element to the repo...", spinner="dots"):
-                repo_driver.push(e_inventory, latest=latest)
+                repo_driver.push(e_inventory, latest=latest, project=project)
         except base_repo.ElementAlreadyExistsError:
             if force:
                 repo_driver.remove(e_inventory)
                 with rich_status.Status(
                     "Push the element to the repo...", spinner="dots"
                 ):
-                    repo_driver.push(e_inventory, latest=latest)
+                    repo_driver.push(e_inventory, latest=latest, project=project)
                     continue
 
             click.secho(

--- a/exordos/tests/unit/test_repo_driver.py
+++ b/exordos/tests/unit/test_repo_driver.py
@@ -1,0 +1,43 @@
+#    Copyright 2026 Genesis Corporation.
+#
+#    All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Unit tests for exordos.repo drivers."""
+
+import json
+import pathlib
+
+from exordos.builder import base as builder_base
+from exordos.repo import fs as repo_fs
+
+
+def _push(tmp_path: pathlib.Path, project: str | None) -> dict:
+    driver = repo_fs.FSRepoDriver(str(tmp_path))
+    driver.init_repo()
+    element = builder_base.ElementInventory(name="elem", version="1.0.0")
+    driver.push(element, project=project)
+    with open(driver.elements_inventory_path(element)) as f:
+        return json.load(f)
+
+
+class TestFSRepoDriverPush:
+    """Tests for exordos.repo.fs.FSRepoDriver.push."""
+
+    def test_push_with_project(self, tmp_path: pathlib.Path) -> None:
+        spec = _push(tmp_path, "my-project")
+        assert spec["project"] == "my-project"
+
+    def test_push_without_project(self, tmp_path: pathlib.Path) -> None:
+        spec = _push(tmp_path, None)
+        assert "project" not in spec


### PR DESCRIPTION
- Add `-p/--project` option to `exordos repo push` accepting a project UUID or name
- Store the value as `project` in the pushed element inventory.json (both fs and nginx drivers), only when provided
- Add unit tests for the fs driver push with and without a project

Claude-Session: https://claude.ai/code/session_015rx6WgmzYaFL1ztt9a9Nmk

## Summary by Sourcery

Support associating pushed repository elements with an optional project.

New Features:
- Add an optional project UUID or name to repository pushes and record it in element inventory metadata when provided.

Enhancements:
- Propagate project metadata consistently through repository push utilities and filesystem and nginx drivers.

Documentation:
- Document the new project option for the repository push command.

Tests:
- Add filesystem driver coverage for pushes with and without project metadata.